### PR TITLE
Upgrade/argo cd

### DIFF
--- a/admin-tools/get-credentials.yaml
+++ b/admin-tools/get-credentials.yaml
@@ -219,7 +219,7 @@
     - name: Display Argo CD URL and credentials
       ansible.builtin.debug:
         msg:
-          - "URL: https://{{ dsc.argocd.subDomain }}{{ dsc.global.rootDomain }} }} "
+          - "URL: https://{{ dsc.argocd.subDomain }}{{ dsc.global.rootDomain }} "
           - "Admin username: {{ keycloak_user }} "
           - "Admin password: {{ keycloak_user_password }} "
       tags:

--- a/roles/argocd/templates/values/00-main.j2
+++ b/roles/argocd/templates/values/00-main.j2
@@ -48,7 +48,6 @@ redis:
 {% endif %}
 controller:
   replicaCount: 3
-  resourcesPreset: "large"
 {% if dsc.global.metrics.enabled %}
   metrics:
     enabled: true

--- a/roles/argocd/templates/values/00-main.j2
+++ b/roles/argocd/templates/values/00-main.j2
@@ -1,11 +1,3 @@
-securityContext: &securityContext
-  containerSecurityContext:
-    runAsUser: null
-    runAsGroup: null
-    seLinuxOptions: null
-  podSecurityContext:
-    fsGroup: null
-
 config:
 {% if dsc.argocd.admin.enabled %}
   secret:
@@ -55,8 +47,8 @@ redis:
       enabled: false
 {% endif %}
 controller:
-  <<: *securityContext
   replicaCount: 3
+  resourcesPreset: "large"
 {% if dsc.global.metrics.enabled %}
   metrics:
     enabled: true
@@ -67,7 +59,6 @@ controller:
 dex:
   enabled: false
 server:
-  <<: *securityContext
   replicaCount: 3
   ingress:
     ingressClassName: {{ dsc.ingress.className | default('') }}
@@ -107,7 +98,6 @@ server:
       namespace: {{ dsc.argocd.namespace }}
 {% endif %}
 repoServer:
-  <<: *securityContext
   extraEnvVars: []
   replicaCount: 3
 {% if dsc.global.metrics.enabled %}
@@ -120,7 +110,6 @@ repoServer:
 applicationSet:
   enabled: false
   replicaCount: 2
-  <<: *securityContext
   webhook:
     ingress:
       ingressClassName: {{ dsc.ingress.className | default('') }}

--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   argocd:
     # https://artifacthub.io/packages/helm/bitnami/argo-cd
-    chartVersion: 5.9.2
+    chartVersion: 6.0.10
   certmanager:
     # https://github.com/cert-manager/cert-manager/releases
     chartVersion: v1.14.3

--- a/versions.md
+++ b/versions.md
@@ -1,6 +1,6 @@
 | Outil | Version | Chart version | Source |
 | ----- | ------- | ------------- | ------ |
-| argocd | 2.10.2 | 5.9.2 | [argocd](https://artifacthub.io/packages/helm/bitnami/argo-cd) |
+| argocd | 2.10.7 | 6.0.10 | [argocd](https://artifacthub.io/packages/helm/bitnami/argo-cd) |
 | certmanager | 1.14.3 | 1.14.3 | [certmanager](https://github.com/cert-manager/cert-manager/releases) |
 | cloudnativepg | 1.22.1 | 0.20.1 | [cloudnativepg](https://artifacthub.io/packages/helm/cloudnative-pg/cloudnative-pg) |
 | console | 8.0.2 | 8.0.2 | [console](https://github.com/cloud-pi-native/console/releases) |


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Installe Argo CD en version 2.10.2 (chart 5.9.2), laquelle ne permet pas le déploiement d'un servicemonitor pour remontée des métriques, du fait d'un bug lié à une erreur de template.

Affiche des caractères superflus suite à l'URL d'Argo CD lors de l'utilisation du playbook "admin-tools/get-credentials.yaml" (erreur de typo).

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Installe Argo CD en version 2.10.7, ce qui permet de déployer le servicemonitor nécessaire à la remontée des métriques.

Affiche correctement l'URL d'Argo CD lors de l'utilisation du playbook "admin-tools/get-credentials.yaml".

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

L'ugrade a été testé avec succès dans un cluster de dev.

Les évolutions depuis la version 5.9.2 du chart sont accessibles ici :
- https://github.com/bitnami/charts/commits/main/bitnami/argo-cd

Le bug de déploiement du servicemonitor a été corrigé côté Bitnami Argo CD via la PR suivante :
- https://github.com/bitnami/charts/pull/25046

Une évolution améliorant la compatibilité avec OpenShift, et prise en compte dans nos values, est également introduite par les PR suivantes :
- https://github.com/bitnami/charts/pull/24557
- https://github.com/bitnami/charts/pull/24064
