### PR TITLE
fix: :bug: dispatch ingress requests to vault active node

### DIFF
--- a/roles/vault/tasks/main.yml
+++ b/roles/vault/tasks/main.yml
@@ -37,6 +37,7 @@
   kubernetes.core.k8s:
     template: "{{ item }}"
   with_items:
+    - role.yaml.j2
     - ingress.yaml.j2
 
 # Post install

--- a/roles/vault/templates/ingress.yaml.j2
+++ b/roles/vault/templates/ingress.yaml.j2
@@ -32,6 +32,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ dsc_name }}-vault
+                name: {{ dsc_name }}-vault-active
                 port:
                   number: 8200

--- a/roles/vault/templates/role.yaml.j2
+++ b/roles/vault/templates/role.yaml.j2
@@ -1,0 +1,9 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "{{ dsc_name }}-vault"
+  namespace: {{ dsc.vault.namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "update", "patch"]

--- a/roles/vault/templates/values/00-main.j2
+++ b/roles/vault/templates/values/00-main.j2
@@ -24,6 +24,7 @@ server:
 {% if dsc.global.metrics.enabled %}
       config: |
         ui = true
+        service_registration "kubernetes" {}
         listener "tcp" {
           tls_disable = 1
           address = "[::]:8200"


### PR DESCRIPTION
<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Certaines requêtes vers l'api vault se font diriger vers des noeuds scellés.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Les requêtes qui arrivent dans l'ingress sont correctement dirigées vers le noeud actif du cluster vault.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
- cf. https://developer.hashicorp.com/vault/docs/configuration/service-registration/kubernetes.
- Déployé sur la plateforme d'integration.

*Ca devrait régler tes problèmes @mathieulaude.*
