### PR TITLE
fix: :bug: Fix ServiceMonitor and standalone config

### DIFF
--- a/roles/vault/tasks/post-install.yml
+++ b/roles/vault/tasks/post-install.yml
@@ -397,7 +397,7 @@
               insecureSkipVerify: true
         namespaceSelector:
           matchNames:
-          - "{{ dsc.vault.namespace }}"
+            - "{{ dsc.vault.namespace }}"
         selector:
           matchLabels:
             app.kubernetes.io/instance: "{{ dsc_name }}-vault"

--- a/roles/vault/tasks/post-install.yml
+++ b/roles/vault/tasks/post-install.yml
@@ -395,3 +395,12 @@
             scrapeTimeout: 10s
             tlsConfig:
               insecureSkipVerify: true
+        namespaceSelector:
+          matchNames:
+          - "{{ dsc.vault.namespace }}"
+        selector:
+          matchLabels:
+            app.kubernetes.io/instance: "{{ dsc_name }}-vault"
+            app.kubernetes.io/name: vault
+            vault-active: null
+            vault-internal: "true"

--- a/roles/vault/templates/values/00-main.j2
+++ b/roles/vault/templates/values/00-main.j2
@@ -42,6 +42,25 @@ server:
 {% endif %}
   standalone:
     enabled: false
+{% if dsc.global.metrics.enabled %}
+    config: |
+      ui = true
+      listener "tcp" {
+        tls_disable = 1
+        address = "[::]:8200"
+        cluster_address = "[::]:8201"
+        telemetry {
+          unauthenticated_metrics_access = "false"
+        }
+      }
+      storage "file" {
+        path = "/vault/data"
+      }
+      telemetry {
+        prometheus_retention_time = "30s"
+        disable_hostname = true
+      }
+{% endif %}
   auditStorage:
     enable: true
   dataStorage:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Lorsque les métriques sont activées dans la dsc, elles ne remontent pas côté Prometheus en ce qui concerne le Vault.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Les métriques du Vault remontent correctement dans Prometheus.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.

Le problème était lié à une erreur de matchLabel côté ServiceMonitor.
Après correctif, le fonctionnement a été testé sur une instance de Vault déployée en HA, ainsi que sur une instance standalone.
La partie config standalone dans les values du chart helm a dû être adaptée également, sinon les métriques n'étaient tout simplement pas activées dans ce cas de figure.
