### PR TITLE
feat: ✨ add dsc.global.platform: rke2

### DIFF
--- a/roles/nexus/templates/nexus.yml.j2
+++ b/roles/nexus/templates/nexus.yml.j2
@@ -16,7 +16,7 @@ spec:
       labels:
         app: nexus
     spec:
-{% if dsc.global.platform == "kubernetesVanilla" %}
+{% if dsc.global.platform == "kubernetesVanilla" or dsc.global.platform == "rke2" %}
       securityContext:
         runAsNonRoot: true
         runAsGroup: 200 

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -386,11 +386,12 @@ spec:
                       type: object
                     platform:
                       default: openshift
-                      description: Cluster platform only openshift and kubernetesVanilla
+                      description: Cluster platform only openshift, kubernetesVanilla and rke2
                         are supported (for now).
                       enum:
                         - openshift
                         - kubernetesVanilla
+                        - rke2 
                       type: string
                     offline:
                       default: false

--- a/roles/sonarqube/tasks/main.yaml
+++ b/roles/sonarqube/tasks/main.yaml
@@ -156,7 +156,6 @@
 
 - name: Deploy helm
   kubernetes.core.helm:
-    force: true
     name: sonarqube
     chart_ref: sonarqube/sonarqube
     chart_version: "{{ dsc.sonarqube.chartVersion }}"


### PR DESCRIPTION
## Issues liées

Issues numéro: https://github.com/cloud-pi-native/socle/issues/89

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Actuellement, l'installation du socle DSO n'est compatible que sur un cluster Openshift ou Kubernetes Vanilla.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Le déploiement sur un cluster rke2 sera possible en rajoutant dans la conf dso sous global :
```
global:
  platform: rke2
```

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non, le déploiement sur un cluster Openshift n'est pas impacté. Ce sera l'option par défaut.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
En faisant cette PR, je me rends compte qu'il devrait être possible d'enlever pas mal de `{% if dsc.global.platform == "kubernetesVanilla" %}`.
J'en profite également pour enlever le `force: true` pour le helm du sonarqube.