### PR TITLE
refactor: :recycle: dsc.global.platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
     - [Vault](#vault)
 - [Backups](#backups)
 - [Offline / air gap](#offline--air-gap)
+- [Platform](#platform)
 - [Profile CIS](#profile-cis)
 - [Utilisation de credentials Docker Hub pour le pull des images](#utilisation-de-credentials-docker-hub-pour-le-pull-des-images)
 - [Contributions](#contributions)
@@ -159,7 +160,7 @@ kubectl apply -f ma-conf-dso.yaml
 Pour vous aider à démarrer, voici un **exemple** de fichier de configuration valide, à adapter à partir de la section **spec**, notamment au niveau :
 * du paramètre `global.rootDomain` (votre domaine principal précédé d'un point),
 * des mots de passe de certains outils,
-* du paramètre `global.platform` (à positionner sur `kubernetesVanilla` si vous n'utilisez pas OpenShift),
+* du paramètre `global.platform` (à positionner sur `kubernetes` si vous n'utilisez pas OpenShift),
 * de la taille de certains PVCs,
 * de l'activation ou non des métriques,
 * du proxy ainsi que des sections CA et ingress.
@@ -1019,6 +1020,13 @@ En mode air gap ou déconnecté d'internet, certaines valeurs de la `dsc` devron
 - `dsc.grafanaOperator.ociChartUrl`
 - `helmRepoUrl` pour chaque service à savoir :
   - `argocd`, `certmanager`, `cloudnativepg`, `console`, `gitlabCiPipelinesExporter`, `gitlabOperator`, `gitlabRunner`, `harbor`, `keycloak`, `kyverno`, `sonarqube` et `vault`
+
+## Platform
+
+Par défaut, le déploiement du socle DSO se fait sur un cluster de la famille Openshift, mais il est possible de déployer sur les autres types de distribution Kubernetes (Vanilla, K3s, RKE2, EKS, GKE...) en spécifiant comme suit dans la dsc.
+```
+platform: kubernetes
+```
 
 ## Profile CIS
 

--- a/roles/nexus/templates/nexus.yml.j2
+++ b/roles/nexus/templates/nexus.yml.j2
@@ -16,7 +16,7 @@ spec:
       labels:
         app: nexus
     spec:
-{% if dsc.global.platform == "kubernetesVanilla" or dsc.global.platform == "rke2" %}
+{% if dsc.global.platform == "kubernetes" %}
       securityContext:
         runAsNonRoot: true
         runAsGroup: 200 

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -540,12 +540,11 @@ spec:
                       type: object
                     platform:
                       default: openshift
-                      description: Cluster platform only openshift, kubernetesVanilla and rke2
-                        are supported (for now).
+                      description: Cluster platform, either the Openshift family (Openshift, OKD), or the rest
+                        (Kubernetes Vanilla, K3s, RKE2, EKS, GKE...).
                       enum:
                         - openshift
-                        - kubernetesVanilla
-                        - rke2
+                        - kubernetes
                       type: string
                     offline:
                       default: false

--- a/roles/sonarqube/templates/values/00-main.j2
+++ b/roles/sonarqube/templates/values/00-main.j2
@@ -22,7 +22,7 @@ ingress:
   labels:
     app: "sonar"
 
-# Should be kept as false even if dsc.global.platform == "kubernetesVanilla" and it may be best to work with your cluster administrator to either provide specific nodes with the proper kernel settings, or ensure they are set cluster wide : sysctl -a "name=vm.max_map_count value=262144"
+# Should be kept as false even if dsc.global.platform == "kubernetes" and it may be best to work with your cluster administrator to either provide specific nodes with the proper kernel settings, or ensure they are set cluster wide : sysctl -a "name=vm.max_map_count value=262144"
 initSysctl:
   enabled: false
 

--- a/roles/sonarqube/templates/values/10-platform.j2
+++ b/roles/sonarqube/templates/values/10-platform.j2
@@ -22,7 +22,7 @@ account:
   securityContext: {}
 {% endif %}
 
-{% if dsc.global.platform == "kubernetesVanilla" %}
+{% if dsc.global.platform == "kubernetes" %}
 account:
   securityContext:
     runAsUser: 101

--- a/roles/vault/templates/values/10-platform.j2
+++ b/roles/vault/templates/values/10-platform.j2
@@ -3,7 +3,7 @@ global:
   openshift: true
 {% endif %}
 
-{% if dsc.global.platform == "kubernetesVanilla" or dsc.global.platform == "rke2" %}
+{% if dsc.global.platform == "kubernetes" %}
 injector:
   securityContext:
     pod:


### PR DESCRIPTION
## Issues liées

Issues numéro: https://github.com/cloud-pi-native/socle/issues/89

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Actuellement, il y a distinction entre chaque type de distribution Kubernetes (Openshift, Kubernetes Vanilla, RKE2) pour le déploiement du socle DSO.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Nous avons pu constater qu'il est possible de classifier le déploiement du socle DSO sur deux familles de distribution Kubernetes :
- Openshift, OKD,
- Vanilla, K3s, RKE2, EKS, GKE...

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Breaking change pour les utilisateurs déployant sur autre chose que de l'Openshift. Il faudra désormais spécifier dans la dsc :
```
platform: kubernetes
```

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Non.
