### PR TITLE
feat: :sparkles: Improve PVC alerting

### DIFF
--- a/observability/files/rules/metrics/console-alerts.yaml.tpl
+++ b/observability/files/rules/metrics/console-alerts.yaml.tpl
@@ -61,6 +61,21 @@ groups:
         for: 5m
         labels:
           severity: warning
+      - alert: DSO Console PVC has low remaining disk space
+        annotations:
+          message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is running out of disk space (< 20% left). VALUE = {{`{{`}} $value {{`}}`}}%
+          summary: DSO Console PVC is running out of disk space in namespace {{`{{`}} $labels.namespace {{`}}`}}
+        expr: |
+          round(
+          kubelet_volume_stats_available_bytes{
+          persistentvolumeclaim=~"(.*-)*console(-.*)*",
+          namespace="{{ .Values.app.namespacePrefix }}console"}
+          / kubelet_volume_stats_capacity_bytes{
+          persistentvolumeclaim=~"(.*-)*console(-.*)*",
+          namespace="{{ .Values.app.namespacePrefix }}console"} * 100, 0.01) < 20 > 10
+        for: 1m
+        labels:
+          severity: warning
       - alert: DSO Console PVC almost out of disk space
         annotations:
           message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is almost full (< 10% left). VALUE = {{`{{`}} $value {{`}}`}}%
@@ -75,7 +90,7 @@ groups:
           namespace="{{ .Values.app.namespacePrefix }}console"} * 100, 0.01) < 10 > 0
         for: 1m
         labels:
-          severity: warning
+          severity: critical
       - alert: DSO Console PVC out of disk space
         annotations:
           message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is full (0% left).

--- a/observability/files/rules/metrics/gitlab-alerts.yaml.tpl
+++ b/observability/files/rules/metrics/gitlab-alerts.yaml.tpl
@@ -169,6 +169,21 @@ groups:
         for: 5m
         labels:
           severity: warning
+      - alert: GitLab PVC has low remaining disk space
+        annotations:
+          message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is running out of disk space (< 20% left). VALUE = {{`{{`}} $value {{`}}`}}%
+          summary: GitLab PVC is running out of disk space in namespace {{`{{`}} $labels.namespace {{`}}`}}
+        expr: |
+          round(
+          kubelet_volume_stats_available_bytes{
+          persistentvolumeclaim=~"(.*-)*gitlab(-.*)*",
+          namespace="{{ .Values.app.namespacePrefix }}gitlab"}
+          / kubelet_volume_stats_capacity_bytes{
+          persistentvolumeclaim=~"(.*-)*gitlab(-.*)*",
+          namespace="{{ .Values.app.namespacePrefix }}gitlab"} * 100, 0.01) < 20 > 10
+        for: 1m
+        labels:
+          severity: warning
       - alert: GitLab PVC almost out of disk space
         annotations:
           message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is almost full (< 10% left). VALUE = {{`{{`}} $value {{`}}`}}%
@@ -183,7 +198,7 @@ groups:
           namespace="{{ .Values.app.namespacePrefix }}gitlab"} * 100, 0.01) < 10 > 0
         for: 1m
         labels:
-          severity: warning
+          severity: critical
       - alert: GitLab PVC out of disk space
         annotations:
           message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is full (0% left).

--- a/observability/files/rules/metrics/harbor-alerts.yaml.tpl
+++ b/observability/files/rules/metrics/harbor-alerts.yaml.tpl
@@ -121,6 +121,21 @@ groups:
         for: 5m
         labels:
           severity: warning
