### PR TITLE
Fix/use image pull secret

### DIFF
--- a/roles/socle-config/tasks/main.yaml
+++ b/roles/socle-config/tasks/main.yaml
@@ -114,7 +114,7 @@
 
 - name: use imagePullSecrets
   ansible.builtin.set_fact:
-    use_image_pull_secrets: "{{ dsc.global.imagePullSecretsData is defined and (dsc.global.imagePullSecretsData | b64decode | from_json | length > 0 | bool ) }}"
+    use_image_pull_secrets: "{{ dsc.global.imagePullSecretsData is defined and dsc.global.imagePullSecretsData | length > 0 | bool }}"
 
 - name: Set root_domain fact
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Lorsque le paramètre `dsc.global.imagePullSecretsData` est vide, le role socle-config échoue à créer le fact `use_image_pull_secrets`.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Le role socle-config parvient à créer le fact `use_image_pull_secrets`.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.
