### PR TITLE
Feat: add dsc.vault.pvcSize

### DIFF
--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -597,6 +597,10 @@ spec:
                     chartVersion:
                       description: Hashicorp Vault helm chart version (e.g., "0.25.0").
                       type: string
+                    pvcSize:
+                      description: "Size for Vault, default: 23Gi"
+                      default: 23Gi
+                      type: string
                     values:
                       description: |
                         You can merge customs values for vault, it will be merged with roles/vault/tasks/main.yaml

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -598,7 +598,7 @@ spec:
                       description: Hashicorp Vault helm chart version (e.g., "0.25.0").
                       type: string
                     pvcSize:
-                      description: "Size for Vault, default: 23Gi"
+                      description: Size for Vault persistent volume.
                       default: 23Gi
                       type: string
                     values:

--- a/roles/vault/templates/values/00-main.j2
+++ b/roles/vault/templates/values/00-main.j2
@@ -44,7 +44,7 @@ server:
     enable: true
   dataStorage:
     enable: true
-    size: 23Gi
+    size: {{ dsc.vault.pvcSize }}
   image:
     repository: docker.io/hashicorp/vault
 csi:


### PR DESCRIPTION
## Issues liées

Issues numéro: https://github.com/cloud-pi-native/socle/issues/212

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Actuellement, la taille du volume de Vault est à 23Gi sans possibilité de la surcharger.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Ajout de la possibilité de surcharger cette valeur depuis la conf dsc, en laissant la valeur par défaut à 23Gi.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Particulièrement utile pour les environnements de tests.
