### PR TITLE
Fix/nexus admin password

### DIFF
--- a/roles/nexus/tasks/main.yaml
+++ b/roles/nexus/tasks/main.yaml
@@ -106,7 +106,7 @@
         return_content: false
       register: nexus_response
       until: nexus_response is not failed
-      retries: 25
+      retries: 60
       delay: 5
 
     - name: Generate random password

--- a/roles/nexus/tasks/main.yaml
+++ b/roles/nexus/tasks/main.yaml
@@ -141,6 +141,24 @@
           data:
             NEXUS_ADMIN_PASSWORD: "{{ new_pass | b64encode }}"
 
+    - name: Get admin-creds secret
+      kubernetes.core.k8s_info:
+        namespace: "{{ dsc.nexus.namespace }}"
+        kind: Secret
+        name: admin-creds
+      register: admin_creds_secret
+
+    - name: Update admin-creds secret
+      when: admin_creds_secret.resources[0] is defined
+      kubernetes.core.k8s:
+        kind: Secret
+        name: admin-creds
+        namespace: "{{ dsc.nexus.namespace }}"
+        state: patched
+        definition:
+          data:
+            password: "{{ new_pass | b64encode }}"
+
 - name: Get inventory
   kubernetes.core.k8s_info:
     namespace: "{{ dsc.console.namespace }}"


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Le block de tâches pour la réinitialisation du mot de passe admin Nexus en cas de besoin ne traîte pas l'actualisation du secret admin-creds lorsqu'il existe.
Ce secret n'est créé que si les métriques sont activées au niveau de la ressource dsc de configuration du socle, mais il doit pouvoir être actualisé lorsqu'il est présent.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Le block de tâches pour la réinitialisation du mot de passe admin Nexus en cas de besoin traîte l'actualisation du secret admin-creds lorsqu'il existe.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Testé et validé dans un cluster Kubernetes vanilla de test.
