### PR TITLE
fix: :wrench: enable the use of proxy for grafana pod

### DIFF
--- a/roles/grafana/templates/grafana.yaml.j2
+++ b/roles/grafana/templates/grafana.yaml.j2
@@ -38,3 +38,13 @@ spec:
           imagePullSecrets: 
             - name: dso-config-pull-secret
 {% endif %}
+{% if dsc.proxy.enabled %}
+            env: 
+            - name: HTTP_PROXY
+              value: "{{ dsc.proxy.http_proxy }}"
+            - name: HTTPS_PROXY
+              value: "{{ dsc.proxy.https_proxy }}"
+            - name: NO_PROXY
+              value: "{{ dsc.proxy.no_proxy }}"
+{% endif %}
+


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Selon la configuration réseau des clusters, il est possible de rencontrer ce type d'erreur sur le pod Grafana.
```
level=error msg="Update check failed" error="failed to get latest.json repo from github.com: Get \"https://raw.githubusercontent.com/grafana/grafana/main/latest.json\": dial tcp 0.0.0.0:443: connect: connection refused" duration=7.440617ms
```

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Selon la configuration réseau du cluster, il est possible que la résolution passe par l'utilisation d'un proxy.
Un mode air-gap pourrait être envisagé, mais quand on voit le contenu du `https://raw.githubusercontent.com/grafana/grafana/main/latest.json` :
```
{
  "__message": "This file is now deprecated, and will be removed in a future release. No further updates should be made to this file",
  "stable": "10.2.3",
  "testing": "10.2.3"
}
```
Pas sur que ça vaille la peine.

La possibilité d'utiliser un proxy me semble malgré tout pertinente, pour peut-être d'autres utilisations.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Non.
