### PR TITLE
Feat/gitlab operator alerting rules

### DIFF
--- a/roles/gitlab-operator/tasks/main.yaml
+++ b/roles/gitlab-operator/tasks/main.yaml
@@ -41,7 +41,11 @@
         needs_update: true
 
 - name: Install GitLab Operator
-  when: (gl_api == 'absent') or (gl_vwhc.resources | length == 0) or (needs_update)
+  when: >
+    gl_api == 'absent' or
+    gl_vwhc.resources | length == 0 or
+    needs_update or
+    dsc.gitlabOperator.forcedInstall
   block:
     - name: Create GitLab Operator namespace
       kubernetes.core.k8s:
@@ -77,3 +81,8 @@
       until: endpoint.resources[0].subsets[0].addresses[0] is defined
       retries: 15
       delay: 5
+
+    - name: Set alerting rules
+      when: dsc.global.alerting.enabled
+      kubernetes.core.k8s:
+        template: prometheusrule.yml.j2

--- a/roles/gitlab-operator/templates/prometheusrule.yml.j2
+++ b/roles/gitlab-operator/templates/prometheusrule.yml.j2
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: gitlab
+  name: gitlab-operator
+  namespace: {{ dsc.gitlabOperator.namespace }}
+spec:
+  groups:
+  - name: GitLab Operator
+    rules:
+    - alert: GitLab Operator Pod not healthy
+      annotations:
+        message: GitLab Operator {{"{{"}} $labels.pod {{"}}"}} pod in namespace {{ dsc.gitlabOperator.namespace }} has been unavailable for the last 5 minutes.
+        summary: GitLab Operator {{"{{"}} $labels.pod {{"}}"}} pod not healthy (container {{"{{"}} $labels.container {{"}}"}} is not ready)
+      expr: |
+        kube_pod_container_status_ready{
+        pod=~"gitlab-controller-manager(-.*)*",
+        namespace="{{ dsc.gitlabOperator.namespace }}"} == 0
+      for: 5m
+      labels:
+        severity: critical

--- a/roles/socle-config/files/config.yaml
+++ b/roles/socle-config/files/config.yaml
@@ -15,6 +15,7 @@ spec:
   cloudnativepg:
     namespace: dso-cloudnativepg
     helmRepoUrl: https://cloudnative-pg.github.io/charts
+    forcedInstall: false
   console:
     namespace: dso-console
     subDomain: console
@@ -37,6 +38,7 @@ spec:
   gitlabOperator:
     namespace: dso-gitlab-operator
     helmRepoUrl: https://gitlab.com/api/v4/projects/18899486/packages/helm/stable
+    forcedInstall: false
   gitlabRunner:
     helmRepoUrl: https://charts.gitlab.io
   global:

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -334,6 +334,13 @@ spec:
                     namespace:
                       description: The namespace for GitLab Operator.
                       type: string
+                    forcedInstall:
+                      description: |
+                        Should we force GitLab Operator installation in the desired namespace ?
+                        Default is false, so it won't install (or reinstall) if it's already there.
+                        Set to true for a forced installation.
+                      default: false
+                      type: boolean
                   type: object
                 gitlabCatalog:
                   description: Configuration for GitLab Catalog.


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

- Installe l'opérateur GitLab sans règle d'alerting.
- Ne lance l'installation de l'opérateur GitLab que s'il est absent du cluster ou nécessite un upgrade.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

- Met en place une règle d'alerting pour l'opérateur GitLab.
- Permet de forcer si besoin la réinstallation de l'opérateur GitLab, via l'introduction du paramètre "forcedInstall" dans la dsc.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.
