### PR TITLE
fix: :wrench: add kube-apiserver clusterIP in no_proxy

### DIFF
--- a/roles/console-dso/tasks/main.yaml
+++ b/roles/console-dso/tasks/main.yaml
@@ -110,6 +110,14 @@
     name: pg-cluster-console-app
   register: pg_db_secret
 
+- name: Get kubernetes service
+  kubernetes.core.k8s_info:
+    namespace: default
+    kind: Service
+    name: kubernetes
+  register: kubernetes_service_clusterip
+  when: dsc.proxy.enabled
+
 - name: Compute Console Helm values
   ansible.builtin.include_role:
     name: combine

--- a/roles/console-dso/templates/values/10-proxy.j2
+++ b/roles/console-dso/templates/values/10-proxy.j2
@@ -1,10 +1,10 @@
-{% if dsc.proxy.enabled and dsc.global.offline != true %}
+{% if dsc.proxy.enabled %}
 global:
   env:
     HTTP_PROXY: {{ dsc.proxy.http_proxy }}
     HTTPS_PROXY: {{ dsc.proxy.https_proxy }}
-    NO_PROXY: {{ dsc.proxy.no_proxy }}
+    NO_PROXY: {{ dsc.proxy.no_proxy }},{{ kubernetes_service_clusterip | from_yaml | json_query('resources[0].spec.clusterIP')}}
     http_proxy: {{ dsc.proxy.http_proxy }}
     https_proxy: {{ dsc.proxy.https_proxy }}
-    no_proxy: {{ dsc.proxy.no_proxy }}
+    no_proxy: {{ dsc.proxy.no_proxy }},{{ kubernetes_service_clusterip | from_yaml | json_query('resources[0].spec.clusterIP')}}
 {% endif %}


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Avec l'utilisation des proxies, cette erreur survient lors de la création d'un nouveau projet sur la console, et également lors du reprovisionnement :
```
  "err": {
    "type": "Error",
    "message": "tunneling socket could not be established, statusCode=503",
    "stack": "Error: tunneling socket could not be established, statusCode=503\n    at ClientRequest.onConnect (/app/node_modules/.pnpm/tunnel-agent@0.6.0/node_modules/tunnel-agent/index.js:166:19)\n    at Object.onceWrapper (node:events:633:26)\n    at ClientRequest.emit (node:events:518:28)\n    at Socket.socketOnData (node:_http_client:580:11)\n    at Socket.emit (node:events:518:28)\n    at addChunk (node:internal/streams/readable:559:12)\n    at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)\n    at Readable.push (node:internal/streams/readable:390:5)\n    at TCP.onStreamRead (node:internal/stream_base_commons:190:23)",
    "code": "ECONNRESET"
  },
  "msg": "tunneling socket could not be established, statusCode=503"
```

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Il s'agissait du plugin Kubernetes qui n'était pas joignable en passant par le proxy. Le `getCustomK8sApi` par défaut, essaye de joindre le `kube-apiserver` en utilisant les variables d’environnement de découverte de service fournies par Kubernetes, plus précisément celles préfixées avec `KUBERNETES_`. Il fallait donc spécifier le `spec.clusterIP` du service Kubernetes dans le no_proxy.


## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Non.