### PR TITLE
fix: :art: Fix Gitaly dashboard to prevent deprecation

### DIFF
--- a/roles/grafana-dashboards/templates/gitlab-gitaly-dashboard.yaml.j2
+++ b/roles/grafana-dashboards/templates/gitlab-gitaly-dashboard.yaml.j2
@@ -72,9 +72,6 @@ spec:
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
           "percentage": false,
           "pluginVersion": "9.5.5",
           "pointradius": 5,
@@ -106,7 +103,7 @@ spec:
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "mode": "time",
             "show": true,
@@ -237,9 +234,6 @@ spec:
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
           "percentage": false,
           "pluginVersion": "9.5.5",
           "pointradius": 5,
@@ -281,7 +275,7 @@ spec:
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "mode": "time",
             "show": true,
@@ -419,9 +413,6 @@ spec:
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
           "percentage": false,
           "pluginVersion": "9.5.5",
           "pointradius": 5,
@@ -463,7 +454,7 @@ spec:
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "mode": "time",
             "show": true,
@@ -518,9 +509,6 @@ spec:
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
           "percentage": false,
           "pluginVersion": "9.5.5",
           "pointradius": 5,
@@ -552,7 +540,7 @@ spec:
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "mode": "time",
             "show": true,


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Le dashboard grafana de GitLab Gitaly utilise le plugin graph ainsi qu'une option d'alerting qui sont tous les deux dépréciés.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Déploiement d'une version corrigée du dashboard, qui utilise le plugin timeseries en remplacement de graph, et supprime l'option d'alerting dépréciée.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.