### PR TITLE
feat: :sparkles: add velero pre hook db backups

### DIFF
--- a/roles/cloudnativepg/templates/values/00-main.j2
+++ b/roles/cloudnativepg/templates/values/00-main.j2
@@ -1,3 +1,8 @@
 containerSecurityContext:
   runAsUser: null
   runAsGroup: null
+{% if dsc.global.backup.type == 'velero' %}
+config:
+  data:
+    INHERITED_ANNOTATIONS: "pre.hook.backup.velero.io/command, pre.hook.backup.velero.io/container, post.hook.backup.velero.io/command, post.hook.backup.velero.io/container, pre.hook.backup.velero.io/timeout, pre.hook.backup.velero.io/on-error, post.hook.backup.velero.io/timeout, post.hook.backup.velero.io/on-error"    
+{% endif %}

--- a/roles/console-dso/templates/values/00-main.j2
+++ b/roles/console-dso/templates/values/00-main.j2
@@ -11,6 +11,10 @@ postgres:
     db: dso-console-db
     user: dso
     pass: {{ dsc.console.dbPassword }}
+{% if dsc.global.backup.type == 'velero' %}
+    annotations:
+      pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "pg_dump -Fc  -U dso -d dso-console-db  > /var/lib/postgresql/data/app.dump"]'
+{% endif %}
 keycloak:
   clientIdBackend: {{ console_backend_secret.resources[0].data.CLIENT_ID | b64decode }}
   clientSecretBackend: {{ console_backend_secret.resources[0].data.CLIENT_SECRET | b64decode }}

--- a/roles/gitlab/templates/values/00-main.j2
+++ b/roles/gitlab/templates/values/00-main.j2
@@ -96,3 +96,10 @@ global:
 
 prometheus:
   install: false
+
+{% if dsc.global.backup.type == 'velero' %}
+postgresql:
+  primary:
+    podAnnotations:
+      pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "PGPASSWORD=$POSTGRES_POSTGRES_PASSWORD pg_dump -Fc  -U postgres -d gitlabhq_production  > /bitnami/postgresql/data/app.dump"]'
+{% endif %}

--- a/roles/harbor/templates/values/00-main.j2
+++ b/roles/harbor/templates/values/00-main.j2
@@ -80,6 +80,10 @@ database:
     serviceAccountName: harbor-sa
     image:
       repository: docker.io/goharbor/harbor-db
+{% if dsc.global.backup.type == 'velero' %}
+  podAnnotations:
+    pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "pg_dump -Fc  -U postgres -d registry  > /var/lib/postgresql/data/app.dump"]'
+{% endif %}
 redis:
   internal:
     serviceAccountName: harbor-sa

--- a/roles/keycloak/templates/pg-cluster-keycloak.yaml.j2
+++ b/roles/keycloak/templates/pg-cluster-keycloak.yaml.j2
@@ -3,6 +3,13 @@ kind: Cluster
 metadata:
   name: pg-cluster-keycloak
   namespace: {{ dsc.keycloak.namespace }}
+{% if dsc.global.backup.type == 'velero' %}
+  annotations:
+    pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d  keycloak > /var/lib/postgresql/data/app.dump-${index}"]'
+    pre.hook.backup.velero.io/container: postgres
+    pre.hook.backup.velero.io/on-error: Fail
+    pre.hook.backup.velero.io/timeout: 90s
+{% endif %}
 spec:
   instances: 3
 

--- a/roles/socle-config/files/cr-conf-dso-default.yaml
+++ b/roles/socle-config/files/cr-conf-dso-default.yaml
@@ -26,6 +26,8 @@ spec:
       .example.com
     metrics:
       enabled: false
+    backup:
+      type: velero
   grafana: {}
   grafanaDatasource: {}
   grafanaOperator: {}

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -287,6 +287,17 @@ spec:
                       required:
                         - enabled
                       type: object
+                    backup:
+                      description: Configuration for backup feature.
+                      properties:
+                        type:
+                          default: none
+                          description: Specifies the backup type used for databases.
+                          enum:
+                            - none
+                            - velero
+                          type: strings
+                      type: object
                   required:
                     - projectsRootDir
                     - rootDomain

--- a/roles/sonarqube/templates/pg-cluster-sonar.yaml.j2
+++ b/roles/sonarqube/templates/pg-cluster-sonar.yaml.j2
@@ -3,6 +3,13 @@ kind: Cluster
 metadata:
   name: pg-cluster-sonar
   namespace: {{ dsc.sonarqube.namespace }}
+{% if dsc.global.backup.type == 'velero' %}
+  annotations:
+    pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d  sonardb > /var/lib/postgresql/data/app.dump-${index}"]'
+    pre.hook.backup.velero.io/container: postgres
+    pre.hook.backup.velero.io/on-error: Fail
+    pre.hook.backup.velero.io/timeout: 90s
+{% endif %}
 spec:
   instances: 3
 


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Aujourd'hui les bases de données de la plateforme ne sont pas sauvegardés régulièrement pour d'éventuels besoin de restauration.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Désormais les bases de données suivantes sont sauvegardées localement dans le système de fichier (dans le dossier `data` du conteneur postgres) avant chaque sauvegarde Velero : 
- keycloak (cnpg) - *( dbName: `keycloak`)*
- sonarqube (cnpg) - *( dbName: `sonardb`)*
- harbor (sts) - *( dbName: `registry`)*
- gitlab (sts) - *( dbName: `gitlabhq_production`)*
- console (sts) - *( dbName: `console-dso-db`)*

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Ces modifications sont temporaires en attendant une solution définitive (utilisation systématique de cluster cnpg + backup intégrés ? cronjob + backup vers s3 ?)

cf. https://github.com/this-is-tobi/tools/blob/main/docker/pg-backup/Dockerfile
