### PR TITLE
fix: :wrench: argocd ca yaml indent

### DIFF
--- a/roles/argocd/templates/values/10-exposed-ca.j2
+++ b/roles/argocd/templates/values/10-exposed-ca.j2
@@ -3,5 +3,5 @@ configs:
   tls:
     certificates:
       {{ gitlab_domain }}: |
-        {{ exposed_ca_pem | indent(width=6, first=False) }}
+        {{ exposed_ca_pem | indent(width=8, first=False) }}
 {% endif %}

--- a/roles/argocd/templates/values/10-offline.j2
+++ b/roles/argocd/templates/values/10-offline.j2
@@ -3,5 +3,5 @@ configs:
   tls:
     certificates:
       {{ dsc.argocd.privateGitlabDomain }}: |
-        {{ exposed_ca_pem | indent(width=6, first=False) }}
+        {{ exposed_ca_pem | indent(width=8, first=False) }}
 {% endif %}


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Il y a une erreur d'indentation lors de l'utilisation des `exposed_ca_pem` depuis la migration du chart https://artifacthub.io/packages/helm/bitnami/argo-cd vers https://artifacthub.io/packages/helm/argo/argo-cd : https://github.com/cloud-pi-native/socle/commit/aa60d15803cbdce606ceb61a7322af5ead2245e4#diff-63c7a088cd527c816d4a454138e377f69f2c2e568ca009c9ab2df3797deca88b

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Fix de l'indentation.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Non.