### PR TITLE
chore: :arrow_up: Upgrade GitLab

### DIFF
--- a/roles/gitlab-runner/templates/values/00-main.j2
+++ b/roles/gitlab-runner/templates/values/00-main.j2
@@ -57,7 +57,7 @@ runners:
         image = "ubuntu:22.04"
         # multiple "always" to retry pull on fail (see. https://docs.gitlab.com/runner/executors/kubernetes.html#set-a-pull-policy)
         pull_policy = ["always", "always"]
-{% if dsc.gitlabRunner.resources != 'none' %}
+{% if dsc.gitlabRunner.resources is defined and dsc.gitlabRunner.resources != 'none' %}
         # request and limit of build pod and override allowed in ci
   {% if dsc.gitlabRunner.resources.requests != 'none' %}
         cpu_request = "{{ dsc.gitlabRunner.resources.requests.cpu }}"

--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -17,16 +17,16 @@ spec:
     release: "1.*.*"
   gitlab:
     # https://artifacthub.io/packages/helm/gitlab/gitlab
-    chartVersion: "7.9.2"
+    chartVersion: "7.11.6"
   gitlabCiPipelinesExporter:
     # https://github.com/mvisonneau/helm-charts/tree/main/charts/gitlab-ci-pipelines-exporter
     chartVersion: "0.3.4"
   gitlabOperator:
     # https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/tags
-    chartVersion: "0.29.2"
+    chartVersion: "1.1.2"
   gitlabRunner:
     # https://gitlab.com/gitlab-org/charts/gitlab-runner/-/tags
-    chartVersion: "0.62.0"
+    chartVersion: "0.64.2"
   grafana:
     # https://github.com/grafana/grafana/tags
     imageVersion: "9.5.5"

--- a/versions.md
+++ b/versions.md
@@ -4,10 +4,10 @@
 | certmanager               | 1.14.3           | 1.14.3        | [certmanager](https://github.com/cert-manager/cert-manager/releases)                    |
 | cloudnativepg             | 1.22.1           | 0.20.1        | [cloudnativepg](https://artifacthub.io/packages/helm/cloudnative-pg/cloudnative-pg)     |
 | console                   | 8.0.2            | 8.0.2         | [console](https://github.com/cloud-pi-native/console/releases)                          |
-| gitlab                    | 16.9.2           | 7.9.2         | [gitlab](https://artifacthub.io/packages/helm/gitlab/gitlab)                            |
+| gitlab                    | 16.11.6           | 7.11.6         | [gitlab](https://artifacthub.io/packages/helm/gitlab/gitlab)                            |
 | gitlabCiPipelinesExporter | 0.5.8            | 0.3.4         | https://github.com/mvisonneau/helm-charts/tree/main/charts/gitlab-ci-pipelines-exporter |
-| gitlabOperator            | 0.29.2           | 0.29.2        | [gitlabOperator](https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/tags)     |
-| gitlabRunner              | 16.9.0           | 0.62.0        | [gitlabRunner](https://gitlab.com/gitlab-org/charts/gitlab-runner/-/tags)               |
+| gitlabOperator            | 1.1.2           | 1.1.2        | [gitlabOperator](https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/tags)     |
+| gitlabRunner              | 16.11.2           | 0.64.2        | [gitlabRunner](https://gitlab.com/gitlab-org/charts/gitlab-runner/-/tags)               |
 | grafana                   | 9.5.5            | N/A           | [grafana](https://github.com/grafana/grafana/tags)                                      |
 | grafanaOperator           | 5.4.2            | 5.4.2         | [grafanaOperator](https://github.com/grafana/grafana-operator/tags)                     |
 | harbor                    | 2.10.1           | 1.14.1        | [harbor](https://artifacthub.io/packages/helm/harbor/harbor)                            |


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Installe GitLab en version 16.11.5, lequel est touché par la CVE-2024-6385.
L'installation du GitLab Runner échoue du fait d'un check manquant sur le paramètre `dsc.gitlabRunner.resources`.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Upgrade GitLab en version 16.11.6.
L'installation de GitLab Runner est à nouveau fonctionnelle.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Upgrade testé dans un cluster de développement et appliqué sur un cluster de production.

Informations sur la CVE via la page du Critical Patch ici :
* https://about.gitlab.com/releases/2024/07/10/patch-release-gitlab-17-1-2-released/
