### PR TITLE
feat: :sparkles: Add Kyverno alerting rules + new crd parameter

### DIFF
--- a/roles/kyverno/tasks/main.yaml
+++ b/roles/kyverno/tasks/main.yaml
@@ -18,7 +18,9 @@
     combine_dest_var: "kyverno_values"
 
 - name: Install Kyverno
-  when: kyverno_pods.resources | length == 0
+  when: >
+    kyverno_pods.resources | length == 0 or
+    dsc.kyverno.forcedInstall
   block:
     - name: Add helm repo
       kubernetes.core.helm_repository:
@@ -34,6 +36,11 @@
         release_namespace: "{{ dsc.kyverno.namespace }}"
         create_namespace: true
         values: "{{ kyverno_values }}"
+
+    - name: Set alerting rules
+      when: dsc.global.alerting.enabled
+      kubernetes.core.k8s:
+        template: prometheusrule.yml.j2
 
 - name: Wait Kyverno service endpoint to be available
   kubernetes.core.k8s_info:
@@ -55,16 +62,41 @@
       | reject('equalto', dsc.kyverno.namespace)
       }}"
 
+- name: Check replace-kubed ClusterPolicy
+  kubernetes.core.k8s_info:
+    kind: ClusterPolicy
+    name: replace-kubed
+  register: replace_kubed_cp
+
 - name: Create replace-kubed ClusterPolicy
+  when: replace_kubed_cp.resources | length == 0
   kubernetes.core.k8s:
     template: replace-kubed.yml.j2
 
+- name: Check security-context ClusterPolicy
+  kubernetes.core.k8s_info:
+    kind: ClusterPolicy
+    name: security-context-dso
+  register: security_context_cp
+
 - name: Create security-context ClusterPolicy for cis profile
+  when: >
+    dsc.global.profile is defined and
+    dsc.global.profile == "cis" and
+    security_context_cp.resources | length == 0
   kubernetes.core.k8s:
     template: cis.yml.j2
-  when: dsc.global.profile is defined and dsc.global.profile == "cis"
+
+- name: Check exposed-ca ClusterPolicy
+  kubernetes.core.k8s_info:
+    kind: ClusterPolicy
+    name: exposed-ca-dso-gitlab-runner
+  register: exposed_ca_cp
 
 - name: Create ClusterPolicy for exposedCA
+  when: >
+    exposed_ca_cp.resources | length == 0 and
+    (dsc.exposedCA.type == "configmap" or
+    dsc.exposedCA.type == "secret")
   kubernetes.core.k8s:
     template: exposedCA.yml.j2
-  when: dsc.exposedCA.type == "configmap" or dsc.exposedCA.type == "secret"

--- a/roles/kyverno/templates/prometheusrule.yml.j2
+++ b/roles/kyverno/templates/prometheusrule.yml.j2
@@ -1,0 +1,70 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: gitlab
+  name: kyverno
+  namespace: {{ dsc.kyverno.namespace }}
+spec:
+  groups:
+  - name: Kyverno
+    rules:
+    - alert: Kyverno admission controler not available
+      annotations:
+        message: Kyverno admission controler in namespace {{ dsc.kyverno.namespace }} has not been available for the last 5 minutes.
+        summary: Kyverno admission controler down (no ready pod)"
+      expr: |
+        sum(kube_pod_status_ready{
+        pod=~"kyverno-admission-controller-.*",
+        namespace="{{ dsc.kyverno.namespace }}",
+        condition="true"}) == 0
+      for: 1m
+      labels:
+        severity: critical
+    - alert: Kyverno background controler not available
+      annotations:
+        message: Kyverno background controler in namespace {{ dsc.kyverno.namespace }} has not been available for the last 5 minutes.
+        summary: Kyverno background controler down (no ready pod)"
+      expr: |
+        sum(kube_pod_status_ready{
+        pod=~"kyverno-background-controller-.*",
+        namespace="{{ dsc.kyverno.namespace }}",
+        condition="true"}) == 0
+      for: 1m
+      labels:
+        severity: critical
+    - alert: Kyverno cleanup controller not available
+      annotations:
+        message: Kyverno cleanup controller in namespace {{ dsc.kyverno.namespace }} has not been available for the last 5 minutes.
+        summary: Kyverno cleanup controller down (no ready pod)"
+      expr: |
+        sum(kube_pod_status_ready{
+        pod=~"kyverno-cleanup-controller-.*",
+        namespace="{{ dsc.kyverno.namespace }}",
+        condition="true"}) == 0
+      for: 1m
+      labels:
+        severity: critical
+    - alert: Kyverno reports controller not available
+      annotations:
+        message: Kyverno reports controller in namespace {{ dsc.kyverno.namespace }} has not been available for the last 5 minutes.
+        summary: Kyverno reports controller down (no ready pod)"
+      expr: |
+        sum(kube_pod_status_ready{
+        pod=~"kyverno-reports-controller-.*",
+        namespace="{{ dsc.kyverno.namespace }}",
+        condition="true"}) == 0
+      for: 1m
+      labels:
+        severity: critical
+    - alert: Kyverno Pod not healthy
+      annotations:
+        message: Kyverno {{"{{"}} $labels.pod {{"}}"}} pod in namespace {{ dsc.kyverno.namespace }} has been unavailable for the last 5 minutes.
+        summary: Kyverno {{"{{"}} $labels.pod {{"}}"}} pod not healthy (container {{"{{"}} $labels.container {{"}}"}} is not ready)
+      expr: |
+        kube_pod_container_status_ready{
+        pod!~"(.*-)*admission-reports(-.*)*",
+        namespace="{{ dsc.kyverno.namespace }}"} == 0
+      for: 1m
+      labels:
+        severity: warning

--- a/roles/socle-config/files/config.yaml
+++ b/roles/socle-config/files/config.yaml
@@ -81,6 +81,7 @@ spec:
   kyverno:
     namespace: dso-kyverno
     helmRepoUrl: https://kyverno.github.io/kyverno
+    forcedInstall: false
   nexus:
     namespace: dso-nexus
     subDomain: nexus

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -866,6 +866,13 @@ spec:
                     namespace:
                       description: The namespace for Kyverno.
                       type: string
+                    forcedInstall:
+                      description: |
+                        Should we force Kyverno installation in the desired namespace ?
+                        Default is false, so it won't install (or reinstall) if it's already there.
+                        Set to true for a forced installation.
+                      default: false
+                      type: boolean
                     helmRepoUrl:
                       description: Kyverno helm repository url.
                       type: string


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

- Installe Kyverno sans règle d'alerting.
- Ne lance l'installation de Kyverno que s'il est absent du cluster.
- Tente systématiquement d'installer les ClusterPolicies, ce qui fait échouer le role si elles sont déjà présentes dans le cluster.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

- Met en place des règles d'alerting pour Kyverno.
- Permet de forcer si besoin la réinstallation de kyverno dans le namespace souhaité, via l'introduction du paramètre "forcedInstall" dans la dsc.
- Vérifie la présence des ClusterPolicies et ne les installe que si elles sont absentes du cluster.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.
