### PR TITLE
add image pull secrets

### DIFF
--- a/roles/argocd/templates/values/10-registry.j2
+++ b/roles/argocd/templates/values/10-registry.j2
@@ -6,3 +6,9 @@ redis:
   image:
     registry: "{{ dsc.global.registry }}"
 {% endif %}
+
+{% if use_image_pull_secrets %}
+global:
+  imagePullSecrets: 
+  - dso-config-pull-secret
+{% endif %}

--- a/roles/cloudnativepg/templates/values/10-registry.j2
+++ b/roles/cloudnativepg/templates/values/10-registry.j2
@@ -2,3 +2,8 @@
 image:
   repository: "{{ dsc.global.registry }}/cloudnative-pg/cloudnative-pg"
 {% endif %}
+
+{% if use_image_pull_secrets %}
+imagePullSecrets:
+- name: dso-config-pull-secret
+{% endif %}

--- a/roles/console-dso-config/tasks/main.yml
+++ b/roles/console-dso-config/tasks/main.yml
@@ -41,7 +41,7 @@
         name: dso-config-pull-secret
         labels: 
           ns.kyverno.io/all-sync: "" # Share secret for all dso namespaces
-        namespace: "{{ dsc.console.namespace }}"
+        namespace: "default"
       type: kubernetes.io/dockerconfigjson
       data:
         .dockerconfigjson: "{{ dsc.global.imagePullSecretsData }}"

--- a/roles/console-dso-config/tasks/main.yml
+++ b/roles/console-dso-config/tasks/main.yml
@@ -39,7 +39,7 @@
       kind: Secret
       metadata:
         name: dso-config-pull-secret
-        labels: 
+        labels:
           ns.kyverno.io/all-sync: "" # Share secret for all dso namespaces
         namespace: "default"
       type: kubernetes.io/dockerconfigjson

--- a/roles/console-dso-config/tasks/main.yml
+++ b/roles/console-dso-config/tasks/main.yml
@@ -32,3 +32,17 @@
         # VAULT_TOKEN: roles/vault/tasks/main.yaml
         ARGO_NAMESPACE: "{{ dsc.argocd.namespace | b64encode }}"
         PROJECTS_ROOT_DIR: "{{ dsc.global.projectsRootDir | join('/') | b64encode }}"
+
+- name: Create imagePullSecret secret
+  kubernetes.core.k8s:
+    definition:
+      kind: Secret
+      metadata:
+        name: dso-config-pull-secret
+        labels: 
+          ns.kyverno.io/all-sync: "" # Share secret for all dso namespaces
+        namespace: "{{ dsc.console.namespace }}"
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ dsc.global.imagePullSecretsData }}"
+  when: use_image_pull_secrets

--- a/roles/console-dso/templates/values/10-registry.j2
+++ b/roles/console-dso/templates/values/10-registry.j2
@@ -11,3 +11,10 @@ postgres:
   container:
     image: "{{ dsc.global.registry }}/postgres:15.3"
 {% endif %}
+
+
+{% if use_image_pull_secrets %}
+global:
+  imagePullSecrets: 
+  - dso-config-pull-secret
+{% endif %}

--- a/roles/gitlab/templates/values/10-registry.j2
+++ b/roles/gitlab/templates/values/10-registry.j2
@@ -75,3 +75,10 @@ redis:
     image:
       registry: "{{ dsc.global.registry }}"
 {% endif %}
+
+{% if use_image_pull_secrets %}
+global:
+  image:
+    pullSecrets: 
+    - name: dso-config-pull-secret
+{% endif %}

--- a/roles/grafana-operator/templates/values.yaml.j2
+++ b/roles/grafana-operator/templates/values.yaml.j2
@@ -27,7 +27,12 @@ image:
   tag: ""
 
 # -- image pull secrets
+{% if use_image_pull_secrets %}
+imagePullSecrets: 
+- name: dso-config-pull-secret
+{% else %}
 imagePullSecrets: []
+{% endif %}
 
 nameOverride: ""
 fullnameOverride: ""

--- a/roles/grafana/templates/grafana.yaml.j2
+++ b/roles/grafana/templates/grafana.yaml.j2
@@ -34,3 +34,7 @@ spec:
           containers:
           - image: grafana/grafana:{{ dsc.grafana.imageVersion }}
             name: grafana
+{% if use_image_pull_secrets %}
+          imagePullSecrets: 
+            - name: dso-config-pull-secret
+{% endif %}

--- a/roles/harbor/templates/pg-cluster-harbor.yaml.j2
+++ b/roles/harbor/templates/pg-cluster-harbor.yaml.j2
@@ -18,6 +18,10 @@ spec:
 {% if use_private_registry %}
   imageName: "{{ dsc.global.registry }}/cloudnative-pg/postgresql:16.1"
 {% endif %}
+{% if use_image_pull_secrets %}
+  imagePullSecrets:
+  - name: dso-config-pull-secret
+{% endif %}
   postgresql:
 {% if use_private_registry %}
     image: "{{ dsc.global.registry }}/cloudnative-pg/postgresql:16.1"

--- a/roles/harbor/templates/values/10-registry.j2
+++ b/roles/harbor/templates/values/10-registry.j2
@@ -41,3 +41,9 @@ exporter:
   image:
     repository: "{{ dsc.global.registry }}/goharbor/harbor-exporter"
 {% endif %}
+
+
+{% if use_image_pull_secrets %}
+imagePullSecrets:
+  - name: dso-config-pull-secret
+{% endif %}

