### PR TITLE
fix: :bug: Fix certmanager install failure when values are empty

### DIFF
--- a/roles/socle-config/files/config.yaml
+++ b/roles/socle-config/files/config.yaml
@@ -13,6 +13,7 @@ spec:
   certmanager:
     helmRepoUrl: https://charts.jetstack.io
     forcedInstall: false
+    values: {}
   cloudnativepg:
     namespace: dso-cloudnativepg
     helmRepoUrl: https://cloudnative-pg.github.io/charts

--- a/roles/socle-config/files/cr-conf-dso-default.yaml
+++ b/roles/socle-config/files/cr-conf-dso-default.yaml
@@ -35,8 +35,7 @@ spec:
     admin:
       enabled: false
   #    password: WeAreThePasswords
-  certmanager:
-    values: {}
+  certmanager: {}
   cloudnativepg: {}
   console:
     cnpg:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

L'installation de cert-manager échoue car le paramètre "spec.certmanager.values" est absent de la dsc.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

L'installation de certmanager est à nouveau fonctionnelle.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.

Le bug d'installation, qui faisait échouer le role combine, était lié à l'absence de "values: {}" pour certmanager dans le fichier "socle-config/files/config.yaml".
