### PR TITLE
refactor: :recycle: add .j2 suffix to keycloak template yaml name

### DIFF
--- a/roles/keycloak/vars/main.yaml
+++ b/roles/keycloak/vars/main.yaml
@@ -14,8 +14,8 @@ keycloak_clients:
   - clientId: console-frontend
     standardFlowEnabled: true
     directAccessGrantsEnabled: true
-    redirectUris: "{{ lookup('ansible.builtin.template', 'console-frontend-redirectUris.yaml') | from_yaml }}"
-    webOrigins: "{{ lookup('ansible.builtin.template', 'console-frontend-webOrigins.yaml') | from_yaml }}"
+    redirectUris: "{{ lookup('ansible.builtin.template', 'console-frontend-redirectUris.yaml.j2') | from_yaml }}"
+    webOrigins: "{{ lookup('ansible.builtin.template', 'console-frontend-webOrigins.yaml.j2') | from_yaml }}"
     defaultClientScopes:
       - generic
     publicClient: true


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Suite à https://github.com/cloud-pi-native/socle/commit/0f60c81b3c6d961cd0800c31f8b442ddba963d85#diff-76d247f738acda32b781e9daff33802594d7d28bc579a5a30163619bf59ddb7b, les fichiers `console-frontend-redirectUris.yaml` et `console-frontend-webOrigins.yaml` ont été suffixé avec `.j2`, ce qui fait planter le role Keycloak.


## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Modification en conséquence du `roles/keycloak/vars/main.yaml` pour matcher les nouveaux noms.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Non.