### PR TITLE
fix: :wrench: add default dictionary values for certmanager

### DIFF
--- a/roles/socle-config/files/cr-conf-dso-default.yaml
+++ b/roles/socle-config/files/cr-conf-dso-default.yaml
@@ -35,7 +35,8 @@ spec:
     admin:
       enabled: false
   #    password: WeAreThePasswords
-  certmanager: {}
+  certmanager:
+    values: {}
   cloudnativepg: {}
   console:
     cnpg:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Depuis https://github.com/cloud-pi-native/socle/commit/5abc8d4dbcef715b1d0a821b8d448a2992b58e3f, les values de templating sont prises en compte et il est possible de rencontrer cette erreur sur l'appel du role Combine : 
```
TASK [combine : Combine with user supplied values] ***************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "failed to combine variables, expected dicts but got a 'dict' and a 'AnsibleUnsafeText': \n{...}
```
Cela survient si la configuration dsc est comme suit :
```
certmanager: {}
```
Le problème ne survient pas avec 
```
certmanager:
  values: {}
```

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Le problème aura toujours lieu si le user ne configure pas correctement la dsc, mais au moins il aura un exemple :)

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Non.