### PR TITLE
Fix/argo cd

### DIFF
--- a/roles/argocd/tasks/main.yaml
+++ b/roles/argocd/tasks/main.yaml
@@ -55,7 +55,6 @@
 
 - name: Deploy helm
   kubernetes.core.helm:
-    force: true
     name: argo
     chart_ref: bitnami/argo-cd
     chart_version: "{{ dsc.argocd.chartVersion }}"

--- a/roles/argocd/tasks/main.yaml
+++ b/roles/argocd/tasks/main.yaml
@@ -29,6 +29,12 @@
         - kind: ServiceAccount
           namespace: "{{ dsc.argocd.namespace }}"
           name: argo-redis
+        - kind: ServiceAccount
+          namespace: "{{ dsc.argocd.namespace }}"
+          name: argo-redis-master
+        - kind: ServiceAccount
+          namespace: "{{ dsc.argocd.namespace }}"
+          name: argo-redis-replica
 
 - name: Add helm repo
   kubernetes.core.helm_repository:
@@ -49,6 +55,7 @@
 
 - name: Deploy helm
   kubernetes.core.helm:
+    force: true
     name: argo
     chart_ref: bitnami/argo-cd
     chart_version: "{{ dsc.argocd.chartVersion }}"

--- a/roles/argocd/templates/values/00-main.j2
+++ b/roles/argocd/templates/values/00-main.j2
@@ -1,6 +1,8 @@
 securityContext: &securityContext
   containerSecurityContext:
     runAsUser: null
+    runAsGroup: null
+    seLinuxOptions: null
   podSecurityContext:
     fsGroup: null
 
@@ -9,15 +11,39 @@ config:
   secret:
     argocdServerAdminPassword: "{{ dsc.argocd.admin.password }}"
 {% endif %}
+  rbac:
+    policy.csv: |
+      p, role:admin, *, *, */*, allow
+      p, role:nada, *, *, */*, deny
+      g, system:cluster-admins, role:admin
+      g, cluster-admins, role:admin
+      g, /ArgoCDAdmins, role:admin
+      g, ArgoCDAdmins, role:admin
+    scopes: "[groups]"
+    policy.default: role:nada
+    admin.enabled: "false"
 redis:
-  <<: *securityContext
   architecture: replication
+  master:
+    podSecurityContext:
+      enabled: false
+    containerSecurityContext:
+      enabled: false
+  replica:
+    podSecurityContext:
+      enabled: false
+    containerSecurityContext:
+      enabled: false
 {% if dsc.global.metrics.enabled %}
   metrics:
     enabled: true
     serviceMonitor:
       enabled: true
       namespace: {{ dsc.argocd.namespace }}
+    podSecurityContext:
+      enabled: false
+    containerSecurityContext:
+      enabled: false
 {% endif %}
 controller:
   <<: *securityContext
@@ -82,24 +108,8 @@ repoServer:
       enabled: true
       namespace: {{ dsc.argocd.namespace }}
 {% endif %}
-extraDeploy:
-  - apiVersion: v1
-    data:
-      policy.csv: |
-        p, role:admin, *, *, */*, allow
-        p, role:nada, *, *, */*, deny
-        g, system:cluster-admins, role:admin
-        g, cluster-admins, role:admin
-        g, /ArgoCDAdmins, role:admin
-        g, ArgoCDAdmins, role:admin
-      scopes: "[groups]"
-      policy.default: role:nada
-      admin.enabled: "false"
-    kind: ConfigMap
-    metadata:
-      name: argocd-rbac-cm
-      namespace: {{ dsc.argocd.namespace }}
 applicationSet:
+  enabled: false
   replicaCount: 3
   webhook:
     ingress:
@@ -112,6 +122,7 @@ applicationSet:
       namespace: {{ dsc.argocd.namespace }}
 {% endif %}
 notifications:
+  enabled: false
   webhook:
     ingress:
       ingressClassName: {{ dsc.ingress.className | default('') }}

--- a/roles/console-dso/templates/project.j2
+++ b/roles/console-dso/templates/project.j2
@@ -24,6 +24,7 @@ spec:
     name: admin-RO
     policies:
     - p, proj:console-pi-native:admin, applications, get, console-pi-native/*, allow
+    - p, proj:console-pi-native:admin-RO, applications, get, console-pi-native/*, allow
   - description: admin-RW
     groups:
     - /admin
@@ -33,5 +34,6 @@ spec:
     name: admin-RW
     policies:
     - p, proj:console-pi-native:admin, applications, *, console-pi-native/*, *
+    - p, proj:console-pi-native:admin-RW, applications, *, console-pi-native/*, *
   sourceRepos:
   - https://github.com/cloud-pi-native/console.git

--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   argocd:
     # https://artifacthub.io/packages/helm/bitnami/argo-cd
-    chartVersion: 4.7.19
+    chartVersion: 5.9.1
   certmanager:
     # https://github.com/cert-manager/cert-manager/releases
     chartVersion: v1.13.1

--- a/versions.md
+++ b/versions.md
@@ -1,6 +1,6 @@
 | Outil | Version | Chart version | Source |
 | ----- | ------- | ------------- | ------ |
-| argocd | 2.7.10 | 4.7.19 | [argocd](https://artifacthub.io/packages/helm/bitnami/argo-cd) |
+| argocd | 2.10.1 | 5.9.1 | [argocd](https://artifacthub.io/packages/helm/bitnami/argo-cd) |
 | certmanager | 1.13.1 | 1.13.1 | [certmanager](https://github.com/cert-manager/cert-manager/releases) |
 | cloudnativepg | 1.20.2 | 0.18.2 | [cloudnativepg](https://artifacthub.io/packages/helm/cloudnative-pg/cloudnative-pg) |
 | console | 6.5.1 | 6.5.1 | [console](https://github.com/cloud-pi-native/console/releases) |


### PR DESCRIPTION
## Issues liées

Issues numéro: 162

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Installe Argo CD en version 2.7.10 (chart 4.7.19).

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Installe Argo CD en version 2.10.1 (chart 5.9.1).

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Oui.
Le role argocd a dû être adapté pour tenir compte des évolutions du chart Helm.
Il en résulte que l'ancienne version d'Argo CD ne pourra être éventuellement installée ou réinstallée qu'à partir d'une ancienne version du socle.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Upgrade d'Argo CD testé avec succès dans deux clusters : test et développement.