### PR TITLE
Feat/cnpg alerting rules

### DIFF
--- a/roles/cloudnativepg/tasks/main.yml
+++ b/roles/cloudnativepg/tasks/main.yml
@@ -14,7 +14,10 @@
   register: cnpg_mwhc
 
 - name: Install CloudNativePG operator
-  when: (cnpg_api == 'absent') or (cnpg_mwhc.resources | length == 0)
+  when: >
+    cnpg_api == 'absent' or
+    cnpg_mwhc.resources | length == 0 or
+    dsc.cloudnativepg.forcedInstall
   block:
     - name: Create CloudNativePG namespace
       kubernetes.core.k8s:
@@ -57,3 +60,8 @@
       until: endpoint.resources[0].subsets[0].addresses[0] is defined
       retries: 15
       delay: 5
+
+    - name: Set alerting rules
+      when: dsc.global.alerting.enabled
+      kubernetes.core.k8s:
+        template: prometheusrule.yml.j2

--- a/roles/cloudnativepg/templates/prometheusrule.yml.j2
+++ b/roles/cloudnativepg/templates/prometheusrule.yml.j2
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: gitlab
+  name: cnpg
+  namespace: {{ dsc.cloudnativepg.namespace }}
+spec:
+  groups:
+  - name: CNPG
+    rules:
+    - alert: CNPG Operator Pod not healthy
+      annotations:
+        message: CNPG Operator {{"{{"}} $labels.pod {{"}}"}} pod in namespace {{ dsc.cloudnativepg.namespace }} has been unavailable for the last 5 minutes.
+        summary: CNPG Operator {{"{{"}} $labels.pod {{"}}"}} pod not healthy (container {{"{{"}} $labels.container {{"}}"}} is not ready)
+      expr: |
+        kube_pod_container_status_ready{
+        pod=~"cloudnative-pg(-.*)*",
+        namespace="{{ dsc.cloudnativepg.namespace }}"} == 0
+      for: 1m
+      labels:
+        severity: critical

--- a/roles/cloudnativepg/templates/prometheusrule.yml.j2
+++ b/roles/cloudnativepg/templates/prometheusrule.yml.j2
@@ -17,6 +17,6 @@ spec:
         kube_pod_container_status_ready{
         pod=~"cloudnative-pg(-.*)*",
         namespace="{{ dsc.cloudnativepg.namespace }}"} == 0
-      for: 1m
+      for: 5m
       labels:
         severity: critical

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -177,6 +177,13 @@ spec:
                     chartVersion:
                       description: CloudNativePG helm chart version (e.g., "0.18.2").
                       type: string
+                    forcedInstall:
+                      description: |
+                        Should we force CNPG Operator installation in the desired namespace ?
+                        Default is false, so it won't install (or reinstall) if it's already there.
+                        Set to true for a forced installation.
+                      default: false
+                      type: boolean
                   type: object
                 console:
                   description: Configuration for the console.


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

- Installe l'opérateur CNPG sans règle d'alerting.
- Ne lance l'installation de l'opérateur CNPG que s'il est absent du cluster.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

- Met en place une règle d'alerting pour l'opérateur CNPG.
- Permet de forcer si besoin la réinstallation de l'opérateur CNPG, via l'introduction du paramètre "forcedInstall" dans la dsc.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.
