### PR TITLE
Fix/grafana stack install uninstall

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -96,21 +96,25 @@
     - name: grafana-operator
       tags:
         - grafana-operator
+        - grafana-stack
         - never
 
     - name: grafana
       tags:
         - grafana
+        - grafana-stack
         - never
 
     - name: grafana-datasource
       tags:
         - grafana-datasource
+        - grafana-stack
         - never
 
     - name: grafana-dashboards
       tags:
         - grafana-dashboards
+        - grafana-stack
         - never
 
   post_tasks:

--- a/roles/grafana-operator/tasks/main.yaml
+++ b/roles/grafana-operator/tasks/main.yaml
@@ -7,10 +7,12 @@
   ansible.builtin.set_fact:
     grafana_op_api: "{{ cluster_infos.apis | dict2items | selectattr('key', 'contains', 'integreatly') }}"
 
-- name: Check if grafana-operator-permissions ClusterRole exists
+- name: Get Grafana Operator ClusterRole
   kubernetes.core.k8s_info:
+    api_version: rbac.authorization.k8s.io/v1
     kind: ClusterRole
-    name: grafana-operator-permissions
+    label_selectors:
+      - "app.kubernetes.io/name=grafana-operator"
   register: grafana_op_cr
 
 - name: Install Grafana Operator

--- a/uninstall.yaml
+++ b/uninstall.yaml
@@ -426,6 +426,28 @@
         - never
         - grafana-operator
 
+    - name: "Suppression du ClusterRole de Grafana Operator"
+      kubernetes.core.k8s:
+        api_version: rbac.authorization.k8s.io/v1
+        state: absent
+        kind: ClusterRole
+        label_selectors:
+          - "app.kubernetes.io/name=grafana-operator"
+      tags:
+        - never
+        - grafana-operator
+
+    - name: "Suppression du ClusterRoleBinding de Grafana Operator"
+      kubernetes.core.k8s:
+        api_version: rbac.authorization.k8s.io/v1
+        state: absent
+        kind: ClusterRoleBinding
+        label_selectors:
+          - "app.kubernetes.io/name=grafana-operator"
+      tags:
+        - never
+        - grafana-operator
+
     - name: "Suppression du namespace Grafana Operator"
       kubernetes.core.k8s:
         state: absent


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Permet d'installer la stack Grafana composant par composant seulement.
Installation et désinstallation de Grafana Operator non optimale (ne vérifie pas correctement la présence du Cluster Role, ne désinstalle pas les ClusterRole et ClusterRoleBinding associés en cas de désinstallation de l'opérateur).

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Offre le choix d'installer la stack Grafana au complet en une seule fois via le tag "grafana-stack", ou bien chaque composants de manière individuelle.
Installe et désinstalle correctement l'opérateur Grafana si besoin. 

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé dans un cluster de développement.