### PR TITLE
fix: :zap: Change GitLab runners policy to avoid pull rate limits

### DIFF
--- a/roles/gitlab-runner/templates/values/00-main.j2
+++ b/roles/gitlab-runner/templates/values/00-main.j2
@@ -56,7 +56,7 @@ runners:
         namespace = "{{ dsc.gitlab.namespace }}"
         image = "ubuntu:22.04"
         # multiple "always" to retry pull on fail (see. https://docs.gitlab.com/runner/executors/kubernetes.html#set-a-pull-policy)
-        pull_policy = ["always", "always"]
+        pull_policy = ["if-not-present", "always"]
 {% if dsc.gitlabRunner.resources != 'none' %}
         # request and limit of build pod and override allowed in ci
   {% if dsc.gitlabRunner.resources.requests != 'none' %}


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

La pull policy des runners GitLab est paramétrée sur `"always", "always"` ce qui peut contribuer à déclencher les pull rate limits de Docker Hub.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

La pull policy des runners GitLab est maintenant paramétrée sur `"if-not-present", "always"` ce qui permet d'alléger la problématique.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Voir la documentation suivante au sujet du paramétrage de pull policy :
* https://docs.gitlab.com/runner/executors/kubernetes/index.html#set-a-pull-policy