+      - alert: Harbor PVC has low remaining disk space
+        annotations:
+          message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is running out of disk space (< 20% left). VALUE = {{`{{`}} $value {{`}}`}}%
+          summary: Harbor PVC is running out of disk space in namespace {{`{{`}} $labels.namespace {{`}}`}}
+        expr: |
+          round(
+          kubelet_volume_stats_available_bytes{
+          persistentvolumeclaim=~"(.*-)*harbor(-.*)*",
+          namespace="{{ .Values.app.namespacePrefix }}harbor"}
+          / kubelet_volume_stats_capacity_bytes{
+          persistentvolumeclaim=~"(.*-)*harbor(-.*)*",
+          namespace="{{ .Values.app.namespacePrefix }}harbor"} * 100, 0.01) < 20 > 10
+        for: 1m
+        labels:
+          severity: warning
       - alert: Harbor PVC almost out of disk space
         annotations:
           message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is almost full (< 10% left). VALUE = {{`{{`}} $value {{`}}`}}%
@@ -135,7 +150,7 @@ groups:
           namespace="{{ .Values.app.namespacePrefix }}harbor"} * 100, 0.01) < 10 > 0
         for: 1m
         labels:
-          severity: warning
+          severity: critical
       - alert: Harbor PVC out of disk space
         annotations:
           message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is full (0% left).

--- a/observability/files/rules/metrics/keycloak-alerts.yaml.tpl
+++ b/observability/files/rules/metrics/keycloak-alerts.yaml.tpl
@@ -54,6 +54,21 @@ groups:
         for: 5m
         labels:
           severity: warning
+      - alert: Keycloak DB PVC has low remaining disk space
+        annotations:
+          message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is running out of disk space (< 20% left). VALUE = {{`{{`}} $value {{`}}`}}%
+          summary: Keycloak CNPG PVC is running out of disk space in namespace {{`{{`}} $labels.namespace {{`}}`}}
+        expr: |
+          round(
+          kubelet_volume_stats_available_bytes{
+          persistentvolumeclaim=~"pg-cluster-keycloak-\\d+",
+          namespace="{{ .Values.app.namespacePrefix }}keycloak"}
+          / kubelet_volume_stats_capacity_bytes{
+          persistentvolumeclaim=~"pg-cluster-keycloak-\\d+",
+          namespace="{{ .Values.app.namespacePrefix }}keycloak"} * 100, 0.01) < 20 > 10
+        for: 1m
+        labels:
+          severity: warning
       - alert: Keycloak DB PVC almost out of disk space
         annotations:
           message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is almost full (< 10% left). VALUE = {{`{{`}} $value {{`}}`}}%
@@ -68,7 +83,7 @@ groups:
           namespace="{{ .Values.app.namespacePrefix }}keycloak"} * 100, 0.01) < 10 > 0
         for: 1m
         labels:
-          severity: warning
+          severity: critical
       - alert: Keycloak DB PVC out of disk space
         annotations:
           message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is full (0% left).

--- a/observability/files/rules/metrics/nexus-alerts.yaml.tpl
+++ b/observability/files/rules/metrics/nexus-alerts.yaml.tpl
@@ -17,6 +17,21 @@ groups:
         for: 5m
         labels:
           severity: critical
+      - alert: Nexus PVC has low remaining disk space
+        annotations:
+          message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is running out of disk space (< 20% left). VALUE = {{`{{`}} $value {{`}}`}}%
+          summary: Nexus PVC is running out of disk space in namespace {{`{{`}} $labels.namespace {{`}}`}}
+        expr: |
+          round(
+          kubelet_volume_stats_available_bytes{
+          persistentvolumeclaim=~"nexus-data-.*",
+          namespace="{{ .Values.app.namespacePrefix }}nexus"}
+          / kubelet_volume_stats_capacity_bytes{
+          persistentvolumeclaim=~"nexus-data-.*",
+          namespace="{{ .Values.app.namespacePrefix }}nexus"} * 100, 0.01) < 20 > 10
+        for: 1m
+        labels:
+          severity: warning
       - alert: Nexus PVC almost out of disk space
         annotations:
           message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is almost full (< 10% left). VALUE = {{`{{`}} $value {{`}}`}}%
@@ -31,7 +46,7 @@ groups:
           namespace="{{ .Values.app.namespacePrefix }}nexus"} * 100, 0.01) < 10 > 0
         for: 1m
         labels:
