### PR TITLE
fix: :bug: Add missing postgres delete command

### DIFF
--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -151,6 +151,7 @@
           psql -U postgres -d keycloak -c "delete from credential where user_id = '"{{ kc_admin_id }}"';"
           -c "delete from user_role_mapping where user_id = '"{{ kc_admin_id }}"';"
           -c "delete from user_entity where id = '"{{ kc_admin_id }}"';"
+          -c "delete from user_required_action where user_id = '"{{ kc_admin_id }}"';"
 
     - name: Restart Keycloak pods to reset admin password
       kubernetes.core.k8s:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Lors du reset de MDP admin de keycloak, une commande de suppression dans la table "user_required_action" est manquante.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Commande de suppression manquante ajoutée.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Nous ajoutons cette commande de suppression dans l'éventualité où des actions requises pour l'ancien utilisateur admin avaient été positionnées dans la table correspondante.