### PR TITLE
chore: :lipstick: upgrade keycloak theme dsfr to v1.0.3

### DIFF
--- a/roles/keycloak/templates/values/00-main.j2
+++ b/roles/keycloak/templates/values/00-main.j2
@@ -225,7 +225,7 @@ initContainers:
       - sh
     args:
       - -c
-      - curl -L -f -S -o /extensions/keycloak-theme-dsfr.jar https://github.com/codegouvfr/keycloak-theme-dsfr/releases/download/v1.0.2/retrocompat-keycloak-theme.jar
+      - curl -L -f -S -o /extensions/keycloak-theme-dsfr.jar https://github.com/codegouvfr/keycloak-theme-dsfr/releases/download/v1.0.3/retrocompat-keycloak-theme.jar
     volumeMounts:
       - name: extensions
         mountPath: /extensions


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Actuellement nous utilisons le [keycloak-theme-dsfr](https://github.com/codegouvfr/keycloak-theme-dsfr) en `v1.0.2` qui empêche la connexion par nom d'utilisateur.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
- Désormais nous utilisons le [keycloak-theme-dsfr](https://github.com/codegouvfr/keycloak-theme-dsfr) en `v1.0.3` qui autorise la connexion par nom d'utilisateur.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
