### PR TITLE
Feat/kyverno

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -21,10 +21,14 @@
         - cert-manager
         - cm
 
-    - name: confSyncer
+#    - name: confSyncer
+#      tags:
+#        - confSyncer
+#        - kubed
+
+    - name: kyverno
       tags:
-        - confSyncer
-        - kubed
+        - kyverno
 
     - name: cloudnativepg
       tags:

--- a/install.yaml
+++ b/install.yaml
@@ -21,11 +21,6 @@
         - cert-manager
         - cm
 
-#    - name: confSyncer
-#      tags:
-#        - confSyncer
-#        - kubed
-
     - name: kyverno
       tags:
         - kyverno

--- a/roles/kyverno/tasks/main.yaml
+++ b/roles/kyverno/tasks/main.yaml
@@ -1,0 +1,36 @@
+---
+- name: Get existing Kyverno pods
+  kubernetes.core.k8s_info:
+    kind: Pod
+    label_selectors:
+      - "app.kubernetes.io/part-of=kyverno"
+  register: kyverno_pods
+
+- name: Install Kyverno
+  when: kyverno_pods.resources | length == 0
+  block:
+    - name: Add helm repo
+      kubernetes.core.helm_repository:
+        name: kyverno
+        repo_url: https://kyverno.github.io/kyverno/
+
+    - name: Deploy helm
+      kubernetes.core.helm:
+        name: kyverno
+        chart_ref: kyverno/kyverno
+        chart_version: "{{ dsc.kyverno.chartVersion }}"
+        release_namespace: dso-kyverno
+        create_namespace: true
+
+- name: Get dsc namespaces
+  ansible.builtin.set_fact:
+    dsc_namespaces: "{{ dsc
+      | dict2items
+      | map(attribute='value')
+      | selectattr('namespace', 'defined')
+      | map(attribute='namespace')
+      }}"
+
+- name: Create replace-kubed ClusterPolicy
+  kubernetes.core.k8s:
+    template: replace-kubed.yml.j2

--- a/roles/kyverno/tasks/main.yaml
+++ b/roles/kyverno/tasks/main.yaml
@@ -19,16 +19,27 @@
         name: kyverno
         chart_ref: kyverno/kyverno
         chart_version: "{{ dsc.kyverno.chartVersion }}"
-        release_namespace: dso-kyverno
+        release_namespace: "{{ dsc.kyverno.namespace }}"
         create_namespace: true
 
-- name: Get dsc namespaces
+- name: Wait Kyverno service endpoint to be available
+  kubernetes.core.k8s_info:
+    kind: Endpoints
+    namespace: "{{ dsc.kyverno.namespace }}"
+    name: kyverno-svc
+  register: endpoint
+  until: endpoint.resources[0].subsets[0].addresses[0] is defined
+  retries: 45
+  delay: 20
+
+- name: Get dsc namespaces but not Kyverno's
   ansible.builtin.set_fact:
     dsc_namespaces: "{{ dsc
       | dict2items
       | map(attribute='value')
       | selectattr('namespace', 'defined')
       | map(attribute='namespace')
+      | reject('equalto', dsc.kyverno.namespace)
       }}"
 
 - name: Create replace-kubed ClusterPolicy

--- a/roles/kyverno/templates/replace-kubed.yml.j2
+++ b/roles/kyverno/templates/replace-kubed.yml.j2
@@ -37,7 +37,7 @@ spec:
           - kyverno
           - openshift-*
           - infra-*
-          - dso-kyverno
+          - {{ dsc.kyverno.namespace }}
     generate:
 {% raw %}
       namespace: "{{request.object.metadata.name}}"

--- a/roles/kyverno/templates/replace-kubed.yml.j2
+++ b/roles/kyverno/templates/replace-kubed.yml.j2
@@ -1,0 +1,53 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: replace-kubed
+  annotations:
+    policies.kyverno.io/title: Replace Kubed Apps
+    pod-policies.kyverno.io/autogen-controllers: none
+    policies.kyverno.io/category: Prod
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Configmap, Secret
+    kyverno.io/kyverno-version: 1.11.4
+    policies.kyverno.io/minversion: 1.10.0
+    kyverno.io/kubernetes-version: "1.23"
+    policies.kyverno.io/description: >-
+      Secrets and Configmap like registry credentials, certificates often need 
+      to exist in multiple Namespaces so Pods there have access. Manually 
+      duplicating those Secrets and Configmap is time consuming and error prone. 
+      This policy will copy a Secret and Configmap with label kyverno.io/sync.   
+spec:
+  validationFailureAction: Enforce
+  generateExisting: true
+  rules:
+  - name: sync-all
+    skipBackgroundRequests: false
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          names:
+{{ dsc_namespaces | to_nice_yaml | indent(10, True) }}
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+          - kyverno
+          - openshift-*
+          - infra-*
+          - dso-kyverno
+    generate:
+{% raw %}
+      namespace: "{{request.object.metadata.name}}"
+{% endraw %}
+      synchronize: true # Cascading deletion form the parent
+      cloneList:
+        namespace: default
+        kinds:
+          - v1/Secret
+          - v1/ConfigMap
+        selector:
+          matchLabels:
+            ns.kyverno.io/all-sync: ""

