### PR TITLE
fix: :wrench: enforce gitlab root user email

### DIFF
--- a/roles/gitlab-catalog/tasks/main.yaml
+++ b/roles/gitlab-catalog/tasks/main.yaml
@@ -12,17 +12,6 @@
   when: ansible_inventory.resources[0].data.GITLAB_TOKEN is defined and ansible_inventory.resources[0].data.GITLAB_TOKEN | length != 0
   register: set_token_inv
 
-- name: Create Catalog
-  community.general.gitlab_project:
-    api_url: https://{{ gitlab_domain }}
-    api_token: "{{ gitlab_token }}"
-    validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    import_url: "{{ dsc.gitlabCatalog.catalogRepoUrl }}"
-    name: Catalog
-    path: catalog
-    group: "{{ dsc.global.projectsRootDir | join('/') }}"
-    visibility: internal
-
 - name: Clone Git repository as bare
   ansible.builtin.git:
     repo: "{{ dsc.gitlabCatalog.catalogRepoUrl }}"
@@ -38,3 +27,14 @@
     git push --mirror "https://admin:{{ gitlab_token }}@{{ gitlab_domain }}/{{ dsc.global.projectsRootDir | join('/') }}/catalog"
   args:
     chdir: /tmp/test
+
+- name: Update Catalog visibility and path
+  community.general.gitlab_project:
+    api_url: https://{{ gitlab_domain }}
+    api_token: "{{ gitlab_token }}"
+    validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
+    import_url: "{{ dsc.gitlabCatalog.catalogRepoUrl }}"
+    name: Catalog
+    path: catalog
+    group: "{{ dsc.global.projectsRootDir | join('/') }}"
+    visibility: internal

--- a/roles/gitlab-runner/templates/values/00-main.j2
+++ b/roles/gitlab-runner/templates/values/00-main.j2
@@ -59,11 +59,11 @@ runners:
         pull_policy = ["always", "always"]
 {% if dsc.gitlabRunner.resources is defined and dsc.gitlabRunner.resources != 'none' %}
         # request and limit of build pod and override allowed in ci
-  {% if dsc.gitlabRunner.resources.requests != 'none' %}
+  {% if dsc.gitlabRunner.resources.requests is defined and dsc.gitlabRunner.resources.requests != 'none' %}
         cpu_request = "{{ dsc.gitlabRunner.resources.requests.cpu }}"
         memory_request = "{{ dsc.gitlabRunner.resources.requests.memory }}"
   {% endif %}
-  {% if dsc.gitlabRunner.resources.limits != 'none' %}
+  {% if dsc.gitlabRunner.resources.limits is defined and dsc.gitlabRunner.resources.limits != 'none' %}
         cpu_limit = "{{ dsc.gitlabRunner.resources.limits.cpu }}"
         memory_limit = "{{ dsc.gitlabRunner.resources.limits.memory }}"
   {% endif %}

--- a/roles/gitlab/templates/values/00-main.j2
+++ b/roles/gitlab/templates/values/00-main.j2
@@ -103,6 +103,9 @@ global:
       providers:
         - secret: openid-connect
 
+  extraEnv:
+    GITLAB_ROOT_EMAIL: "admin@example.com"
+
 prometheus:
   install: false
 


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Suite à la monté de version du chart Gitlab 7.x.x vers 8.2.1, l'adresse mail du root user de Gitlab est randomisée suite à une MR de type sécurité : https://gitlab.com/gitlab-org/gitlab/-/merge_requests/150388. La connexion OIDC avec Keycloak ne pointe donc plus vers ce root user mais crée un nouvel user qui n'a pas les permissions d'utilisation du token root pour poursuivre l'installation du socle.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Nous allons forcer l'adresse mail historique du root user en utilisant les variables d'environnements :
- https://gitlab.com/gitlab-org/gitlab/-/blob/master/doc/install/installation.md#initialize-database-and-activate-advanced-features
- https://docs.gitlab.com/charts/charts/globals#extraenv

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Non.