-          severity: warning
+          severity: critical
       - alert: Nexus PVC out of disk space
         annotations:
           message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is full (0% left).

--- a/observability/files/rules/metrics/sonarqube-alerts.yaml.tpl
+++ b/observability/files/rules/metrics/sonarqube-alerts.yaml.tpl
@@ -42,6 +42,21 @@ groups:
         for: 5m
         labels:
           severity: warning
+      - alert: SonarQube DB PVC has low remaining disk space
+        annotations:
+          message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is running out of disk space (< 20% left). VALUE = {{`{{`}} $value {{`}}`}}%
+          summary: SonarQube CNPG PVC is running out of disk space in namespace {{`{{`}} $labels.namespace {{`}}`}}
+        expr: |
+          round(
+          kubelet_volume_stats_available_bytes{
+          persistentvolumeclaim=~"pg-cluster-sonar-\\d+",
+          namespace="{{ .Values.app.namespacePrefix }}sonarqube"}
+          / kubelet_volume_stats_capacity_bytes{
+          persistentvolumeclaim=~"pg-cluster-sonar-\\d+",
+          namespace="{{ .Values.app.namespacePrefix }}sonarqube"} * 100, 0.01) < 20 > 10
+        for: 1m
+        labels:
+          severity: warning
       - alert: SonarQube DB PVC almost out of disk space
         annotations:
           message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is almost full (< 10% left). VALUE = {{`{{`}} $value {{`}}`}}%
@@ -56,7 +71,7 @@ groups:
           namespace="{{ .Values.app.namespacePrefix }}sonarqube"} * 100, 0.01) < 10 > 0
         for: 1m
         labels:
-          severity: warning
+          severity: critical
       - alert: SonarQube DB PVC out of disk space
         annotations:
           message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is full (0% left).

--- a/observability/files/rules/metrics/vault-alerts.yaml.tpl
+++ b/observability/files/rules/metrics/vault-alerts.yaml.tpl
@@ -62,6 +62,21 @@ groups:
         for: 5m
         labels:
           severity: warning
+      - alert: Vault PVC has low remaining disk space
+        annotations:
+          message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is running out of disk space (< 20% left). VALUE = {{`{{`}} $value {{`}}`}}%
+          summary: Vault PVC is running out of disk space in namespace {{`{{`}} $labels.namespace {{`}}`}}
+        expr: |
+          round(
+          kubelet_volume_stats_available_bytes{
+          persistentvolumeclaim=~"(.*-)*vault(-.*)*",
+          namespace="{{ .Values.app.namespacePrefix }}vault"}
+          / kubelet_volume_stats_capacity_bytes{
+          persistentvolumeclaim=~"(.*-)*vault(-.*)*",
+          namespace="{{ .Values.app.namespacePrefix }}vault"} * 100, 0.01) < 20 > 10
+        for: 1m
+        labels:
+          severity: warning
       - alert: Vault PVC almost out of disk space
         annotations:
           message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is almost full (< 10% left). VALUE = {{`{{`}} $value {{`}}`}}%
@@ -76,7 +91,7 @@ groups:
           namespace="{{ .Values.app.namespacePrefix }}vault"} * 100, 0.01) < 10 > 0
         for: 1m
         labels:
-          severity: warning
+          severity: critical
       - alert: Vault PVC out of disk space
         annotations:
           message: PVC {{`{{`}} $labels.persistentvolumeclaim {{`}}`}} in namespace {{`{{`}} $labels.namespace {{`}}`}} is full (0% left).

--- a/roles/console-dso/templates/prometheusrule.yml.j2
+++ b/roles/console-dso/templates/prometheusrule.yml.j2
@@ -69,6 +69,21 @@ spec:
       for: 5m
       labels:
         severity: warning
