### PR TITLE
feat: :sparkles: enable keycloak dsfr theme

### DIFF
--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -162,6 +162,17 @@
     id: dso
     realm: dso
     display_name: Dso Realm
+    loginWithEmailAllowed: true
+    registration_email_as_username: false
+    loginTheme: dsfr
+    accountTheme: dsfr
+    adminTheme: dsfr
+    emailTheme: dsfr
+    internationalizationEnabled: true
+    supportedLocales:
+      - en
+      - fr
+    defaultLocal: fr
     password_policy: >
       length(15) and lowerCase(1) and upperCase(1) and specialChars(1) and digits(1) and
       passwordHistory(2) and notUsername() and forceExpiredPasswordChange(183)

--- a/roles/keycloak/templates/values/00-main.j2
+++ b/roles/keycloak/templates/values/00-main.j2
@@ -11,35 +11,22 @@ tls:
   enabled: false
 
 production: true
-
 proxy: "edge"
-
 httpRelativePath: "/"
-
 configuration: ""
-
 existingConfigmap: ""
-
 extraStartupArgs: ""
-
 initdbScriptsConfigMap: ""
-
 command: []
-
 args: []
-
 extraEnvVarsCM: ""
-
 extraEnvVarsSecret: ""
-
 replicaCount: 3
 
 containerPorts:
   http: 8080
   https: 8443
   infinispan: 7800
-
-extraContainerPorts: []
 
 podSecurityContext:
   enabled: false
@@ -214,3 +201,31 @@ cache:
 logging:
   output: "default"
   level: "INFO"
+
+extraVolumes:
+  - name: extensions
+    emptyDir: {}
+extraVolumeMounts:
+  - mountPath: /opt/bitnami/keycloak/providers
+    name: extensions
+extraEnv:
+  - name: DSFR_THEME_HOME_URL
+    value: https://{{ console_domain }}
+  - name: DSFR_THEME_SERVICE_TITLE
+    value: DSO
+  - name: DSFR_THEME_BRAND_TOP
+    value: "Ministère<br/>de l'intérieur<br/>et des outre-mer"
+  - name: DSFR_THEME_CONTACT_EMAIL
+    value: cloudpinative-relations@interieur.gouv.fr
+initContainers:
+  - name: realm-ext-provider
+    image: docker.io/curlimages/curl:8.8.0
+    imagePullPolicy: IfNotPresent
+    command:
+      - sh
+    args:
+      - -c
+      - curl -L -f -S -o /extensions/keycloak-theme-dsfr.jar https://github.com/codegouvfr/keycloak-theme-dsfr/releases/download/v1.0.2/retrocompat-keycloak-theme.jar
+    volumeMounts:
+      - name: extensions
+        mountPath: /extensions


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Actuellement le theme par défaut de Keycloak est activé.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Désormais, Keycloak utilise le theme dsfr et la traduction `fr` est activée.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
<img width="1217" alt="Capture d’écran 2024-05-22 à 20 05 07" src="https://github.com/cloud-pi-native/socle/assets/37471993/5dbcac04-9777-4bf4-8858-21eb79d9e70e">

cf. :
- https://sill-preprod.lab.sspcloud.fr/ (`Se connecter`)
- https://github.com/codegouvfr/keycloak-theme-dsfr/pull/10