--- a/roles/socle-config/files/config.yaml
+++ b/roles/socle-config/files/config.yaml
@@ -28,13 +28,15 @@ spec:
   harbor:
     namespace: dso-harbor
     subDomain: harbor
-  nexus:
-    namespace: dso-nexus
-    subDomain: nexus
   keycloak:
     namespace: dso-keycloak
     subDomain: keycloak
     postgresPvcSize: 1Gi
+  kyverno:
+    namespace: dso-kyverno
+  nexus:
+    namespace: dso-nexus
+    subDomain: nexus
   sonarqube:
     namespace: dso-sonarqube
     subDomain: sonar

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -475,6 +475,9 @@ spec:
                 kyverno:
                   description: Configuration for Kyverno.
                   properties:
+                    namespace:
+                      description: The namespace for Kyverno.
+                      type: string
                     chartVersion:
                       description: Kyverno helm chart version (e.g., "3.1.4").
                       type: string

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -472,11 +472,11 @@ spec:
                       default: {}
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
-                kubed:
-                  description: Configuration for Kubed (config-syncer).
+                kyverno:
+                  description: Configuration for Kyverno.
                   properties:
                     chartVersion:
-                      description: Kubed helm chart version (e.g., "v0.13.2").
+                      description: Kyverno helm chart version (e.g., "3.1.4").
                       type: string
                   type: object
                 nexus:
@@ -587,7 +587,7 @@ spec:
                 - harbor
                 - ingress
                 - keycloak
-                - kubed
+                - kyverno
                 - nexus
                 - proxy
                 - sonarqube

--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -36,11 +36,8 @@ spec:
   keycloak:
     # https://artifacthub.io/packages/helm/bitnami/keycloak
     chartVersion: 16.1.5
-#  kubed:
-#    # https://artifacthub.io/packages/helm/appscode/kubed
-#    chartVersion: 0.13.2
   kyverno:
-    # https://github.com/kyverno/kyverno/tree/main/charts/kyverno
+    # https://artifacthub.io/packages/helm/kyverno/kyverno
     chartVersion: 3.1.4
   nexus:
     # https://hub.docker.com/r/sonatype/nexus3/

--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -36,9 +36,12 @@ spec:
   keycloak:
     # https://artifacthub.io/packages/helm/bitnami/keycloak
     chartVersion: 16.1.5
-  kubed:
-    # https://artifacthub.io/packages/helm/appscode/kubed
-    chartVersion: 0.13.2
+#  kubed:
+#    # https://artifacthub.io/packages/helm/appscode/kubed
+#    chartVersion: 0.13.2
+  kyverno:
+    # https://github.com/kyverno/kyverno/tree/main/charts/kyverno
+    chartVersion: 3.1.4
   nexus:
     # https://hub.docker.com/r/sonatype/nexus3/
     imageTag: 3.56.0

--- a/uninstall.yaml
+++ b/uninstall.yaml
@@ -208,6 +208,17 @@
         - never
         - kyverno
 
+    - name: "Suppression des CustomResourceDefinitions Kyverno"
+      kubernetes.core.k8s:
+        api_version: apiextensions.k8s.io/v1
+        state: absent
+        kind: CustomResourceDefinition
+        label_selectors:
+          - "app.kubernetes.io/instance=kyverno"
+      tags:
+        - never
+        - kyverno
+
     - name: "Suppression du namespace Nexus"
       kubernetes.core.k8s:
         state: absent

--- a/uninstall.yaml
+++ b/uninstall.yaml
@@ -168,6 +168,57 @@
       tags:
         - keycloak
 