--- a/roles/keycloak/templates/pg-cluster-keycloak.yaml.j2
+++ b/roles/keycloak/templates/pg-cluster-keycloak.yaml.j2
@@ -18,6 +18,10 @@ spec:
 {% if use_private_registry %}
   imageName: "{{ dsc.global.registry }}/cloudnative-pg/postgresql:16.1"
 {% endif %}
+{% if use_image_pull_secrets %}
+  imagePullSecrets:
+  - name: dso-config-pull-secret
+{% endif %}
   postgresql:
 {% if use_private_registry %}
     image: "{{ dsc.global.registry }}/cloudnative-pg/postgresql:16.1"

--- a/roles/keycloak/templates/values/10-registry.j2
+++ b/roles/keycloak/templates/values/10-registry.j2
@@ -2,3 +2,9 @@
 image:
   registry: "{{ dsc.global.registry }}"
 {% endif %}
+
+{% if use_image_pull_secrets %}
+global:
+  imagePullSecrets: 
+  - dso-config-pull-secret
+{% endif %}

--- a/roles/nexus/templates/nexus.yml.j2
+++ b/roles/nexus/templates/nexus.yml.j2
@@ -23,6 +23,10 @@ spec:
         runAsUser: 200
         fsGroup: 200
 {% endif %}
+{% if use_image_pull_secrets %}
+      imagePullSecrets:
+      - name: dso-config-pull-secret
+{% endif %}
       containers:
         - name: nexus
 {% if use_private_registry %}

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -402,7 +402,7 @@ spec:
                       description: Specifies the internal registry to use.
                       type: string
                     imagePullSecretsData:
-                      description: Specifies the credentials to use for pulling image.
+                      description: Specifies the credentials to use for pulling image, encoded in base64.
                       type: string
                   required:
                     - projectsRootDir

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -401,6 +401,9 @@ spec:
                     registry:
                       description: Specifies the internal registry to use.
                       type: string
+                    imagePullSecretsData:
+                      description: Specifies the credentials to use for pulling image.
+                      type: string
                   required:
                     - projectsRootDir
                     - rootDomain

--- a/roles/socle-config/tasks/main.yaml
+++ b/roles/socle-config/tasks/main.yaml
@@ -114,7 +114,7 @@
 
 - name: use imagePullSecrets
   ansible.builtin.set_fact:
-    use_image_pull_secrets: "{{ dsc.global.imagePullSecretsData is defined and dsc.global.imagePullSecretsData | from_json | bool }}"
+    use_image_pull_secrets: "{{ dsc.global.imagePullSecretsData is defined and (dsc.global.imagePullSecretsData | b64decode | from_json | length > 0 | bool ) }}"
 
 - name: Set root_domain fact
   ansible.builtin.set_fact:

--- a/roles/socle-config/tasks/main.yaml
+++ b/roles/socle-config/tasks/main.yaml
@@ -112,6 +112,10 @@
   ansible.builtin.set_fact:
     use_private_registry: "{{ dsc.global.registry is defined and dsc.global.registry | length > 0 | bool }}"
 
+- name: use imagePullSecrets
+  ansible.builtin.set_fact:
+    use_image_pull_secrets: "{{ dsc.global.imagePullSecretsData is defined and dsc.global.imagePullSecretsData | from_json | bool }}"
+
 - name: Set root_domain fact
   ansible.builtin.set_fact:
     root_domain: "{{ dsc.global.rootDomain }}"

--- a/roles/sonarqube/templates/pg-cluster-sonar.yaml.j2
+++ b/roles/sonarqube/templates/pg-cluster-sonar.yaml.j2
@@ -18,6 +18,10 @@ spec:
 {% if use_private_registry %}
   imageName: "{{ dsc.global.registry }}/cloudnative-pg/postgresql:16.1"
 {% endif %}
+{% if use_image_pull_secrets %}
+  imagePullSecrets:
+  - name: dso-config-pull-secret
+{% endif %}
   postgresql:
 {% if use_private_registry %}
     image: "{{ dsc.global.registry }}/cloudnative-pg/postgresql:16.1"

--- a/roles/sonarqube/templates/values/10-registry.j2
+++ b/roles/sonarqube/templates/values/10-registry.j2
@@ -2,3 +2,9 @@
 image:
   repository: "{{ dsc.global.registry }}/sonarqube"
 {% endif %}
+
+{% if use_image_pull_secrets %}
+image:
+  pullSecrets: 
+  - name: dso-config-pull-secret
+{% endif %}

--- a/roles/vault/templates/values/10-registry.j2
+++ b/roles/vault/templates/values/10-registry.j2
@@ -16,3 +16,9 @@ csi:
     image:
       repository: "{{ dsc.global.registry }}/hashicorp/vault"
 {% endif %}
+
+{% if use_image_pull_secrets %}
+global:
+  imagePullSecrets: 
+  - name: dso-config-pull-secret
+{% endif %}


### PR DESCRIPTION
Ajout de la propriété imagePullSecrets sur les différents deploiment/sts que le socle déploie.

L'ajout se faisant via un secret partagé par une règle kyverno, ce dernier n'est pas concerné par la PR.

Au niveau de la configuration DSC, une nouvelle clé a été ajouté:
spec.global.imagePullSecretsData: contient la configuration docker à injecter dans le secret en base64


Pour avoir une idée précise du contenu, il est possible de générer un secret via la commande kubectl suivante:
kubectl create secret docker-registry regcred --docker-server=<your-registry-server> --docker-username=<your-name> --docker-password=<your-pword> --docker-email=<your-email>

**Attention**: dû à un bug de k8s, seule la dernière version arrive à prendre en compte la propriété imagePullSecrets si elle est placée après la propriété container

Éléments documentés dans le README.