### PR TITLE
fix: :bug: Fix some Keycloak alerting rules

### DIFF
--- a/roles/keycloak/templates/values/00-main.j2
+++ b/roles/keycloak/templates/values/00-main.j2
@@ -160,8 +160,8 @@ metrics:
         rules:
           - alert: Keycloak instance not available
             annotations:
-              message: "Keycloak instance in namespace {% endraw %}{{ dsc.keycloak.namespace }}{% raw %} has not been available for the last 5 minutes."
-              summary: "Keycloak instance down (no ready container)"
+              message: Keycloak instance in namespace {{ include "common.names.namespace" . }} has not been available for the last 5 minutes.
+              summary: Keycloak instance down (no ready container)
             expr: |
               (absent(kube_pod_container_status_ready{
               pod=~"{{ include "common.names.fullname" . }}-\\d+",
@@ -174,22 +174,22 @@ metrics:
             for: 5m
             labels:
               severity: critical
-          - alert: Keycloak Pods not healthy
+          - alert: Keycloak Pod not healthy
             annotations:
-              message: "Some Keycloak pods in namespace {% endraw %}{{ dsc.keycloak.namespace }}{% raw %} have been unavailable for the last 5 minutes."
-              summary: "Keycloak pods not healthy (some containers are not ready)"
+              message: Keycloak {{"{{"}} $labels.pod {{"}}"}} pod in namespace {{ include "common.names.namespace" . }} has been unavailable for the last 5 minutes.
+              summary: Keycloak pod not healthy (container is not ready)
             expr: |
-              sum(kube_pod_container_status_ready{
+              kube_pod_container_status_ready{
               pod=~"{{ include "common.names.fullname" . }}-\\d+",
               container="{{ include "common.names.fullname" . }}",
-              namespace="{{ include "common.names.namespace" . }}"}) < {{ int .Values.replicaCount }} > 0
+              namespace="{{ include "common.names.namespace" . }}"} == 0
             for: 5m
             labels:
               severity: warning
           - alert: Keycloak DB not available
             annotations:
-              message: "All Keycloak CNPG pods in namespace {% endraw %}{{ dsc.keycloak.namespace }}{% raw %} have been unavailable for the last 5 minutes."
-              summary: "Keycloak database down (containers not ready)"
+              message: All Keycloak CNPG pods in namespace {{ include "common.names.namespace" . }} have been unavailable for the last 5 minutes.
+              summary: Keycloak database down (containers not ready)
             expr: |
               (absent(kube_pod_container_status_ready{
               pod=~"pg-cluster-{{ include "common.names.fullname" . }}-\\d+",
@@ -200,14 +200,14 @@ metrics:
             for: 5m
             labels:
               severity: critical
-          - alert: Keycloak DB Pods not healthy
+          - alert: Keycloak DB Pod not healthy
             annotations:
-              message: "Some Keycloak CNPG pods in namespace {% endraw %}{{ dsc.keycloak.namespace }}{% raw %} have been unavailable for the last 5 minutes."
-              summary: "Keycloak database not healthy (some containers are not ready)"
+              message: Keycloak {{"{{"}} $labels.pod {{"}}"}} pod in namespace {{ include "common.names.namespace" . }} has been unavailable for the last 5 minutes.
+              summary: Keycloak database pod not healthy (container is not ready)
             expr: |
-              sum(kube_pod_container_status_ready{
+              kube_pod_container_status_ready{
               pod=~"pg-cluster-{{ include "common.names.fullname" . }}-\\d+",
-              container="postgres", namespace="{{ include "common.names.namespace" . }}"}) < 3 > 0
+              container="postgres", namespace="{{ include "common.names.namespace" . }}"} == 0
             for: 5m
             labels:
               severity: warning


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Les règles d'alerting Keycloak sur les indisponibilités de pods ne sont pas assez spécifiques.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Règles d'alerting Keycloak sur les indisponibilités de pods adaptées : le nom du pod indisponible est maintenant affiché.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Refactor des messages d'alerte à cette occasion, pour utilisation de la variable de template Helm correspondant au namespace en lieu et place de la variable Ansible.