+    - name: "Suppression de la ClusterPolicy replace-kubed"
+      kubernetes.core.k8s:
+        state: absent
+        kind: ClusterPolicy
+        name: replace-kubed
+      tags:
+        - never
+        - kyverno
+
+    - name: "Suppression de l'instance Kyverno"
+      kubernetes.core.helm:
+        name: kyverno
+        chart_ref: kyverno/kyverno
+        release_namespace: dso-kyverno
+        state: absent
+        wait: true
+      tags:
+        - never
+        - kyverno
+
+    - name: "Suppression du namespace Kyverno"
+      kubernetes.core.k8s:
+        state: absent
+        kind: Namespace
+        name: dso-kyverno
+      tags:
+        - never
+        - kyverno
+
+    - name: "Suppression des ValidatingWebhookConfigurations Kyverno"
+      kubernetes.core.k8s:
+        api_version: admissionregistration.k8s.io/v1
+        state: absent
+        kind: ValidatingWebhookConfiguration
+        label_selectors:
+          - "webhook.kyverno.io/managed-by=kyverno"
+      tags:
+        - never
+        - kyverno
+
+    - name: "Suppression des MutatingWebhookConfigurations Kyverno"
+      kubernetes.core.k8s:
+        api_version: admissionregistration.k8s.io/v1
+        state: absent
+        kind: MutatingWebhookConfiguration
+        label_selectors:
+          - "webhook.kyverno.io/managed-by=kyverno"
+      tags:
+        - never
+        - kyverno
+
     - name: "Suppression du namespace Nexus"
       kubernetes.core.k8s:
         state: absent

--- a/uninstall.yaml
+++ b/uninstall.yaml
@@ -177,22 +177,11 @@
         - never
         - kyverno
 
-    - name: "Suppression de l'instance Kyverno"
-      kubernetes.core.helm:
-        name: kyverno
-        chart_ref: kyverno/kyverno
-        release_namespace: dso-kyverno
-        state: absent
-        wait: true
-      tags:
-        - never
-        - kyverno
-
     - name: "Suppression du namespace Kyverno"
       kubernetes.core.k8s:
         state: absent
         kind: Namespace
-        name: dso-kyverno
+        name: "{{ dsc.kyverno.namespace }}"
       tags:
         - never
         - kyverno

--- a/versions.md
+++ b/versions.md
@@ -11,7 +11,7 @@
 | grafanaOperator | 5.4.2 | 5.4.2 | [grafanaOperator](https://github.com/grafana/grafana-operator/tags) |
 | harbor | 2.9.1 | 1.13.1 | [harbor](https://artifacthub.io/packages/helm/harbor/harbor) |
 | keycloak | 22.0.3 | 16.1.5 | [keycloak](https://artifacthub.io/packages/helm/bitnami/keycloak) |
-| kubed | 0.13.2 | 0.13.2 | [kubed](https://artifacthub.io/packages/helm/appscode/kubed) |
+| kyverno | v1.11.4 | 3.1.4 | [kyverno](https://artifacthub.io/packages/helm/kyverno/kyverno) |
 | nexus | 3.56.0 | N/A | [nexus](https://hub.docker.com/r/sonatype/nexus3/) |
 | sonarqube | 10.2.1-community | 10.2.1+800 | [sonarqube](https://artifacthub.io/packages/helm/sonarqube/sonarqube) |
 | vault | 1.14.0 | 0.25.0 | [vault](https://artifacthub.io/packages/helm/hashicorp/vault) |


### PR DESCRIPTION
## Issues liées

Issues numéro: 159

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Nous utilisons l'outil Kubed pour synchroniser les secrets à travers les namespaces de la chaîne. 

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Kubed est remplacé par Kyverno qui est installé si besoin.
Une ClusterPolicy est mise en place pour répliquer, dans tous les namespaces de la chaine dso, les secrets ou configmaps portant le label `ns.kyverno.io/all-sync: ""` et créés dans le namespace default.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Oui.
Si des secrets utilisés par la chaîne étaient précédemment répliqués par Kubed, il faut maintenant les recréer dans le namespace default, et leur attribuer le label `ns.kyverno.io/all-sync: ""`.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement vérifié dans un cluster de test et de dev.

La task de désinstallation de kubed a été conservée pour permettre de gérer la transition.

La désinstallation de Kyverno est également gérée, uniquement sur demande explicite via le tag kyverno.
Dans le cas contraire (absence de tag), Kyverno n'est pas pris en compte par la désinstallation, du fait de la présence du tag never dans le playbook.

Le fichier versions.md a été mis à jour pour refléter cette évolution.