### PR TITLE
Fix/get versions

### DIFF
--- a/admin-tools/get-versions.yaml
+++ b/admin-tools/get-versions.yaml
@@ -136,8 +136,20 @@
             namespace: cert-manager
           register: cert_manager_infos
 
+        - name: Warning message
+          when: >
+            cm_ns.resources | length > 0 and
+            cert_manager_infos.status is not defined
+          ansible.builtin.debug:
+            msg:
+              - "Cert-manager n'est pas installé en tant que chart Helm dans le namespace {{ dsc.kyverno.namespace }}."
+              - "Cela signifie notamment qu'il n'a pas été installé via les roles du Socle."
+              - "Nous ne pouvons en déterminer la version de manière fiable."
+
         - name: Display cert-manager version
-          when: cm_ns.resources | length > 0
+          when: >
+            cm_ns.resources | length > 0 and
+            cert_manager_infos.status is defined
           ansible.builtin.debug:
             msg:
               - "Version de cert-manager : {{ cert_manager_infos.status.app_version }}"
@@ -211,8 +223,20 @@
             namespace: "{{ dsc.cloudnativepg.namespace }}"
           register: cnpg_infos
 
+        - name: Warning message
+          when: >
+            cnpg_ns.resources | length > 0 and
+            cnpg_infos.status is not defined
+          ansible.builtin.debug:
+            msg:
+              - "L'opérateur CNPG n'est pas installé en tant que chart Helm dans le namespace {{ dsc.kyverno.namespace }}."
+              - "Cela signifie notamment qu'il n'a pas été installé via les roles du Socle."
+              - "Nous ne pouvons en déterminer la version de manière fiable."
+
         - name: Display CNPG Operator version
-          when: cnpg_ns.resources | length > 0
+          when: >
+            cnpg_ns.resources | length > 0 and
+            cnpg_infos.status is defined
           ansible.builtin.debug:
             msg:
               - "Version de l'opérateur CNPG : {{ cnpg_infos.status.app_version }}"
@@ -514,8 +538,20 @@
             namespace: "{{ dsc.grafanaOperator.namespace }}"
           register: gop_infos
 
+        - name: Warning message
+          when: >
+            gop_ns.resources | length > 0 and
+            gop_infos.status is not defined
+          ansible.builtin.debug:
+            msg:
+              - "L'opérateur Grafana n'est pas installé en tant que chart Helm dans le namespace {{ dsc.kyverno.namespace }}."
+              - "Cela signifie notamment qu'il n'a pas été installé via les roles du Socle."
+              - "Nous ne pouvons en déterminer la version de manière fiable."
+
         - name: Display Grafana Operator version
-          when: gop_ns.resources | length > 0
+          when: >
+            gop_ns.resources | length > 0 and
+            gop_infos.status is defined
           ansible.builtin.debug:
             msg:
               - "Version de l'opérateur Grafana : {{ gop_infos.status.app_version }}"

--- a/admin-tools/get-versions.yaml
+++ b/admin-tools/get-versions.yaml
@@ -50,6 +50,8 @@
 
     - name: Check socle_config_custom and exit if empty
       when: (dsc_cr is defined) and (socle_config_custom.resources | length == 0)
+      tags:
+        - always
       block:
         - name: Warning message
           ansible.builtin.debug:
@@ -71,8 +73,6 @@
 
         - name: Exit playbook
           ansible.builtin.meta: end_play
-      tags:
-        - always
 
     - name: Set socle_config fact when dsc_cr defined and not empty
       ansible.builtin.set_fact:
@@ -93,18 +93,21 @@
       tags:
         - always
 
-    - ansible.builtin.set_fact:
+    - name: Set facts
+      ansible.builtin.set_fact:
         dsc_default_config: "{{ lookup('ansible.builtin.file', '../roles/socle-config/files/config.yaml') | from_yaml }}"
         dsc_default_releases: "{{ lookup('ansible.builtin.file', '../roles/socle-config/files/releases.yaml') | from_yaml }}"
       tags:
         - always
 
-    - ansible.builtin.set_fact:
+    - name: Set dsc fact
+      ansible.builtin.set_fact:
         dsc: "{{ dsc_default_releases | combine(dsc_default_config, recursive=True) | combine(dsc, recursive=True) }}"
       tags:
         - always
 
-    - ansible.builtin.set_fact:
+    - name: Adjust dsc fact
+      ansible.builtin.set_fact:
         dsc: "{{ dsc.spec }}"
       tags:
         - always
@@ -161,11 +164,23 @@
           when: kyverno_ns.resources | length > 0
           kubernetes.core.helm_info:
             name: kyverno
-            namespace: "{{ dsc.kyverno.namespace  }}"
+            namespace: "{{ dsc.kyverno.namespace }}"
           register: kyverno_infos
 
+        - name: Warning message
+          when: >
+            kyverno_ns.resources | length > 0 and
+            kyverno_infos.status is not defined
+          ansible.builtin.debug:
+            msg:
+              - "Kyverno n'est pas installé en tant que chart Helm dans le namespace {{ dsc.kyverno.namespace }}."
+              - "Cela signifie notamment qu'il n'a pas été installé via les roles du Socle."
+              - "Nous ne pouvons en déterminer la version de manière fiable."
+
         - name: Display Kyverno version
