### PR TITLE
Fix/install requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Pour information, le playbook `install-requirements.yaml` vous installera les é
   - pyyaml
   - kubernetes
   - python-gitlab
+  - jmespath
 
 - Collection Ansible [kubernetes.core](https://github.com/ansible-collections/kubernetes.core) si elle n'est pas déjà présente.
 

--- a/admin-tools/install-requirements.yaml
+++ b/admin-tools/install-requirements.yaml
@@ -13,6 +13,7 @@
       - pyyaml
       - kubernetes
       - python-gitlab
+      - jmespath
     apps:
       - kubectl
       - helm


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Le playbook d'installation des prérequis n'installe pas le module python jmespath, requis ultérieurement par le role console-dso.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Le playbook d'installation des prérequis permet maintenant d'installer jmespath.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Installation en local de jmespath et lancement du role console-dso sur un cluster de développement testés avec succès.
Fichier README mis à jour pour prise en compte du changement.