### PR TITLE
fix vault :bug: when global has no child items

### DIFF
--- a/roles/vault/templates/values/00-main.j2
+++ b/roles/vault/templates/values/00-main.j2
@@ -1,5 +1,5 @@
-global:
 {% if dsc.global.metrics.enabled %}
+global:
   serverTelemetry:
     prometheusOperator: true
 {% endif %}


### PR DESCRIPTION
## Quel est le comportement actuel ?
Lorsque `global.metrics.enable == false` et `global.platform != "openshift"`, la **clé** `global` n'a pas de **valeur** (éléments enfant ou `{}`).
La tâche [`Deploy Helm`](https://github.com/cloud-pi-native/socle/blob/develop/roles/vault/tasks/main.yml#L27) termine l'installation avec l'erreur suivante :
```shell
Error: UPGRADE FAILED: template: vault/templates/\_helpers.tpl:63:64: executing "vault.serverEnabled"
at \<.Values.global.enabled>: nil pointer evaluating interface {}.enabled\
```

## Quel est le nouveau comportement ?
Élimine l'erreur en déplaçant `global:` dans la condition qui suit pour éviter qu'il ne soit ajouté aux values de vault alors qu'il n'a pas d'éléments enfant (ou un tableau explicitement vide `{}`).

## Cette PR introduit-elle un breaking change ?
Non

## Autres informations
Une résolution temporaire est d'ajouter `global: {}` dans `dsc.vault.values`.