### PR TITLE
feat: :sparkles: Add Cert-manager alerting rule

### DIFF
--- a/roles/cert-manager/tasks/main.yaml
+++ b/roles/cert-manager/tasks/main.yaml
@@ -14,7 +14,10 @@
   register: cm_mwhc
 
 - name: Install cert-manager
-  when: (cm_api == 'absent') or (cm_mwhc.resources | length == 0)
+  when: >
+    cm_api == 'absent' or
+    cm_mwhc.resources | length == 0 or
+    dsc.certmanager.forcedInstall
   block:
     - name: Add cert-manager helm repo
       kubernetes.core.helm_repository:
@@ -66,6 +69,11 @@
       until: endpoint.resources[0].subsets[0].addresses[0] is defined
       retries: 15
       delay: 5
+
+    - name: Set alerting rules
+      when: dsc.global.alerting.enabled
+      kubernetes.core.k8s:
+        template: prometheusrule.yml.j2
 
 - name: Create Let's Encrypt ClusterIssuer
   kubernetes.core.k8s:

--- a/roles/cert-manager/templates/prometheusrule.yml.j2
+++ b/roles/cert-manager/templates/prometheusrule.yml.j2
@@ -19,4 +19,4 @@ spec:
         namespace="cert-manager"} == 0
       for: 5m
       labels:
-        severity: warning
+        severity: critical

--- a/roles/cert-manager/templates/prometheusrule.yml.j2
+++ b/roles/cert-manager/templates/prometheusrule.yml.j2
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: gitlab
+  name: certmanager
+  namespace: cert-manager
+spec:
+  groups:
+  - name: Cert-manager
+    rules:
+    - alert: Cert-manager Pod not healthy
+      annotations:
+        message: Cert-manager {{"{{"}} $labels.pod {{"}}"}} pod in namespace cert-manager has been unavailable for the last 5 minutes.
+        summary: Cert-manager {{"{{"}} $labels.pod {{"}}"}} pod not healthy (container {{"{{"}} $labels.container {{"}}"}} is not ready)
+      expr: |
+        kube_pod_container_status_ready{
+        pod=~"cert-manager(-.*)*",
+        namespace="cert-manager"} == 0
+      for: 5m
+      labels:
+        severity: warning

--- a/roles/socle-config/files/config.yaml
+++ b/roles/socle-config/files/config.yaml
@@ -11,6 +11,7 @@ spec:
     helmRepoUrl: https://argoproj.github.io/argo-helm
   certmanager:
     helmRepoUrl: https://charts.jetstack.io
+    forcedInstall: false
   cloudnativepg:
     namespace: dso-cloudnativepg
     helmRepoUrl: https://cloudnative-pg.github.io/charts

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -157,6 +157,13 @@ spec:
                     chartVersion:
                       description: Cert-manager helm chart version (e.g., "v1.13.1").
                       type: string
+                    forcedInstall:
+                      description: |
+                        Should we force Cert-manager installation in the desired namespace ?
+                        Default is false, so it won't install (or reinstall) if it's already there.
+                        Set to true for a forced installation.
+                      default: false
+                      type: boolean
                   type: object
                 cloudnativepg:
                   description: Configuration for CloudNativePG.


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

- Installe Cert-manager sans règle d'alerting.
- Ne lance l'installation de Cert-manager que s'il est absent du cluster.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

- Met en place une règle d'alerting pour Cert-manager.
- Permet de forcer si besoin la réinstallation de Cert-manager, via l'introduction du paramètre "forcedInstall" dans la dsc.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.
