### PR TITLE
fix: :bug: Fix Argo CD role

### DIFF
--- a/roles/argocd/tasks/main.yaml
+++ b/roles/argocd/tasks/main.yaml
@@ -7,14 +7,14 @@
   register: argocd_secret
   failed_when: argocd_secret.resources | length == 0
 
-- name: Argo crb
+- name: Argo CD OpenShift scc crb
   kubernetes.core.k8s:
     definition:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
         creationTimestamp:
-        name: system:openshift:scc:privileged
+        name: "{{ dsc_name }}-argocd-system:openshift:scc:privileged"
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
@@ -22,19 +22,19 @@
       subjects:
         - kind: ServiceAccount
           namespace: "{{ dsc.argocd.namespace }}"
-          name: argo-argocd-repo-server
+          name: "{{ dsc_name }}-argocd-repo-server"
         - kind: ServiceAccount
           namespace: "{{ dsc.argocd.namespace }}"
           name: argocd-server
         - kind: ServiceAccount
           namespace: "{{ dsc.argocd.namespace }}"
-          name: argo-redis
+          name: "{{ dsc_name }}-redis"
         - kind: ServiceAccount
           namespace: "{{ dsc.argocd.namespace }}"
-          name: argo-redis-ha
+          name: "{{ dsc_name }}-redis-ha"
         - kind: ServiceAccount
           namespace: "{{ dsc.argocd.namespace }}"
-          name: argo-redis-ha-haproxy
+          name: "{{ dsc_name }}-redis-ha-haproxy"
 
 - name: Add helm repo
   kubernetes.core.helm_repository:
@@ -56,7 +56,7 @@
 
 - name: Deploy helm
   kubernetes.core.helm:
-    name: argo
+    name: "{{ dsc_name }}"
     chart_ref: argo/argo-cd
     chart_version: "{{ dsc.argocd.chartVersion }}"
     release_namespace: "{{ dsc.argocd.namespace }}"

--- a/roles/argocd/templates/ingress.yaml.j2
+++ b/roles/argocd/templates/ingress.yaml.j2
@@ -30,7 +30,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: argo-argocd-server
+                name: {{ dsc_name }}-argocd-server
                 port:
                   number: 80
 
@@ -67,6 +67,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: argo-argocd-applicationset-controller
+                name: {{ dsc_name }}-argocd-applicationset-controller
                 port:
                   number: 7000

--- a/uninstall.yaml
+++ b/uninstall.yaml
@@ -312,11 +312,33 @@
       tags:
         - vault
 
+    - name: "Suppression de l'intance Argo CD"
+      kubernetes.core.helm:
+        name: "{{ dsc_name }}"
+        release_namespace: "{{ dsc.argocd.namespace }}"
+        release_state: absent
+        wait: true
+      tags:
+        - argocd
+        - argo
+        - gitops
+
     - name: "Suppression du namespace ArgoCD"
       kubernetes.core.k8s:
         state: absent
         kind: Namespace
         name: "{{ dsc.argocd.namespace }}"
+      tags:
+        - argocd
+        - argo
+        - gitops
+
+    - name: "Suppression Argo CD OpenShift scc crb"
+      kubernetes.core.k8s:
+        state: absent
+        kind: ClusterRoleBinding
+        name: "{{ dsc_name }}-argocd-system:openshift:scc:privileged"
+        api_version: rbac.authorization.k8s.io/v1
       tags:
         - argocd
         - argo


### PR DESCRIPTION
To permit dual installation without impacting cluster roles

## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Installe Argo CD avec un nom de release fixe (argo).
Ceci ne permet pas une "dual install" propre d'Argo CD dans le même cluster, car il faut pouvoir renommer les ClusterRoles et CRBs associés dont le nom est fonction de celui de la release.

Par ailleurs, la désinstallation d'Argo CD n'est pas pleinement fonctionnelle, car elle ne désinstalle pas les ClusterRoles et CRBs associés.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Une "dual install" d'Argo CD dans un même cluster est maintenant fonctionnelle.
La désinstallation l'est également.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Oui.

Le changement de nom de release nécessite une migration de notre instance d'Argo CD.
Voir ci-dessous pour la procédure.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.

## Procédure de migration

Pour un instance d'Argo CD déployée avec une version antérieure du Socle.

### Backup projects and apps
```
mkdir -p ./backup/argocd/projects ./backup/argocd/apps
```
```
for p in $(kubectl -n dso-argocd get appproject --no-headers -o name); do kubectl -n dso-argocd get $p -o yaml > ./backup/argocd/projects/${p#*/}.yaml; done
```
```
for a in $(kubectl -n dso-argocd get app --no-headers -o name); do kubectl -n dso-argocd get $a -o yaml > ./backup/argocd/apps/${a#*/}.yaml; done
```

### Uninstall old chart
```
helm -n dso-argocd uninstall argo
```

### Install new chart
```
ansible-playbook install.yaml -t argocd
```

Si les projets et applications Argocd doivent être restaurées, il est possible de nettoyer les annotations, etc à l'aide de kubectl-neat avant de restaurer.

Installer Krew : https://krew.sigs.k8s.io/docs/user-guide/setup/install/

Puis installer kubectl-neat :
```
kubectl krew install neat
```

Les commandes pour restaurer les projets et applications seront alors les suivantes :
```
for p in $(ls ./backup/argocd/projects); do cat "./backup/argocd/projects/$p" | kubectl neat | kubectl apply -f -; done
```
```
for a in $(ls ./backup/argocd/apps); do cat "./backup/argocd/apps/$a" | kubectl neat | kubectl apply -f -; done
```
