### PR TITLE
fix: :bug: postgresWalPvcSize definition check

### DIFF
--- a/roles/console-dso/templates/values/00-main.j2
+++ b/roles/console-dso/templates/values/00-main.j2
@@ -34,7 +34,7 @@ cnpg:
   dbName: dso-console-db
   mode: "{{ dsc.console.cnpg.mode }}"
   pvcSize: "{{ dsc.console.postgresPvcSize }}"
-{% if dsc.console.postgresWalPvcSize %}
+{% if dsc.console.postgresWalPvcSize is defined %}
   walPvcSize: "{{ dsc.console.postgresWalPvcSize }}"
 {% endif %}
 {% if dsc.global.backup.velero.enabled %}

--- a/roles/gitlab/templates/pg-cluster-gitlab.yaml.j2
+++ b/roles/gitlab/templates/pg-cluster-gitlab.yaml.j2
@@ -86,7 +86,7 @@ spec:
   # Require 1Gi of space per instance using default storage class
   storage:
     size: {{ dsc.gitlab.postgresPvcSize }}
-{% if dsc.gitlab.postgresWalPvcSize %}
+{% if dsc.gitlab.postgresWalPvcSize is defined %}
   walStorage:
     size: {{ dsc.gitlab.postgresWalPvcSize }}
 {% endif %}

--- a/roles/harbor/templates/pg-cluster-harbor.yaml.j2
+++ b/roles/harbor/templates/pg-cluster-harbor.yaml.j2
@@ -86,7 +86,7 @@ spec:
   # Require 1Gi of space per instance using default storage class
   storage:
     size: {{ dsc.harbor.postgresPvcSize }}
-{% if dsc.harbor.postgresWalPvcSize %}
+{% if dsc.harbor.postgresWalPvcSize is defined %}
   walStorage:
     size: {{ dsc.harbor.postgresWalPvcSize }}
 {% endif %}

--- a/roles/keycloak/templates/pg-cluster-keycloak.yaml.j2
+++ b/roles/keycloak/templates/pg-cluster-keycloak.yaml.j2
@@ -86,7 +86,7 @@ spec:
   # Require 1Gi of space per instance using default storage class
   storage:
     size: {{ dsc.keycloak.postgresPvcSize }}
-{% if dsc.keycloak.postgresWalPvcSize %}
+{% if dsc.keycloak.postgresWalPvcSize is defined %}
   walStorage:
     size: {{ dsc.keycloak.postgresWalPvcSize }}
 {% endif %}

--- a/roles/sonarqube/templates/pg-cluster-sonar.yaml.j2
+++ b/roles/sonarqube/templates/pg-cluster-sonar.yaml.j2
@@ -86,7 +86,7 @@ spec:
   # Require 1Gi of space per instance using default storage class
   storage:
     size: {{ dsc.sonarqube.postgresPvcSize }}
-{% if dsc.sonarqube.postgresWalPvcSize %}
+{% if dsc.sonarqube.postgresWalPvcSize is defined %}
   walStorage:
     size: {{ dsc.sonarqube.postgresWalPvcSize }}
 {% endif %}


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Les tâches de creation de clusters CNPG échouent si "dsc.keycloak.postgresWalPvcSize" n'est pas définie.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Les tâches de creation de clusters CNPG s'exécutent comme attendu.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.

Le problème était lié à une condition if incomplete dans les templates de clusters CNPG.
