### PR TITLE
feat: :sparkles: control ingressClassName with dsc

### DIFF
--- a/roles/argocd/templates/values.yaml.j2
+++ b/roles/argocd/templates/values.yaml.j2
@@ -86,4 +86,18 @@ extraDeploy:
     kind: ConfigMap
     metadata:
       name: argocd-rbac-cm
-      namespace: {{ dsc.argocd.namespace }}
+      namespace: {{ dsc.ingress.className  }}
+applicationSet:
+  webhook:
+    ingress:
+      ingressClassName: {{ dsc.ingress.className  }}
+notifications:
+  webhook:
+    ingress:
+      ingressClassName: {{ dsc.ingress.className  }}
+server:
+  ingress:
+    ingressClassName: {{ dsc.ingress.className  }}
+server:
+  ingressGrpc:
+    ingressClassName: {{ dsc.ingress.className  }}

--- a/roles/console-dso/templates/values.yaml.j2
+++ b/roles/console-dso/templates/values.yaml.j2
@@ -1,4 +1,5 @@
 ingress:
+  ingressClassName: {{ dsc.ingress.className }}
   hosts:
     - {{ console_domain }}
   annotations: {{ dsc.ingress.annotations }}

--- a/roles/gitlab/templates/gitlab-instance.yaml.j2
+++ b/roles/gitlab/templates/gitlab-instance.yaml.j2
@@ -70,6 +70,7 @@ global:
       name: {{ gitlab_domain }}
 {% endif %}
   ingress:
+    class: {{ dsc.ingress.className }}
     annotations:
 {% for key, val in dsc.ingress.annotations.items() %}
       {{ key }}: {{ val }}

--- a/roles/harbor/templates/values.yaml.j2
+++ b/roles/harbor/templates/values.yaml.j2
@@ -19,6 +19,7 @@ expose:
 {% endif %}
 {% endif %}
   ingress:
+    className: {{ dsc.ingress.className }}
     hosts:
       core: {{ harbor_domain }}
       notary: {{ dsc.harbor.subDomain }}-notary{{ root_domain }}

--- a/roles/keycloak/templates/values.yaml.j2
+++ b/roles/keycloak/templates/values.yaml.j2
@@ -112,7 +112,7 @@ service:
 
 ingress:
   enabled: true
-  ingressClassName: ""
+  ingressClassName: {{ dsc.ingress.className }}
   pathType: "Prefix"
   apiVersion: ""
   hostname: "{{ keycloak_domain }}"

--- a/roles/nexus/templates/ingress.yml.j2
+++ b/roles/nexus/templates/ingress.yml.j2
@@ -23,6 +23,7 @@ spec:
     secretName: nexus-tls-secret
 {% endif %}
 {% endif %}
+  ingressClassName: {{ dsc.ingress.className }}
   rules:
     - host: {{ nexus_domain }}
       http:

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -278,6 +278,9 @@ spec:
                       default: {}
                       description: Additionals annotations to add to all tools' ingresses
                       type: object
+                    className:
+                      description: Ingress class name to use for all ingresses
+                      type: string
                     labels:
                       x-kubernetes-preserve-unknown-fields: true
                       default: {}

--- a/roles/sonarqube/templates/values.yaml.j2
+++ b/roles/sonarqube/templates/values.yaml.j2
@@ -33,7 +33,7 @@ ingress:
 {% endfor %}
   # This property allows for reports up to a certain size to be uploaded to SonarQube
     nginx.ingress.kubernetes.io/proxy-body-size: "64m"
-  ingressClassName: ""
+  ingressClassName: {{ dsc.ingress.className }}
   labels:
     app: "sonar"
 {% if not dsc.ingress.tls.type == 'none' %}

--- a/roles/vault/templates/ingress.yaml.j2
+++ b/roles/vault/templates/ingress.yaml.j2
@@ -23,6 +23,7 @@ spec:
       secretName: vault-tls-secret
 {% endif %}
 {% endif %}
+  ingressClassName: {{ dsc.ingress.className }}
   rules:
     - host: {{ vault_domain }}
       http:


### PR DESCRIPTION
Fix #61 

Pour harbor, la clé n'est pas précisé sur la [page d'artfiacthub](https://artifacthub.io/packages/helm/harbor/harbor) mais est bien présente dans [leur template](https://github.com/goharbor/harbor-helm/blob/main/templates/ingress/ingress.yaml#L59) ..