-          when: kyverno_ns.resources | length > 0
+          when: >
+            kyverno_ns.resources | length > 0 and
+            kyverno_infos.status is defined
           ansible.builtin.debug:
             msg:
               - "Version de Kyverno : {{ kyverno_infos.status.app_version }}"
@@ -193,7 +208,7 @@
           when: cnpg_ns.resources | length > 0
           kubernetes.core.helm_info:
             name: cloudnative-pg
-            namespace: "{{ dsc.cloudnativepg.namespace  }}"
+            namespace: "{{ dsc.cloudnativepg.namespace }}"
           register: cnpg_infos
 
         - name: Display CNPG Operator version
@@ -210,7 +225,7 @@
         - name: Retrieve Keycloak infos
           kubernetes.core.helm_info:
             name: keycloak
-            namespace: "{{ dsc.keycloak.namespace  }}"
+            namespace: "{{ dsc.keycloak.namespace }}"
           register: keycloak_infos
 
         - name: Display Keycloak version
@@ -248,7 +263,7 @@
         - name: Retrieve SonarQube infos
           kubernetes.core.helm_info:
             name: sonarqube
-            namespace: "{{ dsc.sonarqube.namespace  }}"
+            namespace: "{{ dsc.sonarqube.namespace }}"
           register: sonarqube_infos
 
         - name: Display SonarQube version
@@ -307,7 +322,7 @@
         - name: Retrieve gitlab-ci-pipelines-exporter infos
           kubernetes.core.helm_info:
             name: gitlab-ci-pipelines-exporter
-            namespace: "{{ dsc.gitlab.namespace  }}"
+            namespace: "{{ dsc.gitlab.namespace }}"
           register: gcipe_infos
 
         - name: Warning message
@@ -330,7 +345,7 @@
         - name: Retrieve gitlab-operator infos
           kubernetes.core.helm_info:
             name: gitlab-operator
-            namespace: "{{ dsc.gitlabOperator.namespace  }}"
+            namespace: "{{ dsc.gitlabOperator.namespace }}"
           register: gop_infos
 
         - name: Display gitlab-operator version
@@ -347,7 +362,7 @@
         - name: Retrieve gitlab-runner infos
           kubernetes.core.helm_info:
             name: gitlab-runner
-            namespace: "{{ dsc.gitlab.namespace  }}"
+            namespace: "{{ dsc.gitlab.namespace }}"
           register: grunner_infos
 
         - name: Display gitlab-runner version
@@ -363,7 +378,7 @@
         - name: Retrieve Vault infos
           kubernetes.core.helm_info:
             name: "{{ dsc_name }}-vault"
-            namespace: "{{ dsc.vault.namespace  }}"
+            namespace: "{{ dsc.vault.namespace }}"
           register: vault_infos
 
         - name: Display Vault version
@@ -379,8 +394,8 @@
       block:
         - name: Retrieve Argo CD infos
           kubernetes.core.helm_info:
-            name: "argo"
-            namespace: "{{ dsc.argocd.namespace  }}"
+            name: "{{ dsc_name }}"
+            namespace: "{{ dsc.argocd.namespace }}"
           register: argocd_infos
 
         - name: Display Argo CD version
@@ -396,7 +411,7 @@
         - name: Retrieve Harbor infos
           kubernetes.core.helm_info:
             name: "harbor"
-            namespace: "{{ dsc.harbor.namespace  }}"
+            namespace: "{{ dsc.harbor.namespace }}"
           register: harbor_infos
 
         - name: Display Harbor version
@@ -496,7 +511,7 @@
           when: gop_ns.resources | length > 0
           kubernetes.core.helm_info:
             name: grafana-operator
-            namespace: "{{ dsc.grafanaOperator.namespace  }}"
+            namespace: "{{ dsc.grafanaOperator.namespace }}"
           register: gop_infos
 
         - name: Display Grafana Operator version


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Le playbook d'administration admin-tools/get-versions.yaml n'est pas pleinement fonctionnel lorsque nous n'installons pas Cert-manager, Kyverno et les opérateurs CNPG ou Grafana.
En effet, il s'appuie sur le fait que ces éléments sont installés via un chart Helm, ce qui n'est pas nécessairement le cas lorsqu'ils n'ont pas été installés par le Socle.
Le playbook doit aussi être adapté aux évolutions récentes du role argocd. 

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Corrections du playbook pour traiter les outils problématiques.
Nous vérifions s'ils sont installés via Helm avant de tenter d'en obtenir les numéros de versions. Un avertissement est affiché à la place si le namespace de l'élément en question existe mais qu'il n'a pas été installé par Helm. En effet, nous ne pouvons dans ce cas vérifier de manière fiable la version de l'outil installé. Il pourrait par exemple avoir été installé via une registry privée, avec un tag d'image non conventionnel.
La partie Argo CD a également été adaptée, puisque la release est désormais nommée en fonction du nom de la dsc.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans des clusters de développement et de production.

Éléments signalés pas ansible-lint également corrigés à cette occasion.