### PR TITLE
fix: :bug: Fix get version task (validate_certs)

### DIFF
--- a/roles/sonarqube/tasks/main.yaml
+++ b/roles/sonarqube/tasks/main.yaml
@@ -134,6 +134,7 @@
 
 - name: Get SonarQube version
   ansible.builtin.uri:
+    validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     url: https://{{ sonar_domain }}/api/server/version
     method: GET
     return_content: true
@@ -152,10 +153,10 @@
 
 - name: Remove permissions for sonar-users
   ansible.builtin.uri:
+    validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     url: https://{{ sonar_domain }}/api/permissions/remove_group?groupName=sonar-users&permission={{ item }}
     user: "{{ token_pass }}"
     force_basic_auth: true
-    validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     method: post
     status_code: 204
   with_items:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

L'installation de SonarQube peut échouer sur certain clusters, dans un contexte d'exposedCA, au niveau de la tâche « Get SonarQube version ».

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

SonarQube parvient à s'installer, y compris dans un contexte d'exposedCA.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

L'échec était dû à l'absence du paramètre « validate_certs » dans la tâche « Get SonarQube version ».
