### PR TITLE
Fix/gitlab ci pipelines dashboard

### DIFF
--- a/roles/grafana-dashboards/templates/gitlab-ci-pipelines-dashboard.yaml.j2
+++ b/roles/grafana-dashboards/templates/gitlab-ci-pipelines-dashboard.yaml.j2
@@ -739,9 +739,6 @@ spec:
           "lines": false,
           "linewidth": 1,
           "nullPointMode": "null as zero",
-          "options": {
-            "alertThreshold": false
-          },
           "percentage": false,
           "pluginVersion": "7.3.1",
           "pointradius": 2,
@@ -761,7 +758,6 @@ spec:
               "refId": "A"
             }
           ],
-          "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
@@ -771,7 +767,7 @@ spec:
             "sort": 0,
             "value_type": "individual"
           },
-          "type": "graph",
+          "type": "timeseries",
           "xaxis": {
             "buckets": null,
             "mode": "time",


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Le dashboard grafana de GitLab CI Pipelines utilise le plugin graph ainsi qu'une option d'alerting qui sont tous les deux dépréciés.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Déploiement d'une version corrigée du dashboard, qui utilise le plugin timeseries en remplacement de graph, et supprime l'option d'alerting dépréciée.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.