### PR TITLE
feat: :sparkles: add pluginDownloadUrl for Keycloak

### DIFF
--- a/roles/keycloak/templates/values/00-main.j2
+++ b/roles/keycloak/templates/values/00-main.j2
@@ -305,13 +305,17 @@ extraEnvVars:
     value: cloudpinative-relations@interieur.gouv.fr
 initContainers:
   - name: realm-ext-provider
+{% if use_private_registry %}
+    image: "{{ dsc.global.registry }}/curlimages/curl:8.8.0"
+{% else %}
     image: docker.io/curlimages/curl:8.8.0
+{% endif %}
     imagePullPolicy: IfNotPresent
     command:
       - sh
     args:
       - -c
-      - curl -L -f -S -o /extensions/keycloak-theme-dsfr.jar https://github.com/codegouvfr/keycloak-theme-dsfr/releases/download/v1.0.3/retrocompat-keycloak-theme.jar
+      - curl -k -L -f -S -o /extensions/keycloak-theme-dsfr.jar {{ dsc.keycloak.pluginDownloadUrl }}/retrocompat-keycloak-theme.jar
     volumeMounts:
       - name: extensions
         mountPath: /extensions

--- a/roles/socle-config/files/config.yaml
+++ b/roles/socle-config/files/config.yaml
@@ -72,6 +72,7 @@ spec:
     subDomain: keycloak
     helmRepoUrl: https://charts.bitnami.com/bitnami
     postgresPvcSize: 1Gi
+    pluginDownloadUrl: https://github.com/codegouvfr/keycloak-theme-dsfr/releases/download/v1.0.3
     cnpg:
       mode: primary
       exposed: false

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -860,6 +860,9 @@ spec:
                       description: Size for postgres' pvc
                       type: string
                       default: 10Gi
+                    pluginDownloadUrl:
+                      description: Plugins download Url.
+                      type: string
                     values:
                       description: |
                         You can merge customs values for keycloak, they will be merged with roles/keycloak/templates/values.j2


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Actuellement il n'est pas possible de récupérer le plugin Keycloak `https://github.com/codegouvfr/keycloak-theme-dsfr/releases/download/v1.0.3/retrocompat-keycloak-theme.jar` pour un déploiement air-gapped.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Possibilité de spécifier une url privée avec `dsc.keycloak.pluginDownloadUrl`.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Non.