+    - alert: DSO Console PVC has low remaining disk space
+      annotations:
+        message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{"{{"}} $labels.namespace {{"}}"}} is running out of disk space (< 20% left). VALUE = {{"{{"}} $value {{"}}"}}%
+        summary: DSO Console PVC is running out of disk space in namespace {{"{{"}} $labels.namespace {{"}}"}}
+      expr: |
+        round(
+        kubelet_volume_stats_available_bytes{
+        persistentvolumeclaim=~"(.*-)*console(-.*)*",
+        namespace="{{ dsc.console.namespace }}"}
+        / kubelet_volume_stats_capacity_bytes{
+        persistentvolumeclaim=~"(.*-)*console(-.*)*",
+        namespace="{{ dsc.console.namespace }}"} * 100, 0.01) < 20 > 10
+      for: 1m
+      labels:
+        severity: warning
     - alert: DSO Console PVC almost out of disk space
       annotations:
         message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{ dsc.console.namespace }} is almost full (< 10% left). VALUE = {{"{{"}} $value {{"}}"}}%
@@ -83,7 +98,7 @@ spec:
         namespace="{{ dsc.console.namespace }}"} * 100, 0.01) < 10 > 0
       for: 1m
       labels:
-        severity: warning
+        severity: critical
     - alert: DSO Console PVC out of disk space
       annotations:
         message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{ dsc.console.namespace }} is full (0% left).

--- a/roles/gitlab/templates/prometheusrule.yml.j2
+++ b/roles/gitlab/templates/prometheusrule.yml.j2
@@ -177,6 +177,21 @@ spec:
       for: 5m
       labels:
         severity: warning
+    - alert: GitLab PVC has low remaining disk space
+      annotations:
+        message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{"{{"}} $labels.namespace {{"}}"}} is running out of disk space (< 20% left). VALUE = {{"{{"}} $value {{"}}"}}%
+        summary: GitLab PVC is running out of disk space in namespace {{"{{"}} $labels.namespace {{"}}"}}
+      expr: |
+        round(
+        kubelet_volume_stats_available_bytes{
+        persistentvolumeclaim=~"(.*-)*gitlab(-.*)*",
+        namespace="{{ dsc.gitlab.namespace }}"}
+        / kubelet_volume_stats_capacity_bytes{
+        persistentvolumeclaim=~"(.*-)*gitlab(-.*)*",
+        namespace="{{ dsc.gitlab.namespace }}"} * 100, 0.01) < 20 > 10
+      for: 1m
+      labels:
+        severity: warning
     - alert: GitLab PVC almost out of disk space
       annotations:
         message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{ dsc.gitlab.namespace }} is almost full (< 10% left). VALUE = {{"{{"}} $value {{"}}"}}%
@@ -191,7 +206,7 @@ spec:
         namespace="{{ dsc.gitlab.namespace }}"} * 100, 0.01) < 10 > 0
       for: 1m
       labels:
-        severity: warning
+        severity: critical
     - alert: GitLab PVC out of disk space
       annotations:
         message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{ dsc.gitlab.namespace }} is full (0% left).

--- a/roles/harbor/templates/prometheusrule.yml.j2
+++ b/roles/harbor/templates/prometheusrule.yml.j2
@@ -129,6 +129,21 @@ spec:
       for: 5m
       labels:
         severity: warning
+    - alert: Harbor PVC has low remaining disk space
+      annotations:
+        message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{"{{"}} $labels.namespace {{"}}"}} is running out of disk space (< 20% left). VALUE = {{"{{"}} $value {{"}}"}}%
+        summary: Harbor PVC is running out of disk space in namespace {{"{{"}} $labels.namespace {{"}}"}}
+      expr: |
+        round(
+        kubelet_volume_stats_available_bytes{
+        persistentvolumeclaim=~"(.*-)*harbor(-.*)*",
+        namespace="{{ dsc.harbor.namespace }}"}
+        / kubelet_volume_stats_capacity_bytes{
+        persistentvolumeclaim=~"(.*-)*harbor(-.*)*",
+        namespace="{{ dsc.harbor.namespace }}"} * 100, 0.01) < 20 > 10
+      for: 1m
+      labels:
+        severity: warning
     - alert: Harbor PVC almost out of disk space
       annotations:
         message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{ dsc.harbor.namespace }} is almost full (< 10% left). VALUE = {{"{{"}} $value {{"}}"}}%
