### PR TITLE
feat: ✨ add helm repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1040,7 +1040,6 @@ En mode air gap ou déconnecté d'internet, certaines valeurs de la `dsc` devron
 - `helmRepoUrl` pour chaque service à savoir :
   - `argocd`, `certmanager`, `cloudnativepg`, `console`, `gitlabCiPipelinesExporter`, `gitlabOperator`, `gitlabRunner`, `harbor`, `keycloak`, `kyverno`, `sonarqube` et `vault`
 
-
 ## Utilisation de credentials Docker Hub pour le pull des images
 
 Si vous disposez d'un compte Docker Hub, il est possible de l'utiliser pour le pull d'images des outils de la plateforme elle-même.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
     - [SonarQube Community Edition](#sonarqube-community-edition)
     - [Vault](#vault)
 - [Backups](#backups)
+- [Offline / air gap](#Offline--air-gap)
 - [Utilisation de credentials Docker Hub pour le pull des images](#utilisation-de-credentials-docker-hub-pour-le-pull-des-images)
 - [Contributions](#contributions)
   - [Les commandes de l'application](#les-commandes-de-lapplication)
@@ -1027,6 +1028,18 @@ Pour les backups S3 des BDD PostgreSQL déployées via CNPG :
 ```
 kubectl explain dsc.spec.global.backup.cnpg
 ```
+
+## Offline / air gap
+
+En mode air gap ou déconnecté d'internet, certaines valeurs de la `dsc` devront être adaptées.
+- `dsc.sonarqube:`
+  - `pluginDownloadUrl` et `PrometheusJavaagentVersion`
+- `dsc.gitlabCatalog.catalogRepoUrl`
+- `dsc.argocd.privateGitlabDomain`
+- `dsc.grafanaOperator.ociChartUrl`
+- `helmRepoUrl` pour chaque service à savoir :
+  - `argocd`, `certmanager`, `cloudnativepg`, `console`, `gitlabCiPipelinesExporter`, `gitlabOperator`, `gitlabRunner`, `harbor`, `keycloak`, `kyverno`, `sonarqube` et `vault`
+
 
 ## Utilisation de credentials Docker Hub pour le pull des images
 

--- a/roles/argocd/tasks/main.yaml
+++ b/roles/argocd/tasks/main.yaml
@@ -39,7 +39,8 @@
 - name: Add helm repo
   kubernetes.core.helm_repository:
     name: bitnami
-    repo_url: https://charts.bitnami.com/bitnami
+    repo_url: "{{ dsc.argocd.helmRepoUrl }}"
+    force_update: true
 
 - name: Set path fact
   ansible.builtin.set_fact:

--- a/roles/cert-manager/tasks/main.yaml
+++ b/roles/cert-manager/tasks/main.yaml
@@ -19,7 +19,8 @@
     - name: Add cert-manager helm repo
       kubernetes.core.helm_repository:
         name: jetstack
-        repo_url: https://charts.jetstack.io
+        repo_url: "{{ dsc.certmanager.helmRepoUrl }}"
+        force_update: true
 
     # Installation des CRDs indépendamment du chart helm.
     # Recommandé en production.

--- a/roles/cloudnativepg/tasks/main.yml
+++ b/roles/cloudnativepg/tasks/main.yml
@@ -26,7 +26,8 @@
     - name: Add CloudNativePG helm repo
       kubernetes.core.helm_repository:
         name: cnpg
-        repo_url: https://cloudnative-pg.github.io/charts
+        repo_url: "{{ dsc.cloudnativepg.helmRepoUrl }}"
+        force_update: true
 
     - name: Set path fact
       ansible.builtin.set_fact:

--- a/roles/cluster-offline/tasks/main.yml
+++ b/roles/cluster-offline/tasks/main.yml
@@ -17,11 +17,11 @@
       - dsc.gitlabCatalog.catalogRepoUrl != "https://github.com/cloud-pi-native/gitlab-ci-catalog.git"
     fail_msg: "'dsc.gitlabCatalog.catalogRepoUrl' is same as 'https://github.com/cloud-pi-native/gitlab-ci-catalog.git'"
 
-- name: Validate dsc.console.consoleRepoUrl is different than default
+- name: Validate dsc.console.helmRepoUrl is different than default
   assert:
     that:
-      - dsc.console.consoleRepoUrl != "https://github.com/cloud-pi-native/console.git"
-    fail_msg: "'dsc.console.consoleRepoUrl' is same as 'https://github.com/cloud-pi-native/console.git'"
+      - dsc.console.helmRepoUrl != "https://github.com/cloud-pi-native/console.git"
+    fail_msg: "'dsc.console.helmRepoUrl' is same as 'https://github.com/cloud-pi-native/console.git'"
 
 - name: Validate dsc.argocd.privateGitlabDomain is not empty
   assert:

--- a/roles/cluster-offline/tasks/main.yml
+++ b/roles/cluster-offline/tasks/main.yml
@@ -20,8 +20,8 @@
 - name: Validate dsc.console.helmRepoUrl is different than default
   assert:
     that:
-      - dsc.console.helmRepoUrl != "https://github.com/cloud-pi-native/console.git"
-    fail_msg: "'dsc.console.helmRepoUrl' is same as 'https://github.com/cloud-pi-native/console.git'"
+      - dsc.console.helmRepoUrl != "https://cloud-pi-native.github.io/helm-charts"
+    fail_msg: "'dsc.console.helmRepoUrl' is same as 'https://cloud-pi-native.github.io/helm-charts'"
 
 - name: Validate dsc.argocd.privateGitlabDomain is not empty
   assert:

--- a/roles/console-dso/templates/app.yaml.j2
+++ b/roles/console-dso/templates/app.yaml.j2
@@ -12,7 +12,7 @@ spec:
   project: console-pi-native
   source: 
     chart: cpn-console
-    repoURL: "{{ dsc.console.consoleRepoUrl }}" 
+    repoURL: "{{ dsc.console.helmRepoUrl }}"
     targetRevision: {{ dsc.console.release }}
     helm:
       releaseName: dso

--- a/roles/console-dso/templates/project.j2
+++ b/roles/console-dso/templates/project.j2
@@ -34,4 +34,4 @@ spec:
     policies:
     - p, proj:console-pi-native:admin-RW, applications, *, console-pi-native/*, allow
   sourceRepos:
-  - "{{ dsc.console.consoleRepoUrl }}"
+  - "{{ dsc.console.helmRepoUrl }}"

--- a/roles/gitlab-ci-pipelines-exporter/tasks/main.yaml
+++ b/roles/gitlab-ci-pipelines-exporter/tasks/main.yaml
@@ -28,7 +28,8 @@
     - name: Add GitLab CI Pipelines Exporter helm repo
       kubernetes.core.helm_repository:
         name: mvisonneau
-        repo_url: https://charts.visonneau.fr
+        repo_url: "{{ dsc.gitlabCiPipelinesExporter.helmRepoUrl }}"
+        force_update: true
 
     - name: Set path fact
       ansible.builtin.set_fact:

--- a/roles/gitlab-operator/tasks/main.yaml
+++ b/roles/gitlab-operator/tasks/main.yaml
@@ -53,7 +53,8 @@
     - name: Add GitLab Operator helm repo
       kubernetes.core.helm_repository:
         name: gitlab-operator
-        repo_url: https://gitlab.com/api/v4/projects/18899486/packages/helm/stable
+        repo_url: "{{ dsc.gitlabOperator.helmRepoUrl }}"
+        force_update: true
 
     - name: Set GitLab Operator helm values
       ansible.builtin.set_fact:
@@ -82,7 +83,7 @@
         chart_version: "{{ dsc.gitlabOperator.chartVersion }}"
         release_namespace: "{{ dsc.gitlabOperator.namespace }}"
         values: "{{ operator_values }}"
-        post_renderer: /tmp/yq_script.sh 
+        post_renderer: /tmp/yq_script.sh
       when: use_private_registry
 
     - name: Wait gitlab-webhook-service endpoint

--- a/roles/gitlab-runner/tasks/main.yaml
+++ b/roles/gitlab-runner/tasks/main.yaml
@@ -41,7 +41,8 @@
 - name: Add GitLab Runner helm repo
   kubernetes.core.helm_repository:
     name: gitlab
-    repo_url: https://charts.gitlab.io
+    repo_url: "{{ dsc.gitlabRunner.helmRepoUrl }}"
+    force_update: true
 
 - name: Create gitlab-runner role
   kubernetes.core.k8s:

--- a/roles/gitlab/tasks/main.yaml
+++ b/roles/gitlab/tasks/main.yaml
@@ -350,4 +350,3 @@
       ansible.builtin.include_tasks:
         file: add-servicemonitors.yaml
       loop: "{{ gitlab_additional_service_monitors }}"
-

--- a/roles/grafana-operator/tasks/main.yaml
+++ b/roles/grafana-operator/tasks/main.yaml
@@ -32,7 +32,7 @@
     - name: Deploy Grafana Operator helm
       kubernetes.core.helm:
         name: grafana-operator
-        chart_ref: oci://ghcr.io/grafana/helm-charts/grafana-operator
+        chart_ref: "oci://{{ dsc.grafanaOperator.ociChartUrl }}"
         chart_version: "{{ dsc.grafanaOperator.chartVersion }}"
         release_namespace: "{{ dsc.grafanaOperator.namespace }}"
         create_namespace: true

--- a/roles/grafana-operator/tasks/main.yaml
+++ b/roles/grafana-operator/tasks/main.yaml
@@ -32,7 +32,7 @@
     - name: Deploy Grafana Operator helm
       kubernetes.core.helm:
         name: grafana-operator
-        chart_ref: "oci://{{ dsc.grafanaOperator.ociChartUrl }}"
+        chart_ref: "{{ dsc.grafanaOperator.ociChartUrl }}"
         chart_version: "{{ dsc.grafanaOperator.chartVersion }}"
         release_namespace: "{{ dsc.grafanaOperator.namespace }}"
         create_namespace: true

--- a/roles/harbor/tasks/main.yaml
+++ b/roles/harbor/tasks/main.yaml
@@ -115,7 +115,8 @@
 - name: Add helm repo
   kubernetes.core.helm_repository:
     name: harbor
-    repo_url: https://helm.goharbor.io
+    repo_url: "{{ dsc.harbor.helmRepoUrl }}"
+    force_update: true
 
 - name: Set path fact
   ansible.builtin.set_fact:

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -177,7 +177,8 @@
 - name: Add bitnami helm repo
   kubernetes.core.helm_repository:
     name: bitnami
-    repo_url: https://charts.bitnami.com/bitnami
+    repo_url: "{{ dsc.keycloak.helmRepoUrl }}"
+    force_update: true
 
 - name: Set path fact
   ansible.builtin.set_fact:

--- a/roles/kyverno/tasks/main.yaml
+++ b/roles/kyverno/tasks/main.yaml
@@ -23,7 +23,8 @@
     - name: Add helm repo
       kubernetes.core.helm_repository:
         name: kyverno
-        repo_url: https://kyverno.github.io/kyverno/
+        repo_url: "{{ dsc.kyverno.helmRepoUrl }}"
+        force_update: true
 
     - name: Deploy helm
       kubernetes.core.helm:

--- a/roles/socle-config/files/config.yaml
+++ b/roles/socle-config/files/config.yaml
@@ -48,7 +48,7 @@ spec:
     grafanaPvcSize: 5Gi
   grafanaOperator:
     namespace: dso-grafana-operator
-    ociChartUrl: ghcr.io/grafana/helm-charts/grafana-operator
+    ociChartUrl: oci://ghcr.io/grafana/helm-charts/grafana-operator
   harbor:
     namespace: dso-harbor
     subDomain: harbor

--- a/roles/socle-config/files/config.yaml
+++ b/roles/socle-config/files/config.yaml
@@ -8,20 +8,30 @@ spec:
   argocd:
     namespace: dso-argocd
     subDomain: argocd
+    helmRepoUrl: https://charts.bitnami.com/bitnami
+  certmanager:
+    helmRepoUrl: https://charts.jetstack.io
   cloudnativepg:
     namespace: dso-cloudnativepg
+    helmRepoUrl: https://cloudnative-pg.github.io/charts
   console:
     namespace: dso-console
     subDomain: console
-  gitlabOperator:
-    namespace: dso-gitlab-operator
+    helmRepoUrl: https://cloud-pi-native.github.io/helm-charts
   gitlab:
     namespace: dso-gitlab
     subDomain: gitlab
     insecureCI: false
     pvcGitalySize: 50Gi
+  gitlabCiPipelinesExporter:
+    helmRepoUrl: https://charts.visonneau.fr
+  gitlabOperator:
+    namespace: dso-gitlab-operator
+    helmRepoUrl: https://gitlab.com/api/v4/projects/18899486/packages/helm/stable
   gitlabCatalog:
     catalogRepoUrl: https://github.com/cloud-pi-native/gitlab-ci-catalog.git
+  gitlabRunner:
+    helmRepoUrl: https://charts.gitlab.io
   global:
     backup:
       velero:
@@ -38,9 +48,11 @@ spec:
     grafanaPvcSize: 5Gi
   grafanaOperator:
     namespace: dso-grafana-operator
+    ociChartUrl: ghcr.io/grafana/helm-charts/grafana-operator
   harbor:
     namespace: dso-harbor
     subDomain: harbor
+    helmRepoUrl: https://helm.goharbor.io
     pvcRegistrySize: 50Gi
     pvcJobLogSize: 5Gi
     pvcDatabaseSize: 10Gi
@@ -49,9 +61,11 @@ spec:
   keycloak:
     namespace: dso-keycloak
     subDomain: keycloak
+    helmRepoUrl: https://charts.bitnami.com/bitnami
     postgresPvcSize: 1Gi
   kyverno:
     namespace: dso-kyverno
+    helmRepoUrl: https://kyverno.github.io/kyverno
   nexus:
     namespace: dso-nexus
     subDomain: nexus
@@ -60,8 +74,10 @@ spec:
   sonarqube:
     namespace: dso-sonarqube
     subDomain: sonar
+    helmRepoUrl: https://sonarsource.github.io/helm-chart-sonarqube
     postgresPvcSize: 5Gi
   vault:
     namespace: dso-vault
     subDomain: vault
+    helmRepoUrl: https://helm.releases.hashicorp.com
     pvcSize: 23Gi

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -129,6 +129,10 @@ spec:
                     subDomain:
                       description: The subdomain for ArgoCD.
                       type: string
+                    helmRepoUrl:
+                      description: ArgoCD Bitnami helm repository url.
+                      type: string
+                      default: https://charts.bitnami.com/bitnami
                     chartVersion:
                       description: ArgoCD Bitnami helm chart version (e.g., "4.7.13").
                       type: string
@@ -148,6 +152,10 @@ spec:
                 certmanager:
                   description: Configuration for Cert Manager.
                   properties:
+                    helmRepoUrl:
+                      description: Cert-manager helm repository url.
+                      type: string
+                      default: https://charts.jetstack.io
                     chartVersion:
                       description: Cert-manager helm chart version (e.g., "v1.13.1").
                       type: string
@@ -156,8 +164,12 @@ spec:
                   description: Configuration for CloudNativePG.
                   properties:
                     namespace:
-                      description: The namespace for cloudnativepg.
+                      description: The namespace for CloudNativePG.
                       type: string
+                    helmRepoUrl:
+                      description: CloudNativePG helm repository url.
+                      type: string
+                      default: https://cloudnative-pg.github.io/charts
                     chartVersion:
                       description: CloudNativePG helm chart version (e.g., "0.18.2").
                       type: string
@@ -174,6 +186,10 @@ spec:
                     subDomain:
                       description: The subdomain for console.
                       type: string
+                    helmRepoUrl:
+                      description: Console helm repository url.
+                      type: string
+                      default: https://cloud-pi-native.github.io/helm-charts
                     values:
                       description: Extra helm values for console
                       type: object
@@ -183,10 +199,6 @@ spec:
                       description: Size for postgres' pvc
                       type: string
                       default: 10Gi
-                    consoleRepoUrl:
-                      description: Console repository url.
-                      default: https://cloud-pi-native.github.io/helm-charts 
-                      type: string
                   type: object
                 gitlab:
                   description: Configuration for GitLab.
@@ -249,6 +261,10 @@ spec:
                 gitlabCiPipelinesExporter:
                   description: Configuration for GitLab CI Pipelines Exporter.
                   properties:
+                    helmRepoUrl:
+                      description: GitLab CI Pipelines Exporter helm repository url.
+                      type: string
+                      default: https://charts.visonneau.fr
                     chartVersion:
                       description: GitLab CI Pipelines Exporter chart version (e.g., "0.3.4").
                       type: string
@@ -256,6 +272,10 @@ spec:
                 gitlabOperator:
                   description: Configuration for GitLab Operator.
                   properties:
+                    helmRepoUrl:
+                      description: GitLab Operator helm repository url.
+                      type: string
+                      default: https://gitlab.com/api/v4/projects/18899486/packages/helm/stable
                     chartVersion:
                       description: GitLab Operator release version (e.g., "0.24.1").
                       type: string
@@ -274,6 +294,10 @@ spec:
                 gitlabRunner:
                   description: Configuration for GitLab Runner.
                   properties:
+                    helmRepoUrl:
+                      description: GitLab Runner helm repository url.
+                      type: string
+                      default: https://charts.gitlab.io
                     chartVersion:
                       description: GitLab Runner chart version (e.g., "0.57.0").
                       type: string
@@ -449,7 +473,7 @@ spec:
                       enum:
                         - openshift
                         - kubernetesVanilla
-                        - rke2 
+                        - rke2
                       type: string
                     offline:
                       default: false
@@ -499,6 +523,10 @@ spec:
                 grafanaOperator:
                   description: Configuration for Grafana Operator.
                   properties:
+                    ociChartUrl:
+                      description: Grafana Operator OCI chart url.
+                      type: string
+                      default: ghcr.io/grafana/helm-charts/grafana-operator
                     chartVersion:
                       description: Grafana Operator release version (e.g., "v5.6.0").
                       type: string
@@ -518,6 +546,10 @@ spec:
                     subDomain:
                       description: The subdomain for Harbor.
                       type: string
+                    helmRepoUrl:
+                      description: Harbor helm repository url.
+                      type: string
+                      default: https://helm.goharbor.io
                     chartVersion:
                       description: Harbor helm chart version (e.g., "1.12.2").
                       type: string
@@ -550,7 +582,7 @@ spec:
                             type: object
                             properties:
                               provider:
-                                description: ID of the provider 
+                                description: ID of the provider
                                 type: string
                                 default: docker-hub
                               endpointUrl:
@@ -690,8 +722,12 @@ spec:
                     subDomain:
                       description: The subdomain for Keycloak.
                       type: string
+                    helmRepoUrl:
+                      description: Keycloak Bitnami helm repository url.
+                      type: string
+                      default: https://charts.bitnami.com/bitnami
                     chartVersion:
-                      description: Keycloak chart version (e.g., "16.0.3").
+                      description: Keycloak Bitnami chart version (e.g., "16.0.3").
                       type: string
                     postgresPvcSize:
                       description: Size for postgres' pvc
@@ -712,6 +748,10 @@ spec:
                     namespace:
                       description: The namespace for Kyverno.
                       type: string
+                    helmRepoUrl:
+                      description: Kyverno helm repository url.
+                      type: string
+                      default: https://kyverno.github.io/kyverno
                     chartVersion:
                       description: Kyverno helm chart version (e.g., "3.1.4").
                       type: string
@@ -786,6 +826,10 @@ spec:
                     subDomain:
                       description: The subdomain for SonarQube.
                       type: string
+                    helmRepoUrl:
+                      description: SonarQube helm repository url.
+                      type: string
+                      default: https://sonarsource.github.io/helm-chart-sonarqube
                     chartVersion:
                       description: SonarQube helm chart version (e.g., "10.2.1+800").
                       type: string
@@ -816,6 +860,10 @@ spec:
                     subDomain:
                       description: The subdomain for Vault.
                       type: string
+                    helmRepoUrl:
+                      description: Hashicorp Vault helm repository url.
+                      type: string
+                      default: https://helm.releases.hashicorp.com
                     chartVersion:
                       description: Hashicorp Vault helm chart version (e.g., "0.25.0").
                       type: string

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -132,7 +132,6 @@ spec:
                     helmRepoUrl:
                       description: ArgoCD Bitnami helm repository url.
                       type: string
-                      default: https://charts.bitnami.com/bitnami
                     chartVersion:
                       description: ArgoCD Bitnami helm chart version (e.g., "4.7.13").
                       type: string
@@ -155,7 +154,6 @@ spec:
                     helmRepoUrl:
                       description: Cert-manager helm repository url.
                       type: string
-                      default: https://charts.jetstack.io
                     chartVersion:
                       description: Cert-manager helm chart version (e.g., "v1.13.1").
                       type: string
@@ -169,7 +167,6 @@ spec:
                     helmRepoUrl:
                       description: CloudNativePG helm repository url.
                       type: string
-                      default: https://cloudnative-pg.github.io/charts
                     chartVersion:
                       description: CloudNativePG helm chart version (e.g., "0.18.2").
                       type: string
@@ -189,7 +186,6 @@ spec:
                     helmRepoUrl:
                       description: Console helm repository url.
                       type: string
-                      default: https://cloud-pi-native.github.io/helm-charts
                     values:
                       description: Extra helm values for console
                       type: object
@@ -264,7 +260,6 @@ spec:
                     helmRepoUrl:
                       description: GitLab CI Pipelines Exporter helm repository url.
                       type: string
-                      default: https://charts.visonneau.fr
                     chartVersion:
                       description: GitLab CI Pipelines Exporter chart version (e.g., "0.3.4").
                       type: string
@@ -275,7 +270,6 @@ spec:
                     helmRepoUrl:
                       description: GitLab Operator helm repository url.
                       type: string
-                      default: https://gitlab.com/api/v4/projects/18899486/packages/helm/stable
                     chartVersion:
                       description: GitLab Operator release version (e.g., "0.24.1").
                       type: string
@@ -297,7 +291,6 @@ spec:
                     helmRepoUrl:
                       description: GitLab Runner helm repository url.
                       type: string
-                      default: https://charts.gitlab.io
                     chartVersion:
                       description: GitLab Runner chart version (e.g., "0.57.0").
                       type: string
@@ -526,7 +519,6 @@ spec:
                     ociChartUrl:
                       description: Grafana Operator OCI chart url.
                       type: string
-                      default: ghcr.io/grafana/helm-charts/grafana-operator
                     chartVersion:
                       description: Grafana Operator release version (e.g., "v5.6.0").
                       type: string
@@ -549,7 +541,6 @@ spec:
                     helmRepoUrl:
                       description: Harbor helm repository url.
                       type: string
-                      default: https://helm.goharbor.io
                     chartVersion:
                       description: Harbor helm chart version (e.g., "1.12.2").
                       type: string
@@ -725,7 +716,6 @@ spec:
                     helmRepoUrl:
                       description: Keycloak Bitnami helm repository url.
                       type: string
-                      default: https://charts.bitnami.com/bitnami
                     chartVersion:
                       description: Keycloak Bitnami chart version (e.g., "16.0.3").
                       type: string
@@ -751,7 +741,6 @@ spec:
                     helmRepoUrl:
                       description: Kyverno helm repository url.
                       type: string
-                      default: https://kyverno.github.io/kyverno
                     chartVersion:
                       description: Kyverno helm chart version (e.g., "3.1.4").
                       type: string
@@ -829,7 +818,6 @@ spec:
                     helmRepoUrl:
                       description: SonarQube helm repository url.
                       type: string
-                      default: https://sonarsource.github.io/helm-chart-sonarqube
                     chartVersion:
                       description: SonarQube helm chart version (e.g., "10.2.1+800").
                       type: string
@@ -863,7 +851,6 @@ spec:
                     helmRepoUrl:
                       description: Hashicorp Vault helm repository url.
                       type: string
-                      default: https://helm.releases.hashicorp.com
                     chartVersion:
                       description: Hashicorp Vault helm chart version (e.g., "0.25.0").
                       type: string

--- a/roles/sonarqube/tasks/main.yaml
+++ b/roles/sonarqube/tasks/main.yaml
@@ -81,7 +81,8 @@
 - name: Add SonarQube helm repo
   kubernetes.core.helm_repository:
     name: sonarqube
-    repo_url: https://SonarSource.github.io/helm-chart-sonarqube
+    repo_url: "{{ dsc.sonarqube.helmRepoUrl }}"
+    force_update: true
 
 - name: Get admin password secret
   kubernetes.core.k8s_info:

--- a/roles/vault/tasks/main.yml
+++ b/roles/vault/tasks/main.yml
@@ -9,7 +9,8 @@
 - name: Add helm repo
   kubernetes.core.helm_repository:
     name: hashicorp
-    repo_url: https://helm.releases.hashicorp.com
+    repo_url: "{{ dsc.vault.helmRepoUrl }}"
+    force_update: true
 
 - name: Set path fact
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Quel est le comportement actuel ?
Les url des repository helm ne sont pas modifiables, donc la DSO ne peut pas être installé en airgap.

## Quel est le nouveau comportement ?
`helmRepoUrl` peut être utilisé pour surcharger la valeur par défaut du chart repository, déplacé dans le CRD, de `argocd`, `certmanager`, `cloudnativepg`, `console`, `gitlabOperator`, `gitlabCiPipelinesExporter`, `gitlabRunner`, `harbor`, `keycloak`, `kyverno`, `sonarqube` et `vault`. 
`dsc.grafanaOperator.ociChartUrl` est également utilisé pour surcharger la valeur par défaut, mais il s'agit d'un registre Helm basé sur OCI.

## Cette PR introduit-elle un breaking change ?
Pour rendre uniform et retirer la répétition de "console", `consoleRepoUrl` à été changé en `helmRepoUrl`.

De la même façon, `dsc.catalog.catalogRepoUrl` **devrait**, à mon avis, être changé en `repoCloneUrl` pour éviter la répétition et rendre plus claire le fait qu'il s'agit de l'url http pour cloner le dépôt de GitLab Catalog.

## Autres informations
À l'ANFSI, nous travaillons au déploiement de la DSO en air gap et nous avons besoin de surcharger l'url des dépôts Helm (et registre OCI pour Grafana operator).
Je n'ai pas souhaité ajouter dans le nouveau role `cluster-offline` la verification que ces valeurs soient définies en dehors de `dsc.console.helmRepoUrl`.
