### PR TITLE
feat: :zap: Add postgresWalMaxSlotKeepSize parameter

### DIFF
--- a/roles/gitlab/templates/pg-cluster-gitlab.yaml.j2
+++ b/roles/gitlab/templates/pg-cluster-gitlab.yaml.j2
@@ -25,6 +25,9 @@ spec:
   postgresql:
     parameters:
       max_worker_processes: "60"
+{% if dsc.gitlab.postgresWalMaxSlotKeepSize is defined %}
+      max_slot_wal_keep_size: {{ dsc.gitlab.postgresWalMaxSlotKeepSize }}
+{% endif %}
 {% if dsc.gitlab.cnpg.mode == "primary" %}
     pg_hba:
       # To access through TCP/IP you will need to get username

--- a/roles/harbor/templates/pg-cluster-harbor.yaml.j2
+++ b/roles/harbor/templates/pg-cluster-harbor.yaml.j2
@@ -25,6 +25,9 @@ spec:
   postgresql:
     parameters:
       max_worker_processes: "60"
+{% if dsc.harbor.postgresWalMaxSlotKeepSize is defined %}
+      max_slot_wal_keep_size: {{ dsc.harbor.postgresWalMaxSlotKeepSize }}
+{% endif %}
 {% if dsc.harbor.cnpg.mode == "primary" %}
     pg_hba:
       # To access through TCP/IP you will need to get username

--- a/roles/keycloak/templates/pg-cluster-keycloak.yaml.j2
+++ b/roles/keycloak/templates/pg-cluster-keycloak.yaml.j2
@@ -25,6 +25,9 @@ spec:
   postgresql:
     parameters:
       max_worker_processes: "60"
+{% if dsc.keycloak.postgresWalMaxSlotKeepSize is defined %}
+      max_slot_wal_keep_size: {{ dsc.keycloak.postgresWalMaxSlotKeepSize }}
+{% endif %}
 {% if dsc.keycloak.cnpg.mode == "primary" %}
     pg_hba:
       # To access through TCP/IP you will need to get username

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -219,6 +219,14 @@ spec:
                       description: Size for postgres data pvc.
                       type: string
                       default: 10Gi
+                    postgresWalMaxSlotKeepSize:
+                      description: |
+                        Maximum size of WAL files that replication slots are allowed to retain in the pg_wal directory at checkpoint time.
+                        Default is -1, meaning that replication slots may retain an unlimited amount of WAL files.
+                        You can for instance set it to "9GB".
+                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        Refer to postgresql.conf for memory units.
+                      type: string
                     postgresWalPvcSize:
                       description: Size for postgres wal pvc (if value is not set then WAL files are stored within the data PVC).
                       type: string
@@ -301,6 +309,14 @@ spec:
                       description: Size for postgres data pvc.
                       type: string
                       default: 10Gi
+                    postgresWalMaxSlotKeepSize:
+                      description: |
+                        Maximum size of WAL files that replication slots are allowed to retain in the pg_wal directory at checkpoint time.
+                        Default is -1, meaning that replication slots may retain an unlimited amount of WAL files.
+                        You can for instance set it to "9GB".
+                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        Refer to postgresql.conf for memory units.
+                      type: string
                     postgresWalPvcSize:
                       description: Size for postgres wal pvc (if value is not set then WAL files are stored within the data PVC).
                       type: string
@@ -763,6 +779,14 @@ spec:
                       description: Size for postgres data pvc.
                       type: string
                       default: 10Gi
+                    postgresWalMaxSlotKeepSize:
+                      description: |
+                        Maximum size of WAL files that replication slots are allowed to retain in the pg_wal directory at checkpoint time.
+                        Default is -1, meaning that replication slots may retain an unlimited amount of WAL files.
+                        You can for instance set it to "9GB".
+                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        Refer to postgresql.conf for memory units.
+                      type: string
                     postgresWalPvcSize:
                       description: Size for postgres wal pvc (if value is not set then WAL files are stored within the data PVC).
                       type: string
@@ -899,6 +923,14 @@ spec:
                       description: Size for postgres data pvc.
                       type: string
                       default: 10Gi
+                    postgresWalMaxSlotKeepSize:
+                      description: |
+                        Maximum size of WAL files that replication slots are allowed to retain in the pg_wal directory at checkpoint time.
+                        Default is -1, meaning that replication slots may retain an unlimited amount of WAL files.
+                        You can for instance set it to "9GB".
+                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        Refer to postgresql.conf for memory units.
+                      type: string
                     postgresWalPvcSize:
                       description: Size for postgres wal pvc (if value is not set then WAL files are stored within the data PVC).
                       type: string
@@ -1041,6 +1073,14 @@ spec:
                       description: Size for postgres data pvc.
                       type: string
                       default: 10Gi
+                    postgresWalMaxSlotKeepSize:
+                      description: |
+                        Maximum size of WAL files that replication slots are allowed to retain in the pg_wal directory at checkpoint time.
+                        Default is -1, meaning that replication slots may retain an unlimited amount of WAL files.
+                        You can for instance set it to "9GB".
+                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        Refer to postgresql.conf for memory units.
+                      type: string
                     postgresWalPvcSize:
                       description: Size for postgres wal pvc (if value is not set then WAL files are stored within the data PVC).
                       type: string

--- a/roles/sonarqube/templates/pg-cluster-sonar.yaml.j2
+++ b/roles/sonarqube/templates/pg-cluster-sonar.yaml.j2
@@ -25,6 +25,9 @@ spec:
   postgresql:
     parameters:
       max_worker_processes: "60"
+{% if dsc.sonarqube.postgresWalMaxSlotKeepSize is defined %}
+      max_slot_wal_keep_size: {{ dsc.sonarqube.postgresWalMaxSlotKeepSize }}
+{% endif %}
 {% if dsc.sonarqube.cnpg.mode == "primary" %}
     pg_hba:
       # To access through TCP/IP you will need to get username


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Les clusters CNPG sont déployés sans fixer de limite à l'espace disque occupé par les fichiers WAL lorsque la réplication est activée (comportement par défaut).
Il en résulte une saturation d'espace disque au bout d'un temps variable.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous introduisons dans la dsc le paramètre "postgresWalMaxSlotKeepSize" pour chaque outil disposant d'un cluster CNPG.
Ce paramètre correspond à "max_slot_wal_keep_size" dans la configuration du cluster CNPG.
Lui fixer une valeur adéquate, inférieure à la taille du PVC, permet d'éviter le problème de saturation d'espace disque rencontré.
La documentation officielle sur le sujet est disponible ici :
https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Changement effectué et vérifié dans un cluster de développement.

Fonctionnera d'autant mieux que nous aurons attribué un PVC dédié aux fichiers WAL via le paramètre "postgresWalPvcSize" de la dsc.