@@ -143,7 +158,7 @@ spec:
         namespace="{{ dsc.harbor.namespace }}"} * 100, 0.01) < 10 > 0
       for: 1m
       labels:
-        severity: warning
+        severity: critical
     - alert: Harbor PVC out of disk space
       annotations:
         message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{ dsc.harbor.namespace }} is full (0% left).

--- a/roles/keycloak/templates/values/00-main.j2
+++ b/roles/keycloak/templates/values/00-main.j2
@@ -211,6 +211,21 @@ metrics:
             for: 5m
             labels:
               severity: warning
+          - alert: Keycloak DB PVC has low remaining disk space
+            annotations:
+              message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{"{{"}} $labels.namespace {{"}}"}} is running out of disk space (< 20% left). VALUE = {{"{{"}} $value {{"}}"}}%
+              summary: Keycloak CNPG PVC is running out of disk space in namespace {{"{{"}} $labels.namespace {{"}}"}}
+            expr: |
+              round(
+              kubelet_volume_stats_available_bytes{
+              persistentvolumeclaim=~"pg-cluster-keycloak-\\d+",
+              namespace="{{ include "common.names.namespace" . }}"}
+              / kubelet_volume_stats_capacity_bytes{
+              persistentvolumeclaim=~"pg-cluster-keycloak-\\d+",
+              namespace="{{ include "common.names.namespace" . }}"} * 100, 0.01) < 20 > 10
+            for: 1m
+            labels:
+              severity: warning
           - alert: Keycloak DB PVC almost out of disk space
             annotations:
               message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{ include "common.names.namespace" . }} is almost full (< 10% left). VALUE = {{"{{"}} $value {{"}}"}}%
@@ -225,7 +240,7 @@ metrics:
               namespace="{{ include "common.names.namespace" . }}"} * 100, 0.01) < 10 > 0
             for: 1m
             labels:
-              severity: warning
+              severity: critical
           - alert: Keycloak DB PVC out of disk space
             annotations:
               message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{ include "common.names.namespace" . }} is full (0% left).

--- a/roles/nexus/templates/prometheusrule.yml.j2
+++ b/roles/nexus/templates/prometheusrule.yml.j2
@@ -25,6 +25,21 @@ spec:
       for: 5m
       labels:
         severity: critical
+    - alert: Nexus PVC has low remaining disk space
+      annotations:
+        message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{"{{"}} $labels.namespace {{"}}"}} is running out of disk space (< 20% left). VALUE = {{"{{"}} $value {{"}}"}}%
+        summary: Nexus PVC is running out of disk space in namespace {{"{{"}} $labels.namespace {{"}}"}}
+      expr: |
+        round(
+        kubelet_volume_stats_available_bytes{
+        persistentvolumeclaim=~"nexus-data-.*",
+        namespace="{{ dsc.nexus.namespace }}"}
+        / kubelet_volume_stats_capacity_bytes{
+        persistentvolumeclaim=~"nexus-data-.*",
+        namespace="{{ dsc.nexus.namespace }}"} * 100, 0.01) < 20 > 10
+      for: 1m
+      labels:
+        severity: warning
     - alert: Nexus PVC almost out of disk space
       annotations:
         message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{ dsc.nexus.namespace }} is almost full (< 10% left). VALUE = {{"{{"}} $value {{"}}"}}%
@@ -39,7 +54,7 @@ spec:
         namespace="{{ dsc.nexus.namespace }}"} * 100, 0.01) < 10 > 0
       for: 1m
       labels:
