### PR TITLE
fix: :wrench: PascaleCase to camelCase

### DIFF
--- a/roles/cluster-offline/tasks/main.yml
+++ b/roles/cluster-offline/tasks/main.yml
@@ -5,11 +5,11 @@
       - dsc.sonarqube.pluginDownloadUrl != ""
     fail_msg: "'dsc.sonarqube.pluginDownloadUrl' must not be empty"
 
-- name: Validate dsc.sonarqube.PrometheusJavaagentVersion is not empty
+- name: Validate dsc.sonarqube.prometheusJavaagentVersion is not empty
   assert:
     that:
-      - dsc.sonarqube.PrometheusJavaagentVersion != ""
-    fail_msg: "'dsc.sonarqube.PrometheusJavaagentVersion' must not be empty"
+      - dsc.sonarqube.prometheusJavaagentVersion != ""
+    fail_msg: "'dsc.sonarqube.prometheusJavaagentVersion' must not be empty"
 
 - name: Validate dsc.gitlabCatalog.catalogRepoUrl is different than default
   assert:

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -873,7 +873,7 @@ spec:
                     pluginDownloadUrl:
                       description: Plugins download Url.
                       type: string
-                    PrometheusJavaagentVersion:
+                    prometheusJavaagentVersion:
                       description: Prometheus javaagent version.
                       type: string
                     values:

--- a/roles/sonarqube/templates/values/10-offline.j2
+++ b/roles/sonarqube/templates/values/10-offline.j2
@@ -1,8 +1,8 @@
 {% if dsc.global.offline %} 
 prometheusExporter:
-  version: {{ dsc.sonarqube.PrometheusJavaagentVersion }}
+  version: {{ dsc.sonarqube.prometheusJavaagentVersion }}
   noCheckCertificate: true
-  downloadURL: {{ dsc.sonarqube.pluginDownloadUrl }}/jmx_prometheus_javaagent-{{ dsc.sonarqube.PrometheusJavaagentVersion }}.jar 
+  downloadURL: {{ dsc.sonarqube.pluginDownloadUrl }}/jmx_prometheus_javaagent-{{ dsc.sonarqube.prometheusJavaagentVersion }}.jar 
 
 plugins:
   install:


### PR DESCRIPTION
## Issues liées

Issues numéro:  https://github.com/cloud-pi-native/socle/issues/281

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
PrometheusJavaagentVersion est écrit (avec un P majuscule) en PascaleCase au lieu de camelCase qui est la convention Kubernetes pour les fichiers YAML.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
PrometheusJavaagentVersion est remplacé par prometheusJavaagentVersion.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Il s'agit d'un breaking change pour les déploiements ayant défini `dsc.global.offline` à true.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Non.
