### PR TITLE
Fix: :wrench: block logic for first console deployment

### DIFF
--- a/roles/console-dso/tasks/main.yaml
+++ b/roles/console-dso/tasks/main.yaml
@@ -123,13 +123,22 @@
     template: app.yaml.j2
 
 - block: 
+    - name: Set first_console_deployment to "true"
+      ansible.builtin.set_fact:
+        first_console_deployment: true
+
     - name: Get pg-cluster-console-app secret
       kubernetes.core.k8s_info:
         namespace: "{{ dsc.console.namespace }}"
         kind: Secret
         name: pg-cluster-console-app
       register: pg_db_secret
+      until: pg_db_secret.resources[0].data.uri is defined
+      retries: 10
+      delay: 5
+  when: pg_db_secret.resources[0].data.uri is undefined 
 
+- block: 
     - name: Compute Console Helm values
       ansible.builtin.include_role:
         name: combine
@@ -141,4 +150,4 @@
     - name: Apply app
       kubernetes.core.k8s:
         template: app.yaml.j2
-  when: pg_db_secret | from_yaml | json_query('resources[0].data.uri') is undefined
+  when: first_console_deployment is defined


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Actuellement la logique du bloc fait que l'ensemble des tasks du bloc ne s'exécute que si et seulement si `pg_db_secret.resources[0].data.uri is undefined`.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Alors qu'en réalité, on souhaite que `pg_db_secret.resources[0].data.uri` soit défini pour pouvoir récupérer les secrets dans `pg_db_secret` afin de recalculer les values Helm et réappliquer le `app.yaml.j2` dans le cas d'un premier déploiement.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
