### PR TITLE
fix: :art: Update condition for alert deployment

### DIFF
--- a/roles/vault/templates/values/00-main.j2
+++ b/roles/vault/templates/values/00-main.j2
@@ -95,6 +95,7 @@ serverTelemetry:
         for: 5m
         labels:
           severity: critical
+{% endif %}
       - alert: Vault instance not healthy
         annotations:
           message: Vault {{"{{"}} $labels.pod {{"}}"}} pod in namespace {{ dsc.vault.namespace }} is not healthy (sealed?). Check its logs.
@@ -104,7 +105,6 @@ serverTelemetry:
         for: 5m
         labels:
           severity: warning
-{% endif %}
       - alert: Vault is not available
         annotations:
           message: Vault in namespace {{ dsc.vault.namespace }} has not been available for the last 5 minutes.


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Déploie l'alerte "Vault instance not healthy" qui s'appuie sur la métrique "up" uniquement lorsque les métriques sont activées dans la dsc.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

L'alerte "Vault instance not healthy" est maintenant déployée indépendamment de l'activation des métriques de Vault, du moment que l'alerting est activé dans la dsc. En effet, la métrique "up" est indépendante des métriques de Vault. Elle est mise en place par Prometheus ([source](https://prometheus.io/docs/concepts/jobs_instances/)).

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement de déploiement de l'alerte testé dans un cluster de développement.
