### PR TITLE
fix: :wrench: remove post renderer

### DIFF
--- a/roles/gitlab-operator/tasks/main.yaml
+++ b/roles/gitlab-operator/tasks/main.yaml
@@ -67,24 +67,6 @@
         chart_version: "{{ dsc.gitlabOperator.chartVersion }}"
         release_namespace: "{{ dsc.gitlabOperator.namespace }}"
         values: "{{ operator_values }}"
-      when: not use_private_registry
-
-    - name: Generate post_renderer script
-      template:
-        src: post_renderer_template.j2
-        dest: /tmp/yq_script.sh
-        mode: 0755
-      when: use_private_registry
-
-    - name: Deploy GitLab Operator helm
-      kubernetes.core.helm:
-        name: gitlab-operator
-        chart_ref: gitlab-operator/gitlab-operator
-        chart_version: "{{ dsc.gitlabOperator.chartVersion }}"
-        release_namespace: "{{ dsc.gitlabOperator.namespace }}"
-        values: "{{ operator_values }}"
-        post_renderer: /tmp/yq_script.sh
-      when: use_private_registry
 
     - name: Wait gitlab-webhook-service endpoint
       kubernetes.core.k8s_info:

--- a/roles/gitlab-operator/templates/post_renderer_template.j2
+++ b/roles/gitlab-operator/templates/post_renderer_template.j2
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-rm -f /tmp/all.yaml
-cat <&0 > /tmp/all.yaml
-yq eval '.spec.template.spec.containers[1].image = "{{ dsc.global.registry }}/kubebuilder/kube-rbac-proxy:v0.14.1"' /tmp/all.yaml 2> /dev/null && rm /tmp/all.yaml

--- a/roles/gitlab-operator/templates/values.yaml.j2
+++ b/roles/gitlab-operator/templates/values.yaml.j2
@@ -1,7 +1,7 @@
 watchCluster: true
 
 image:
-{% if use_private_registry %}                                                         
+{% if use_private_registry %}
   registry: "{{ dsc.global.registry }}"
 {% else %}
   registry: registry.gitlab.com
@@ -36,6 +36,11 @@ tolerations: []
 manager:
   debug:
     enabled: true
+{% if use_private_registry %}
+  kubeRbacProxy:
+    image:
+      registry: "{{ dsc.global.registry }}"
+{% endif %}
   serviceAccount:
     # Specifies whether a service account should be created
     create: true


### PR DESCRIPTION
## Issues liées

Issues numéro: https://github.com/cloud-pi-native/socle/issues/209

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Actuellement pour surcharger le registry du kubeRbacProxy, il était nécessaire d'utiliser le post_renderer parce qu'il n'était pas possible de surcharger depuis le values.yaml.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Suite à la MR https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/merge_requests/794, il est désormais de surcharger le registry du kubeRbacProxy depuis le values.yaml.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
⚠️ Nécessite changement de version du chart Gitlab-Operator : 0.29.2 -> 1.0.0⚠️ -> Implique changement de version du Chart Gitlab : 7.9.2 -> one of the following: 7.10.5, 7.11.2, 8.0.0 ⚠️ 
```
TASK [gitlab : Install GitLab instance] ****************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to patch object: b'{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"admission webhook \\\\\"vgitlab.kb.io\\\\\" denied the request: gitlab.apps.gitlab.com \\\\\"gitlab\\\\\" is invalid: spec.chart.version: Invalid value: \\\\\"7.9.2\\\\\": chart version 7.9.2 not supported; please use one of the following: 7.10.5, 7.11.2, 8.0.0\",\"reason\":\"Invalid\",\"details\":{\"name\":\"gitlab\",\"group\":\"apps.gitlab.com\",\"kind\":\"gitlab\",\"causes\":[{\"reason\":\"FieldValueInvalid\",\"message\":\"Invalid value: \\\\\"7.9.2\\\\\": chart version 7.9.2 not supported; please use one of the following: 7.10.5, 7.11.2, 8.0.0\",\"field\":\"spec.chart.version\"}]},\"code\":422}\\n'", "reason": "Unprocessable Entity"}

```
## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Il vaudrait peut-être mieux de pas merge jusqu'au jour où les versions des charts Gitlab seront au niveau.