### PR TITLE
Feat: add pvcGitalySize

### DIFF
--- a/roles/gitlab/templates/values/00-main.j2
+++ b/roles/gitlab/templates/values/00-main.j2
@@ -33,6 +33,8 @@ gitlab:
       serviceMonitor:
         enabled: true
 {% endif %}
+    persistence:
+      size: {{ dsc.gitlab.pvcGitalySize }}
   gitlab-exporter:
 {% if dsc.global.metrics.enabled %}
     metrics:

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -194,6 +194,10 @@ spec:
                     chartVersion:
                       description: GitLab chart version (e.g., "6.11.10").
                       type: string
+                    pvcGitalySize:
+                      description: "Size for Gitaly, default: 50Gi"
+                      default: 50Gi
+                      type: string
                     values:
                       description: |
                         You can merge customs values for gitlab, it will be merged with roles/gitlab/templates/gitlab-instance.yaml.j2

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -195,7 +195,7 @@ spec:
                       description: GitLab chart version (e.g., "6.11.10").
                       type: string
                     pvcGitalySize:
-                      description: "Size for Gitaly, default: 50Gi"
+                      description: Size for Gitaly persistent volume.
                       default: 50Gi
                       type: string
                     values:


### PR DESCRIPTION
## Issues liées

Issues numéro: https://github.com/cloud-pi-native/socle/issues/212

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Actuellement, la taille du volume de Gitaly est à 50Gi sans possibilité de la surcharger.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Ajout de la possibilité de surcharger cette valeur depuis la conf dsc, en laissant la valeur par défaut à 50Gi.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Particulièrement utile pour les environnements de tests.