### PR TITLE
fix: :wrench: sonarqube db owner

### DIFF
--- a/roles/sonarqube/templates/pg-cluster-sonar.yaml.j2
+++ b/roles/sonarqube/templates/pg-cluster-sonar.yaml.j2
@@ -29,7 +29,7 @@ spec:
     pg_hba:
       # To access through TCP/IP you will need to get username
       # and password from the secret pg-cluster-sonar-app
-      - host sonardb dso_admin all md5
+      - host sonardb sonarqube all md5
       - host sonardb streaming_replica all md5
 {% endif %}
   bootstrap:

--- a/roles/sonarqube/templates/values/00-main.j2
+++ b/roles/sonarqube/templates/values/00-main.j2
@@ -69,7 +69,7 @@ jdbcOverwrite:
   # If enable the JDBC Overwrite, make sure to set `postgresql.enabled=false`
   enable: true
   jdbcUrl: "jdbc:postgresql://pg-cluster-sonar-rw/sonardb?socketTimeout=1500"
-  jdbcUsername: "dso_admin"
+  jdbcUsername: "sonarqube"
   jdbcSecretName: "pg-cluster-sonar-app"
   jdbcSecretPasswordKey: "password"
 


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Suite au changement du owner de la db sonarqube depuis https://github.com/cloud-pi-native/socle/commit/ddae834117394970dd21c21cd5cd877c00bdda4b#diff-7bca93bebee2b05c274ae764a5f4e0a85cd389bdd6b7aec30112bdd0349dd673, le role sonarqube plante sur 
```
Caused by: com.zaxxer.hikari.pool.HikariPool$PoolInitializationException: Failed to initialize pool: FATAL: password authentication failed for user "dso_admin"
```

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Rename de tout ce qui est `dso_admin` en `sonarqube` dans le role sonarqube pour matcher le changement du owner de la db.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Non.
