### PR TITLE
fix: :wrench: add .conf-dso-vault-internal in no_proxy

### DIFF
--- a/roles/vault/templates/values/10-proxy.j2
+++ b/roles/vault/templates/values/10-proxy.j2
@@ -3,5 +3,5 @@ server:
   extraEnvironmentVars:
     HTTP_PROXY: "{{ dsc.proxy.http_proxy }}"
     HTTPS_PROXY: "{{ dsc.proxy.https_proxy }}"
-    NO_PROXY: "{{ dsc.proxy.no_proxy }}"
+    NO_PROXY: "{{ dsc.proxy.no_proxy }},.{{ dsc_name }}-vault-internal"
 {% endif %}


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Les tasks de mise en place du OIDC vault dans le `post-install.yml` font des curl sur `VAULT_CLUSTER_ADDR=https://<pod name>.conf-dso-vault-internal:8201`.  
En cas d'utilisation de proxy dans le cluster, il est actuellement possible de rajouter `.conf-dso-vault-internal` dans `proxy.no_proxy` de la dsc.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Ajout de  `.conf-dso-vault-internal` dans `roles/vault/templates/values/10-proxy.j2` pour éviter à l'utilisateur de chercher la réponse à une solution connue (comme ce qui est fait pour Harbor et Argocd).

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Non.
