### PR TITLE
feat: :sparkles: kubernetes vanilla

### DIFF
--- a/roles/argocd/templates/values/00-main.j2
+++ b/roles/argocd/templates/values/00-main.j2
@@ -32,6 +32,7 @@ config:
     admin.enabled: "false"
 redis:
   architecture: replication
+{% if dsc.global.platform == "openshift" %}
   master:
     podSecurityContext:
       enabled: false
@@ -42,16 +43,19 @@ redis:
       enabled: false
     containerSecurityContext:
       enabled: false
+{% endif %}
 {% if dsc.global.metrics.enabled %}
   <<: *serviceMonitor
+{% if dsc.global.platform == "openshift" %}
     podSecurityContext:
       enabled: false
     containerSecurityContext:
       enabled: false
 {% endif %}
+{% endif %}
 controller:
   replicaCount: 3
-{% if dsc.global.metrics.enabled %}
+{% if dsc.global.metrics.enabled and dsc.global.platform == "openshift" %}
   <<: *serviceMonitor
 {% endif %}
 dex:
@@ -88,13 +92,13 @@ server:
         - TaskRun
         - PipelineRun
   extraEnvVars: []
-{% if dsc.global.metrics.enabled %}
+{% if dsc.global.metrics.enabled and dsc.global.platform == "openshift" %}
   <<: *serviceMonitor
 {% endif %}
 repoServer:
   extraEnvVars: []
   replicaCount: 3
-{% if dsc.global.metrics.enabled %}
+{% if dsc.global.metrics.enabled and dsc.global.platform == "openshift" %}
   <<: *serviceMonitor
 {% endif %}
 applicationSet:
@@ -103,7 +107,7 @@ applicationSet:
   webhook:
     ingress:
       ingressClassName: {{ dsc.ingress.className | default('') }}
-{% if dsc.global.metrics.enabled %}
+{% if dsc.global.metrics.enabled and dsc.global.platform == "openshift" %}
   <<: *serviceMonitor
 {% endif %}
 notifications:

--- a/roles/gitlab/templates/values/00-main.j2
+++ b/roles/gitlab/templates/values/00-main.j2
@@ -54,7 +54,6 @@ global:
     enabled: false
   certificates:
     customCAs:
-      - configMap: openshift-service-ca.crt
 {% for item in dsc.additionalsCA %}
 {% if item.kind == 'ConfigMap' %}
       - configMap: {{ item.name }}

--- a/roles/gitlab/templates/values/10-platform.j2
+++ b/roles/gitlab/templates/values/10-platform.j2
@@ -1,0 +1,6 @@
+{% if dsc.global.platform == "openshift" %}
+global:
+  certificates:
+    customCAs:
+      - configMap: openshift-service-ca.crt
+{% endif %}

--- a/roles/nexus/templates/nexus.yml.j2
+++ b/roles/nexus/templates/nexus.yml.j2
@@ -16,6 +16,13 @@ spec:
       labels:
         app: nexus
     spec:
+{% if dsc.global.platform == "kubernetesVanilla" %}
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: 200 
+        runAsUser: 200
+        fsGroup: 200
+{% endif %}
       containers:
         - name: nexus
 {% if use_private_registry %}

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -301,6 +301,14 @@ spec:
                             - velero
                           type: string
                       type: object
+                    platform:
+                      default: openshift
+                      description: Cluster platform only openshift and kubernetesVanilla
+                        are supported (for now).
+                      enum:
+                        - openshift
+                        - kubernetesVanilla
+                      type: string
                     registry:
                       description: Specifies the internal registry to use.
                       type: string
@@ -309,6 +317,7 @@ spec:
                     - rootDomain
                     - environment
                     - metrics
+                    - platform
                   type: object
                 grafana:
                   description: Configuration for Grafana instance.

--- a/roles/sonarqube/templates/values/00-main.j2
+++ b/roles/sonarqube/templates/values/00-main.j2
@@ -1,17 +1,7 @@
 
-OpenShift:
-  enabled: true
-
 image:
   pullPolicy: IfNotPresent
   repository: docker.io/sonarqube
-
-securityContext:
-  fsGroup: null
-
-containerSecurityContext:
-  runAsUser: null
-  runAsGroup: null
 
 sonarWebContext: /
 
@@ -23,7 +13,6 @@ ingress:
       pathType: Prefix
       path: "/"
   annotations:
-    route.openshift.io/termination: "edge"
 {% for key, val in dsc.ingress.annotations.items() %}
     {{ key }}: "{{ val }}"
 {% endfor %}
@@ -33,11 +22,7 @@ ingress:
   labels:
     app: "sonar"
 
-initContainers:
-  securityContext:
-    runAsUser: null
-    runAsGroup: null
-
+# Should be kept as false even if dsc.global.platform == "kubernetesVanilla" and it may be best to work with your cluster administrator to either provide specific nodes with the proper kernel settings, or ensure they are set cluster wide : sysctl -a "name=vm.max_map_count value=262144"
 initSysctl:
   enabled: false
 
@@ -106,7 +91,6 @@ account:
 #  adminPassword: admin
 #  currentAdminPassword: admin
   adminPasswordSecretName: "sonarqube"
-  securityContext: {}
   resources:
     limits:
       cpu: 100m

--- a/roles/sonarqube/templates/values/10-platform.j2
+++ b/roles/sonarqube/templates/values/10-platform.j2
@@ -1,0 +1,29 @@
+{% if dsc.global.platform == "openshift" %}
+OpenShift:
+  enabled: true
+
+securityContext:
+  fsGroup: null
+
+containerSecurityContext:
+  runAsUser: null
+  runAsGroup: null
+
+ingress:
+  annotations:
+    route.openshift.io/termination: "edge"
+
+initContainers:
+  securityContext:
+    runAsUser: null
+    runAsGroup: null
+
+account:
+  securityContext: {}
+{% endif %}
+
+{% if dsc.global.platform == "kubernetesVanilla" %}
+account:
+  securityContext:
+    runAsUser: 101
+{% endif %}

--- a/roles/vault/templates/values/00-main.j2
+++ b/roles/vault/templates/values/00-main.j2
@@ -1,5 +1,4 @@
 global:
-  openshift: true
 {% if dsc.global.metrics.enabled %}
   serverTelemetry:
     prometheusOperator: true

--- a/roles/vault/templates/values/10-platform.j2
+++ b/roles/vault/templates/values/10-platform.j2
@@ -1,0 +1,30 @@
+{% if dsc.global.platform == "openshift" %}
+global:
+  openshift: true
+{% endif %}
+
+{% if dsc.global.platform == "kubernetesVanilla" %}
+injector:
+  securityContext:
+    pod:
+      runAsNonRoot: true
+      runAsGroup: 1000 
+      runAsUser: 100
+      fsGroup: 1000
+    container:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+
+server:
+  statefulSet:
+    securityContext:
+      pod:
+        runAsNonRoot: true
+        runAsGroup: 1000 
+        runAsUser: 100
+        fsGroup: 1000
+      container:
+        allowPrivilegeEscalation: false
+{% endif %}


### PR DESCRIPTION
## Issues liées

Issues numéro: https://github.com/cloud-pi-native/socle/issues/89

---------

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Actuellement, l'installation du socle DSO n'est compatible que sur un cluster Openshift, avec accès à internet pour le cluster.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Le déploiement sur un cluster Kubernetes Vanilla sera possible en rajoutant dans la conf dso sous global :
```
global:
  platform: kubernetesVanilla
```

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non, le déploiement sur un cluster Openshift n'est pas impacté. Ce sera l'option par défaut.


## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Non.