### PR TITLE
fix: :bug: Fix "Vault Pod not healthy" alert rule.

### DIFF
--- a/roles/vault/templates/values/00-main.j2
+++ b/roles/vault/templates/values/00-main.j2
@@ -143,8 +143,7 @@ serverTelemetry:
           summary: Vault pod not healthy (container is not ready)
         expr: |
           kube_pod_container_status_ready{
-          pod=~"(.*-)*vault(-.*)*",
-          container=~"vault|sidecar-injector",
+          pod!~"backup-utils-vault(-.*)*",
           namespace="{{ dsc.vault.namespace }}"} == 0
         for: 5m
         labels:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

L'alerte "Vault Pod not healthy" remonte également pour les pods "backup-utils" du namespace de Vault, mais ce n'est pas ce que nous voulons.
Les containers de ces pods repassent en effet en état not ready une fois leur tâche exécutée, ce qui déclenche l'alerte. 
Nous voulons que cette alerte ne remonte que pour les autres pods du namespace.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

L'alerte "Vault Pod not healthy" remonte pour tous les pods sauf pour les "backup-utils".

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.