-        severity: warning
+        severity: critical
     - alert: Nexus PVC out of disk space
       annotations:
         message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{ dsc.nexus.namespace }} is full (0% left).

--- a/roles/sonarqube/templates/prometheusrule.yml.j2
+++ b/roles/sonarqube/templates/prometheusrule.yml.j2
@@ -50,6 +50,21 @@ spec:
       for: 5m
       labels:
         severity: warning
+    - alert: SonarQube DB PVC has low remaining disk space
+      annotations:
+        message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{"{{"}} $labels.namespace {{"}}"}} is running out of disk space (< 20% left). VALUE = {{"{{"}} $value {{"}}"}}%
+        summary: SonarQube CNPG PVC is running out of disk space in namespace {{"{{"}} $labels.namespace {{"}}"}}
+      expr: |
+        round(
+        kubelet_volume_stats_available_bytes{
+        persistentvolumeclaim=~"pg-cluster-sonar-\\d+",
+        namespace="{{ dsc.sonarqube.namespace }}"}
+        / kubelet_volume_stats_capacity_bytes{
+        persistentvolumeclaim=~"pg-cluster-sonar-\\d+",
+        namespace="{{ dsc.sonarqube.namespace }}"} * 100, 0.01) < 20 > 10
+      for: 1m
+      labels:
+        severity: warning
     - alert: SonarQube DB PVC almost out of disk space
       annotations:
         message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{ dsc.sonarqube.namespace }} is almost full (< 10% left). VALUE = {{"{{"}} $value {{"}}"}}%
@@ -64,7 +79,7 @@ spec:
         namespace="{{ dsc.sonarqube.namespace }}"} * 100, 0.01) < 10 > 0
       for: 1m
       labels:
-        severity: warning
+        severity: critical
     - alert: SonarQube DB PVC out of disk space
       annotations:
         message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{ dsc.sonarqube.namespace }} is full (0% left).

--- a/roles/vault/templates/values/00-main.j2
+++ b/roles/vault/templates/values/00-main.j2
@@ -148,6 +148,21 @@ serverTelemetry:
         for: 5m
         labels:
           severity: warning
+      - alert: Vault PVC has low remaining disk space
+        annotations:
+          message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{"{{"}} $labels.namespace {{"}}"}} is running out of disk space (< 20% left). VALUE = {{"{{"}} $value {{"}}"}}%
+          summary: Vault PVC is running out of disk space in namespace {{"{{"}} $labels.namespace {{"}}"}}
+        expr: |
+          round(
+          kubelet_volume_stats_available_bytes{
+          persistentvolumeclaim=~"(.*-)*vault(-.*)*",
+          namespace="{{ dsc.vault.namespace }}"}
+          / kubelet_volume_stats_capacity_bytes{
+          persistentvolumeclaim=~"(.*-)*vault(-.*)*",
+          namespace="{{ dsc.vault.namespace }}"} * 100, 0.01) < 20 > 10
+        for: 1m
+        labels:
+          severity: warning
       - alert: Vault PVC almost out of disk space
         annotations:
           message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{ dsc.vault.namespace }} is almost full (< 10% left). VALUE = {{"{{"}} $value {{"}}"}}%
@@ -162,7 +177,7 @@ serverTelemetry:
           namespace="{{ dsc.vault.namespace }}"} * 100, 0.01) < 10 > 0
         for: 1m
         labels:
-          severity: warning
+          severity: critical
       - alert: Vault PVC out of disk space
         annotations:
           message: PVC {{"{{"}} $labels.persistentvolumeclaim {{"}}"}} in namespace {{ dsc.vault.namespace }} is full (0% left).


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Les alertes sur la partie PVC ne se déclenchent qu'à partir d'un taux de remplissage supérieur à 90%.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous ajoutons une alerte intermériaire de niveau "warning" au-delà d'un seuil de 80%.
Nous maintenons l'alerte au-delà de 90%, mais en la considérant comme "critical".

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
