### PR TITLE
feat: :lock: force images pull on gitlab runner to prevent cache abuse

### DIFF
--- a/roles/gitlab-runner/templates/values/00-main.j2
+++ b/roles/gitlab-runner/templates/values/00-main.j2
@@ -55,6 +55,8 @@ runners:
       [runners.kubernetes]
         namespace = "{{ dsc.gitlab.namespace }}"
         image = "ubuntu:22.04"
+        # multiple "always" to retry pull on fail (see. https://docs.gitlab.com/runner/executors/kubernetes.html#set-a-pull-policy)
+        pull_policy = ["always", "always"]
 
   ## Specify the name for the runner.
   name: gitlab-runner


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Actuellement la PullPolicy dans les runners n'est pas forcée à `always`.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
La PullPolicy au sein des runners est forcée à `always` pour éviter la récupération d'imagesbuild par d'autres projets via le cache des runners.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
