### PR TITLE
fix typos, grammar, double/end-of-line spaces

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,10 @@
+---
+exclude_paths:
+  - .cache/ # implicit unless exclude_paths is defined in config
+  - .github/
+  - .idea/
+  - .vscode/
+  - pnpm-lock.yaml
+
+skip_list:
+  - role-name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,11 +261,11 @@ for tbl in `psql -U postgres -qAt -c "select tablename from pg_tables where sche
   psql -U postgres -c "alter table \"$tbl\" owner to harbor" registry
 done
 
-for tbl in `psql -U postgres -qAt -c "select sequence_name from information_schema.sequences where sequence_schema = 'public';" registry`; do  
+for tbl in `psql -U postgres -qAt -c "select sequence_name from information_schema.sequences where sequence_schema = 'public';" registry`; do
   psql -U postgres -c "alter sequence \"$tbl\" owner to harbor" registry
 done
 
-for tbl in `psql  -U postgres -qAt -c "select table_name from information_schema.views where table_schema = 'public';" registry`; do  
+for tbl in `psql  -U postgres -qAt -c "select table_name from information_schema.views where table_schema = 'public';" registry`; do
   psql -U postgres -c "alter view \"$tbl\" owner to harbor" registry
 done
 ```
@@ -472,7 +472,7 @@ If the Vault cluster finds itself in a state where none of the nodes is a leader
 ### Features
 
 * :sparkles: Enable directAccessGrants for argo-client ([be0843f](https://github.com/cloud-pi-native/socle/commit/be0843f3871a937e45c42c5b5645eead7f86abd0))
-* :sparkles: Enable postgres super user (as we might need it) ([08a64ad](https://github.com/cloud-pi-native/socle/commit/08a64ad836d39448c1516a70215dfaa3a434a9e6))
+* :sparkles: Enable postgres superuser (as we might need it) ([08a64ad](https://github.com/cloud-pi-native/socle/commit/08a64ad836d39448c1516a70215dfaa3a434a9e6))
 * :sparkles: Enabling brute force detection ([c3d8f50](https://github.com/cloud-pi-native/socle/commit/c3d8f50bc67204ac578a57e9f838e0d2019cfe99))
 * :sparkles: Set failureFactor for brute force protection ([dbe7b20](https://github.com/cloud-pi-native/socle/commit/dbe7b2034878ca8e1efdfd7ef1ba767d908b8709))
 
@@ -544,7 +544,7 @@ If the Vault cluster finds itself in a state where none of the nodes is a leader
 * :sparkles: ([9487622](https://github.com/cloud-pi-native/socle/commit/94876223048655cf4420842a1fc2db8f3714c6c7))
 * :sparkles: Activate keycloak basic metrics ([e7630fd](https://github.com/cloud-pi-native/socle/commit/e7630fd158fb4e12e9f8f98bc4724cef91645cb2))
 * :sparkles: Activate metrics when dsc.global.metric.enabled ([49e91f8](https://github.com/cloud-pi-native/socle/commit/49e91f82a1447e1b38e8f633bab669f8cda8f7a1))
-* :sparkles: Activate monitoring  for additionnal resources + refactor ([9c9f979](https://github.com/cloud-pi-native/socle/commit/9c9f979b05e23a0130371cecc02d216570664de5))
+* :sparkles: Activate monitoring  for additional resources + refactor ([9c9f979](https://github.com/cloud-pi-native/socle/commit/9c9f979b05e23a0130371cecc02d216570664de5))
 * :sparkles: Activate monitoring + small refactor ([255bb56](https://github.com/cloud-pi-native/socle/commit/255bb5657ad3dded213e8aa055c42f5b03b65f22))
 * :sparkles: Activate Nexus metrics scraping ([0e53610](https://github.com/cloud-pi-native/socle/commit/0e53610ce121caa244e868154a67a5f8db3eaa28))
 * :sparkles: Activate Vault metrics ([63ade45](https://github.com/cloud-pi-native/socle/commit/63ade457c10c5553df35ed08c097d87d01c7c5fb))
@@ -632,7 +632,7 @@ If the Vault cluster finds itself in a state where none of the nodes is a leader
 
 ### Bug Fixes
 
-* :adhesive_bandage: Ajout du user dso admin dans les bons groupes ([14f9ee4](https://github.com/cloud-pi-native/socle/commit/14f9ee405abd921d8467c80588496a7959f705c5))
+* :adhesive_bandage: Ajout de l'user dso admin dans les bons groupes ([14f9ee4](https://github.com/cloud-pi-native/socle/commit/14f9ee405abd921d8467c80588496a7959f705c5))
 * :ambulance: Correctif cert-manager sur récupération des CRDS ([c77e78b](https://github.com/cloud-pi-native/socle/commit/c77e78bc57aa31d791e5042060b4d0ef7335cd6b))
 * :ambulance: correctif du role nexus ([6763075](https://github.com/cloud-pi-native/socle/commit/67630759cd1e46f1c245f8b5784d5ed243c8e767))
 * :bug: Correctif désinstallation GitLab ([d233e61](https://github.com/cloud-pi-native/socle/commit/d233e6179177ad3c415a136240dba57579eed9d2))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,11 +261,11 @@ for tbl in `psql -U postgres -qAt -c "select tablename from pg_tables where sche
   psql -U postgres -c "alter table \"$tbl\" owner to harbor" registry
 done
 
-for tbl in `psql -U postgres -qAt -c "select sequence_name from information_schema.sequences where sequence_schema = 'public';" registry`; do
+for tbl in `psql -U postgres -qAt -c "select sequence_name from information_schema.sequences where sequence_schema = 'public';" registry`; do  
   psql -U postgres -c "alter sequence \"$tbl\" owner to harbor" registry
 done
 
-for tbl in `psql  -U postgres -qAt -c "select table_name from information_schema.views where table_schema = 'public';" registry`; do
+for tbl in `psql  -U postgres -qAt -c "select table_name from information_schema.views where table_schema = 'public';" registry`; do  
   psql -U postgres -c "alter view \"$tbl\" owner to harbor" registry
 done
 ```
@@ -472,7 +472,7 @@ If the Vault cluster finds itself in a state where none of the nodes is a leader
 ### Features
 
 * :sparkles: Enable directAccessGrants for argo-client ([be0843f](https://github.com/cloud-pi-native/socle/commit/be0843f3871a937e45c42c5b5645eead7f86abd0))
-* :sparkles: Enable postgres superuser (as we might need it) ([08a64ad](https://github.com/cloud-pi-native/socle/commit/08a64ad836d39448c1516a70215dfaa3a434a9e6))
+* :sparkles: Enable postgres super user (as we might need it) ([08a64ad](https://github.com/cloud-pi-native/socle/commit/08a64ad836d39448c1516a70215dfaa3a434a9e6))
 * :sparkles: Enabling brute force detection ([c3d8f50](https://github.com/cloud-pi-native/socle/commit/c3d8f50bc67204ac578a57e9f838e0d2019cfe99))
 * :sparkles: Set failureFactor for brute force protection ([dbe7b20](https://github.com/cloud-pi-native/socle/commit/dbe7b2034878ca8e1efdfd7ef1ba767d908b8709))
 
@@ -544,7 +544,7 @@ If the Vault cluster finds itself in a state where none of the nodes is a leader
 * :sparkles: ([9487622](https://github.com/cloud-pi-native/socle/commit/94876223048655cf4420842a1fc2db8f3714c6c7))
 * :sparkles: Activate keycloak basic metrics ([e7630fd](https://github.com/cloud-pi-native/socle/commit/e7630fd158fb4e12e9f8f98bc4724cef91645cb2))
 * :sparkles: Activate metrics when dsc.global.metric.enabled ([49e91f8](https://github.com/cloud-pi-native/socle/commit/49e91f82a1447e1b38e8f633bab669f8cda8f7a1))
-* :sparkles: Activate monitoring  for additional resources + refactor ([9c9f979](https://github.com/cloud-pi-native/socle/commit/9c9f979b05e23a0130371cecc02d216570664de5))
+* :sparkles: Activate monitoring  for additionnal resources + refactor ([9c9f979](https://github.com/cloud-pi-native/socle/commit/9c9f979b05e23a0130371cecc02d216570664de5))
 * :sparkles: Activate monitoring + small refactor ([255bb56](https://github.com/cloud-pi-native/socle/commit/255bb5657ad3dded213e8aa055c42f5b03b65f22))
 * :sparkles: Activate Nexus metrics scraping ([0e53610](https://github.com/cloud-pi-native/socle/commit/0e53610ce121caa244e868154a67a5f8db3eaa28))
 * :sparkles: Activate Vault metrics ([63ade45](https://github.com/cloud-pi-native/socle/commit/63ade457c10c5553df35ed08c097d87d01c7c5fb))
@@ -632,7 +632,7 @@ If the Vault cluster finds itself in a state where none of the nodes is a leader
 
 ### Bug Fixes
 
-* :adhesive_bandage: Ajout de l'user dso admin dans les bons groupes ([14f9ee4](https://github.com/cloud-pi-native/socle/commit/14f9ee405abd921d8467c80588496a7959f705c5))
+* :adhesive_bandage: Ajout du user dso admin dans les bons groupes ([14f9ee4](https://github.com/cloud-pi-native/socle/commit/14f9ee405abd921d8467c80588496a7959f705c5))
 * :ambulance: Correctif cert-manager sur récupération des CRDS ([c77e78b](https://github.com/cloud-pi-native/socle/commit/c77e78bc57aa31d791e5042060b4d0ef7335cd6b))
 * :ambulance: correctif du role nexus ([6763075](https://github.com/cloud-pi-native/socle/commit/67630759cd1e46f1c245f8b5784d5ed243c8e767))
 * :bug: Correctif désinstallation GitLab ([d233e61](https://github.com/cloud-pi-native/socle/commit/d233e6179177ad3c415a136240dba57579eed9d2))

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Toujours sur votre environnement de déploiement, vous devrez :
 
 L'installation de la suite des prérequis **sur l'environnement de déploiement** s'effectue à l'aide du playbook nommé `install-requirements.yaml`. Il est mis à disposition dans le répertoire `admin-tools` du dépôt socle que vous aurez clôné.
 
-Si l'utilisateur avec lequel vous exécutez ce playbook dispose des droits sudo sans mot de passe (option `NOPASSWD` du fichier sudoers), vous pourrez le lancer directement sans options :
+Si l'utilisateur avec lequel vous exécutez ce playbook dispose des droits sudo sans mots de passe (option `NOPASSWD` du fichier sudoers), vous pourrez le lancer directement sans options :
 
 ```bash
 ansible-playbook admin-tools/install-requirements.yaml
@@ -136,7 +136,7 @@ Pour information, le playbook `install-requirements.yaml` vous installera les é
 - Commandes installées avec Homebrew :
   - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
   - [helm](https://helm.sh/docs/intro/install/)
-  - [yq](https://github.com/mikefarah/yq/#install) (Facultative mais utile pour debug.)
+  - [yq](https://github.com/mikefarah/yq/#install) (Facultative, mais utile pour debug)
 
 ## Configuration
 
@@ -146,7 +146,7 @@ Lorsque vous avez cloné le présent dépôt socle, lancez une première fois la
 ansible-playbook install.yaml
 ```
 
-Elle vous signalera que vous n'avez encore jamais installé le socle sur votre cluster, puis vous invitera à modifier la ressource de scope cluster et de type **dsc** nommée **conf-dso** via la commande suivante :
+Elle vous signalera que vous n'avez encore jamais installé le socle sur votre cluster, puis vous invitera à modifier la ressource de scope cluster et de type `dsc` nommée `conf-dso` via la commande suivante :
 
 ```bash
 kubectl edit dsc conf-dso
@@ -202,7 +202,7 @@ S'agissant du gel des versions de charts ou d'images pour les outils en question
 
 ### Lancement
 
-Dès que votre [configuration](#configuration) est prête, c'est-à-dire que la ressource `dsc` par défaut  `conf-dso` a bien été mise à jour avec les éléments nécessaires et souhaités, relancez la commande suivante :
+Dès que votre [configuration](#configuration) est prête, c'est-à-dire que la ressource `dsc` par défaut `conf-dso` a bien été mise à jour avec les éléments nécessaires et souhaités, relancez la commande suivante :
 
 ```bash
 ansible-playbook install.yaml
@@ -253,7 +253,7 @@ Lorsque votre nouvelle configuration est prête, et déclarée par exemple dans 
 kubectl apply -f ma-conf-perso.yaml
 ```
 
-Vous pourrer ensuite la retrouver via la commande :
+Vous pourrez ensuite la retrouver via la commande :
 
 ```bash
 kubectl get dsc
@@ -535,8 +535,8 @@ Les sections suivantes détaillent comment procéder, outil par outil.
 
 **Remarques importantes** :
 
-- Comme vu dans la section d'installation (sous-section [Déploiement de plusieurs forges DSO dans un même cluster](#déploiement-de-plusieurs-forges-dso-dans-un-même-cluster )), si vous utilisez votre propre ressource `dsc` de configuration, distincte de `conf-dso`, alors toutes les commandes `ansible-playbook` indiquées ci-dessous devront être complétées par l'[extra variable](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#defining-variables-at-runtime) `dsc_cr` appropriée.
-- Pour le gel des versions d'images, il est recommandé, si possible, de positionner un **tag d'image en adéquation avec la version du chart Helm utilisé**, c'est-à-dire d'utiliser le numéro "APP VERSION" retourné par la commande `helm search repo`.
+- Comme vu dans la section d'installation (sous-section [Déploiement de plusieurs forges DSO dans un même cluster](#déploiement-de-plusieurs-forges-dso-dans-un-même-cluster )), si vous utilisez votre propre ressource `dsc` de configuration, distincte de `conf-dso`, alors toutes les commandes `ansible-playbook` indiquées ci-dessous devront être complétées par la [variable supplémentaire](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#defining-variables-at-runtime) `dsc_cr` appropriée (avec `--extra-vars` ou `-e`).
+- Pour le gel des versions d'images, il est recommandé, si possible, de positionner un **tag d'image en adéquation avec la version du chart Helm utilisé**, c'est-à-dire d'utiliser le numéro `APP VERSION` retourné par la commande `helm search repo`.
 
 ### Modification des versions de charts
 
@@ -544,11 +544,11 @@ Techniquement, la modification des versions de charts utilisés est possible, ma
 
 Ceci parce que la version de la Console Cloud π Native déployée par le socle, composant central qui s'interface avec tous les outils de la chaîne, a été testée et développée avec les versions d'outils telles qu'elles sont fixées au moment de la publication.
 
-Aussi, **nous ne pouvons garantir le bon fonctionnement** de la forge DSO dans un contexte où les versions de charts seraient modifiées.
+Aussi, **nous ne pouvons garantir le bon fonctionnement** de la forge DSO dans un contexte avec lequel les versions de charts seraient modifiées.
 
 De plus, et comme indiqué plus haut, les outils cert-manager, CloudNativePG, GitLab Operator, Grafana Operator et Kyverno seront communs à toutes les instances de la chaine DSO ou à toute autre application déployée dans le cluster. En modifier la version n'est donc pas anodin.
 
-Si vous souhaitez malgré tout tenter une modification de version d'un chart en particulier, Vous devrez **avoir au moins installé le socle DSO une première fois**. En effet, le playbook et les roles associés installeront les dépôts Helm de chaque outil. Ceci vous permettra ensuite d'utiliser la commande `helm` pour rechercher plus facilement les versions de charts disponibles.
+Si vous souhaitez malgré tout tenter une modification de version d'un chart en particulier, vous devrez **avoir au moins installé le socle DSO une première fois**. En effet, le playbook et les roles associés installeront les dépôts Helm de chaque outil. Ceci vous permettra ensuite d'utiliser la commande `helm` pour rechercher plus facilement les versions de charts disponibles.
 
 Pensez également à effectuer au moins un backup du namespace et des ressources cluster scoped associées.
 
@@ -644,7 +644,7 @@ Il est recommandé de ne pas modifier cette version de chart, sauf si vous savez
 
 #### CloudNativePG
 
-Comme avec cert-manager, il existe une correspondance biunivoque entre la version de chart utilisée et la version d'application ("APP VERSION") de l'opérateur.
+Comme avec cert-manager, il existe une correspondance biunivoque entre la version de chart utilisée et la version d'application (`APP VERSION`) de l'opérateur.
 
 Ainsi, spécifier une version de chart est suffisant pour geler la version d'image au niveau de l'opérateur.
 
@@ -652,7 +652,7 @@ Il est recommandé de ne pas modifier cette version de chart, sauf si vous savez
 
 Comme indiqué dans sa [documentation officielle](https://cloudnative-pg.io/documentation/1.20/quickstart/#part-3-deploy-a-postgresql-cluster), par défaut CloudNativePG installera la dernière version mineure disponible de la dernière version majeure de PostgreSQL au moment de la publication de l'opérateur.
 
-De plus, comme l'indique la [FAQ officielle](https://cloudnative-pg.io/documentation/1.20/faq/), CloudNativePG utilise des conteneurs d'application immutables. Cela signifie que le conteneur ne sera pas modifié durant tout son cycle de vie (aucun patch, aucune mise à jour ni changement de configuration).
+De plus, comme l'indique la [FAQ officielle](https://cloudnative-pg.io/documentation/1.20/faq/), CloudNativePG utilise des conteneurs d'application immuables. Cela signifie que le conteneur ne sera pas modifié durant tout son cycle de vie (aucun patch, aucune mise à jour ni changement de configuration).
 
 #### Console Cloud π Native
 
@@ -682,7 +682,7 @@ Il est donc recommandé de ne pas modifier les versions de charts déjà fixées
 
 #### GitLab CI pipelines exporter
 
-La version d'image utilisée par GitLab CI pipelines exporter est directement liée à la version de chart déployée. Elle est donc déjà gelée par défaut.
+La version d'image utilisée par _GitLab CI pipelines exporter_ est directement liée à la version de chart déployée. Elle est donc déjà gelée par défaut.
 
 Il est recommandé de ne pas modifier cette version de chart, sauf si vous savez ce que vous faites.
 
@@ -698,7 +698,7 @@ https://docs.gitlab.com/runner/#gitlab-runner-versions
 
 #### Harbor
 
-Fixer le numéro de version du chart Helm sera normalement suffisant pour fixer aussi le numéro de version des images associées. Le numéro de version de ces images sera celui visible dans la colonne "APP VERSION" de la commande `helm search repo -l harbor/harbor`.
+Fixer le numéro de version du chart Helm sera normalement suffisant pour fixer aussi le numéro de version des images associées. Le numéro de version de ces images sera celui visible dans la colonne `APP VERSION` de la commande `helm search repo -l harbor/harbor`.
 
 Il est toutefois possible de fixer les versions d'images pour Harbor de façon plus fine (**recommandé en production**).
 
@@ -719,7 +719,7 @@ Les différents tags utilisables sont disponibles ici :
 - redis : <https://hub.docker.com/r/goharbor/redis-photon/tags>
 - exporter : <https://hub.docker.com/r/goharbor/harbor-exporter/tags>
 
-**Rappel** : Il est néanmoins recommandé de positionner des tags d'images en adéquation avec la version du chart Helm utilisée et documentée dans le fichier [versions.md](versions.md), situé à la racine du socle, c'est-à-dire d'utiliser le numéro "APP VERSION" retourné par la commande `helm search repo -l harbor/harbor --version numero-de-version-de-chart`.
+**Rappel** : Il est néanmoins recommandé de positionner des tags d'images en adéquation avec la version du chart Helm utilisée et documentée dans le fichier [versions.md](versions.md), situé à la racine du socle, c'est-à-dire d'utiliser le numéro `APP VERSION` retourné par la commande `helm search repo -l harbor/harbor --version numero-de-version-de-chart`.
 
 Pour spécifier nos tags, il nous suffira d'éditer la ressource `dsc` de configuration (par défaut, ce sera la `dsc` nommée `conf-dso`) et de surcharger les "values" correspondantes du chart Helm, en ajoutant celles dont nous avons besoin. Exemple, pour la version 1.14.1 du chart :
 
@@ -809,7 +809,7 @@ Nous utiliserons un tag dit "[immutable](https://docs.bitnami.com/kubernetes/app
 
 Les différents tags utilisables pour l'image de Keycloak sont disponibles ici : <https://hub.docker.com/r/bitnami/keycloak/tags>
 
-Les tags dits "immutables" sont ceux qui possèdent un suffixe de type rXX, lequel correspond au numéro de révision. Ils pointent toujours vers la même image. Par exemple le tag "19.0.3-debian-11-r22" est un tag immutable.
+Les _immutable tags_ sont ceux qui possèdent un suffixe de type rXX, lequel correspond au numéro de révision. Ils pointent toujours vers la même image. Par exemple, `19.0.3-debian-11-r22` est un _immutable tag_.
 
 Pour spécifier un tel tag, il nous suffira d'éditer la ressource `dsc` de configuration (par défaut, ce sera la `dsc` nommée `conf-dso`) et de surcharger les "values" correspondantes du chart Helm, en ajoutant celles dont nous avons besoin. Exemple :
 
@@ -854,13 +854,13 @@ nexus:
 
 Le composant SonarQube est installé via son [chart Helm officiel](https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube).
 
-Les tags d'images utilisables sont ceux retournés par la commande suivante, au niveau de la colonne "APP VERSION" :
+Les tags d'images utilisables sont ceux retournés par la commande suivante, au niveau de la colonne `APP VERSION` :
 
 ```bash
 helm search repo -l sonarqube/sonarqube
 ```
 
-Il faudra juste leur ajouter le suffixe "-community" qui correspond à l'édition utilisée, ou bien le suffixe `-{{ .Values.edition }}` si nous précisons aussi l'édition dans nos values.
+Il faudra juste leur ajouter le suffixe `-community` qui correspond à l'édition utilisée, ou bien le suffixe `-{{ .Values.edition }}` si nous précisons aussi l'édition dans nos values.
 
 Pour spécifier un tel tag, il nous suffira d'éditer la ressource `dsc` de configuration (par défaut, ce sera la `dsc` nommée `conf-dso`) et de surcharger les "values" correspondantes du chart Helm, en ajoutant celles dont nous avons besoin. Exemple :
 
@@ -982,7 +982,7 @@ k create secret docker-registry docker-hub-creds \
 
 Notez que du fait de l'utilisation de l'option `dry-run`, le secret n'est pas véritablement créé. La partie qui nous intéresse, encodée en base64, est simplement affichée sur la sortie standard.
 
-Copiez cette sortie, et collez-la dans la section `spec.global.imagePullSecretsData` de votre resource dsc (par défaut conf-dso), exemple :
+Copiez cette sortie, et collez-la dans la section `spec.global.imagePullSecretsData` de votre resource dsc (par défaut `conf-dso`), exemple :
 
 ```yaml
 global:
@@ -1019,7 +1019,7 @@ Puis relancez l'installation de l'outil voulu ou de la chaîne complète.
 # Lancer la vérification syntaxique
 pnpm install && pnpm run lint
 
-# Lancer le formattage du code
+# Lancer le formatage du code
 pnpm install && pnpm run format
 ```
 

--- a/README.md
+++ b/README.md
@@ -188,12 +188,12 @@ Il s'agit de valeurs de chart [Helm](https://helm.sh/fr). Vous pouvez les utilis
 
 Voici les liens vers les documentations de chart Helm pour les outils concernés :
 
-- [Argo CD](https://github.com/bitnami/charts/tree/main/bitnami/argo-cd)
+- [Argo CD](https://github.com/argoproj/argo-helm/tree/main/charts/argo-cd)
 - [Console Cloud π Native](https://github.com/cloud-pi-native/console#readme)
 - [GitLab](https://gitlab.com/gitlab-org/charts/gitlab)
 - [Harbor](https://github.com/goharbor/harbor-helm)
 - [Keycloak](https://github.com/bitnami/charts/tree/main/bitnami/keycloak)
-- [SonarQube](https://github.com/bitnami/charts/tree/main/bitnami/sonarqube)
+- [SonarQube](https://github.com/SonarSource/helm-chart-sonarqube)
 - [HashiCorp Vault](https://github.com/hashicorp/vault-helm)
 
 S'agissant du gel des versions de charts ou d'images pour les outils en question, **nous vous invitons fortement à consulter la section détaillée [Gel des versions](#gel-des-versions)** située plus bas dans le présent document.

--- a/admin-tools/get-credentials.yaml
+++ b/admin-tools/get-credentials.yaml
@@ -60,7 +60,7 @@
               - ""
               - "Puis relancez le playbook avec une resource dsc existante."
               - ""
-              - "Rappel : le présent playbook lancé seul, sans extra vars, founira les credentials associés à la configuration dsc par défaut (conf-dso)"
+              - "Rappel : le présent playbook lancé seul, sans extra vars, fournira les credentials associés à la configuration dsc par défaut (conf-dso)"
 
         - name: Exit playbook
           ansible.builtin.meta: end_play

--- a/admin-tools/get-credentials.yaml
+++ b/admin-tools/get-credentials.yaml
@@ -43,6 +43,8 @@
 
     - name: Check socle_config_custom and exit if empty
       when: (dsc_cr is defined) and (socle_config_custom.resources | length == 0)
+      tags:
+        - always
       block:
         - name: Warning message
           ansible.builtin.debug:
@@ -64,8 +66,6 @@
 
         - name: Exit playbook
           ansible.builtin.meta: end_play
-      tags:
-        - always
 
     - name: Set socle_config fact when dsc_cr defined and not empty
       ansible.builtin.set_fact:
@@ -74,31 +74,18 @@
       tags:
         - always
 
-    - name: Set DSC Name fact
+    - name: Set DSC facts
       ansible.builtin.set_fact:
         dsc_name: "{{ socle_config.resources[0].metadata.name }}"
-      tags:
-        - always
-
-    - name: Set DSC fact
-      ansible.builtin.set_fact:
         dsc: "{{ socle_config.resources[0] }}"
-      tags:
-        - always
-
-    - ansible.builtin.set_fact:
         dsc_default_config: "{{ lookup('ansible.builtin.file', '../roles/socle-config/files/config.yaml') | from_yaml }}"
         dsc_default_releases: "{{ lookup('ansible.builtin.file', '../roles/socle-config/files/releases.yaml') | from_yaml }}"
       tags:
         - always
 
-    - ansible.builtin.set_fact:
-        dsc: "{{ dsc_default_releases | combine(dsc_default_config, recursive=True) | combine(dsc, recursive=True) }}"
-      tags:
-        - always
-
-    - ansible.builtin.set_fact:
-        dsc: "{{ dsc.spec }}"
+    - name: Combine DSC with config and releases
+      ansible.builtin.set_fact:
+        dsc: "{{ (dsc_default_releases | combine(dsc_default_config, recursive=True) | combine(dsc, recursive=True)).spec }}"
       tags:
         - always
 

--- a/admin-tools/get-versions.yaml
+++ b/admin-tools/get-versions.yaml
@@ -69,7 +69,7 @@
               - ""
               - "Puis relancez le playbook avec une resource dsc existante."
               - ""
-              - "Rappel : le présent playbook lancé seul, sans extra vars, founira les credentials associés à la configuration dsc par défaut (conf-dso)"
+              - "Rappel : le présent playbook lancé seul, sans extra vars, fournira les credentials associés à la configuration dsc par défaut (conf-dso)"
 
         - name: Exit playbook
           ansible.builtin.meta: end_play

--- a/admin-tools/install-requirements.yaml
+++ b/admin-tools/install-requirements.yaml
@@ -26,7 +26,7 @@
       ansible.builtin.package:
         name: "{{ item }}"
         state: present
-      loop: "{{ packages  }}"
+      loop: "{{ packages }}"
 
     - name: "Install Python modules"
       ansible.builtin.pip:

--- a/filter_plugins/debug.py
+++ b/filter_plugins/debug.py
@@ -2,12 +2,12 @@ def get_debug_messages(dsc):
     messages = []
     if dsc['proxy']['enabled']:
         messages.append("--- Proxy ---")
-        messages.append("Nexus Proxy paramaters cannot be set via API, please configure it with local admin account")
+        messages.append("Nexus Proxy parameters cannot be set via API, please configure it with local admin account")
         messages.append("(Parameter Icon) => HTTP => Proxy Settings")
     return messages
 
-class FilterModule(object):  
-    def filters(self):    
+class FilterModule(object):
+    def filters(self):
         return {
             'get_debug_messages': get_debug_messages,
         }

--- a/install.yaml
+++ b/install.yaml
@@ -4,121 +4,121 @@
   gather_facts: false
 
   roles:
-    - name: socle-config
+    - role: socle-config
       tags:
         - always
 
-    - name: cluster-offline
+    - role: cluster-offline
       tags:
         - always
       when: dsc.global.offline
 
-    - name: ca
+    - role: ca
       tags:
         - always
 
-    - name: console-dso-config
+    - role: console-dso-config
       tags:
         - always
 
-    - name: kyverno
+    - role: kyverno
       tags:
         - kyverno
 
-    - name: cert-manager
+    - role: cert-manager
       tags:
         - cert-manager
         - cm
         - always
 
-    - name: cloudnativepg
+    - role: cloudnativepg
       tags:
         - cloudnativepg
         - cnpg
 
-    - name: prometheus
+    - role: prometheus
       tags:
         - prometheus
         - prom
       when: dsc.prometheus.crd.type == 'managed'
 
-    - name: keycloak
+    - role: keycloak
       tags:
         - keycloak
         - sso
 
-    - name: nexus
+    - role: nexus
       tags:
         - nexus
 
-    - name: sonarqube
+    - role: sonarqube
       tags:
         - sonarqube
         - sonar
 
-    - name: gitlab-operator
+    - role: gitlab-operator
       tags:
         - gitlab-operator
 
-    - name: gitlab
+    - role: gitlab
       tags:
         - gitlab
 
-    - name: gitlab-catalog
+    - role: gitlab-catalog
       tags:
         - catalog
         - gitlab-catalog
 
-    - name: gitlab-runner
+    - role: gitlab-runner
       tags:
         - runner
         - gitlab-runner
 
-    - name: gitlab-ci-pipelines-exporter
+    - role: gitlab-ci-pipelines-exporter
       tags:
         - ci-pipelines-exporter
         - gitlab-ci-pipelines-exporter
       when: not dsc.global.offline
 
-    - name: vault
+    - role: vault
       tags:
         - vault
 
-    - name: argocd
+    - role: argocd
       tags:
         - gitops
         - argocd
         - argo
 
-    - name: harbor
+    - role: harbor
       tags:
         - harbor
         - registry
 
-    - name: console-dso
+    - role: console-dso
       tags:
         - console
         - console-dso
 
-    - name: grafana-operator
+    - role: grafana-operator
       tags:
         - grafana-operator
         - grafana-stack
         - never
 
-    - name: grafana
+    - role: grafana
       tags:
         - grafana
         - grafana-stack
         - never
 
-    - name: grafana-datasource
+    - role: grafana-datasource
       tags:
         - grafana-datasource
         - grafana-stack
         - never
 
-    - name: grafana-dashboards
+    - role: grafana-dashboards
       tags:
         - grafana-dashboards
         - grafana-stack

--- a/observability/files/rules/metrics/kyverno-alerts.yaml.tpl
+++ b/observability/files/rules/metrics/kyverno-alerts.yaml.tpl
@@ -1,10 +1,10 @@
 groups:
   - name: DSO_Kyverno
     rules:
-      - alert: Kyverno admission controler not available
+      - alert: Kyverno admission controller not available
         annotations:
-          message: Kyverno admission controler in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
-          summary: Kyverno admission controler down (no ready pod)"
+          message: Kyverno admission controller in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
+          summary: Kyverno admission controller down (no ready pod)"
         expr: |
           sum(kube_pod_status_ready{
           pod=~"kyverno-admission-controller-.*",
@@ -13,10 +13,10 @@ groups:
         for: 5m
         labels:
           severity: critical
-      - alert: Kyverno background controler not available
+      - alert: Kyverno background controller not available
         annotations:
-          message: Kyverno background controler in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
-          summary: Kyverno background controler down (no ready pod)"
+          message: Kyverno background controller in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
+          summary: Kyverno background controller down (no ready pod)"
         expr: |
           sum(kube_pod_status_ready{
           pod=~"kyverno-background-controller-.*",

--- a/roles/argocd/templates/values/10-alerting.j2
+++ b/roles/argocd/templates/values/10-alerting.j2
@@ -15,7 +15,7 @@ controller:
             summary: "[Argo CD] No reported applications"
             description: |
               Argo CD has not reported any applications data for the past 15 minutes which
-              means that it must be down or not functioning properly.  This needs to be
+              means that it must be down or not functioning properly. This needs to be
               resolved for this cloud to continue to maintain state.
         - alert: Argo CD App Not Synced
           expr: |

--- a/roles/argocd/templates/values/10-registry.j2
+++ b/roles/argocd/templates/values/10-registry.j2
@@ -9,6 +9,6 @@ redis:
 
 {% if use_image_pull_secrets %}
 global:
-  imagePullSecrets: 
+  imagePullSecrets:
   - dso-config-pull-secret
 {% endif %}

--- a/roles/ca/tasks/additionals_ca.yaml
+++ b/roles/ca/tasks/additionals_ca.yaml
@@ -1,9 +1,9 @@
 ---
-- name: Set empty ca fact
+- name: Set empty CA fact
   ansible.builtin.set_fact:
     additionals_ca_pem_array: []
 
-- name: Get a ca resource
+- name: Get a CA resource
   ansible.builtin.include_tasks:
     file: get-ca.yaml
   with_items: "{{ dsc.additionalsCA }}"

--- a/roles/ca/tasks/additionals_ca.yaml
+++ b/roles/ca/tasks/additionals_ca.yaml
@@ -8,8 +8,8 @@
     file: get-ca.yaml
   with_items: "{{ dsc.additionalsCA }}"
   vars:
-    kind: "{{ item.kind }}"
-    name: "{{ item.name }}"
+    ca_kind: "{{ item.kind }}"
+    ca_name: "{{ item.name }}"
     key: "{{ item.key | default('') }}"
 
 - name: Set empty ca fact

--- a/roles/ca/tasks/get-ca.yaml
+++ b/roles/ca/tasks/get-ca.yaml
@@ -2,25 +2,25 @@
 - name: Get CA cert
   kubernetes.core.k8s_info:
     namespace: default
-    kind: "{{ kind }}"
-    name: "{{ name }}"
+    kind: "{{ ca_kind }}"
+    name: "{{ ca_name }}"
   register: ca_cert
 
 - name: Set ca fact (cm)
   ansible.builtin.set_fact:
     additionals_ca_pem_array: "{{ additionals_ca_pem_array + [ca_cert.resources[0].data[key]] }}"
-  when: kind == 'ConfigMap' and key | length != 0
+  when: ca_kind == 'ConfigMap' and key | length != 0
 
 - name: Set ca fact (secret)
   ansible.builtin.set_fact:
     additionals_ca_pem_array: "{{ additionals_ca_pem_array + [(ca_cert.resources[0].data[key] | b64decode)] }}"
-  when: kind == 'Secret' and key | length != 0
+  when: ca_kind == 'Secret' and key | length != 0
 
 - name: Set ca fact (cm)
   ansible.builtin.set_fact:
     additionals_ca_pem_array: "{{ additionals_ca_pem_array + [ca_cert.resources[0].data[resKey.key]] }}"
   loop: "{{ ca_cert.resources[0].data | dict2items }}"
-  when: kind == 'ConfigMap' and key | length == 0
+  when: ca_kind == 'ConfigMap' and key | length == 0
   loop_control:
     loop_var: resKey
 
@@ -28,6 +28,6 @@
   ansible.builtin.set_fact:
     additionals_ca_pem_array: "{{ additionals_ca_pem_array + [(ca_cert.resources[0].data[resKey.key] | b64decode)] }}"
   loop: "{{ ca_cert.resources[0].data | dict2items }}"
-  when: kind == 'Secret' and key | length == 0
+  when: ca_kind == 'Secret' and key | length == 0
   loop_control:
     loop_var: resKey

--- a/roles/cloudnativepg/templates/values/10-velero.j2
+++ b/roles/cloudnativepg/templates/values/10-velero.j2
@@ -1,5 +1,5 @@
 {% if dsc.global.backup.velero.enabled %}
 config:
   data:
-    INHERITED_ANNOTATIONS: "pre.hook.backup.velero.io/command, pre.hook.backup.velero.io/container, post.hook.backup.velero.io/command, post.hook.backup.velero.io/container, pre.hook.backup.velero.io/timeout, pre.hook.backup.velero.io/on-error, post.hook.backup.velero.io/timeout, post.hook.backup.velero.io/on-error"    
+    INHERITED_ANNOTATIONS: "pre.hook.backup.velero.io/command, pre.hook.backup.velero.io/container, post.hook.backup.velero.io/command, post.hook.backup.velero.io/container, pre.hook.backup.velero.io/timeout, pre.hook.backup.velero.io/on-error, post.hook.backup.velero.io/timeout, post.hook.backup.velero.io/on-error"
 {% endif %}

--- a/roles/cluster-offline/tasks/main.yml
+++ b/roles/cluster-offline/tasks/main.yml
@@ -1,30 +1,30 @@
 ---
 - name: Validate dsc.sonarqube.pluginDownloadUrl is not empty
-  assert:
+  ansible.builtin.assert:
     that:
       - dsc.sonarqube.pluginDownloadUrl != ""
     fail_msg: "'dsc.sonarqube.pluginDownloadUrl' must not be empty"
 
 - name: Validate dsc.sonarqube.prometheusJavaagentVersion is not empty
-  assert:
+  ansible.builtin.assert:
     that:
       - dsc.sonarqube.prometheusJavaagentVersion != ""
     fail_msg: "'dsc.sonarqube.prometheusJavaagentVersion' must not be empty"
 
 - name: Validate dsc.gitlabCatalog.catalogRepoUrl is different than default
-  assert:
+  ansible.builtin.assert:
     that:
       - dsc.gitlabCatalog.catalogRepoUrl != "https://github.com/cloud-pi-native/gitlab-ci-catalog.git"
     fail_msg: "'dsc.gitlabCatalog.catalogRepoUrl' is same as 'https://github.com/cloud-pi-native/gitlab-ci-catalog.git'"
 
 - name: Validate dsc.console.helmRepoUrl is different than default
-  assert:
+  ansible.builtin.assert:
     that:
       - dsc.console.helmRepoUrl != "https://cloud-pi-native.github.io/helm-charts"
     fail_msg: "'dsc.console.helmRepoUrl' is same as 'https://cloud-pi-native.github.io/helm-charts'"
 
 - name: Validate dsc.argocd.privateGitlabDomain is not empty
-  assert:
+  ansible.builtin.assert:
     that:
       - dsc.argocd.privateGitlabDomain != ""
     fail_msg: "'dsc.argocd.privateGitlabDomain' is empty"

--- a/roles/console-dso/tasks/main.yaml
+++ b/roles/console-dso/tasks/main.yaml
@@ -126,7 +126,7 @@
     combine_user_values: "{{ dsc.console['values'] }}"
     combine_dest_var: "console_values"
 
-- name: Apply app
+- name: Apply app (argoCD project)
   kubernetes.core.k8s:
     template: app.yaml.j2
 
@@ -155,7 +155,7 @@
         combine_user_values: "{{ dsc.console['values'] }}"
         combine_dest_var: "console_values"
 
-    - name: Apply app
+    - name: Apply app (argoCD project)
       kubernetes.core.k8s:
         template: app.yaml.j2
   when: first_console_deployment is defined

--- a/roles/console-dso/tasks/main.yaml
+++ b/roles/console-dso/tasks/main.yaml
@@ -130,11 +130,9 @@
   kubernetes.core.k8s:
     template: app.yaml.j2
 
-- block:
-    - name: Set first_console_deployment to "true"
-      ansible.builtin.set_fact:
-        first_console_deployment: true
-
+- name: First console deployment
+  when: pg_db_secret.resources[0].data.uri is undefined
+  block:
     - name: Get pg-cluster-console-app secret
       kubernetes.core.k8s_info:
         namespace: "{{ dsc.console.namespace }}"
@@ -144,9 +142,7 @@
       until: pg_db_secret.resources[0].data.uri is defined
       retries: 10
       delay: 5
-  when: pg_db_secret.resources[0].data.uri is undefined
 
-- block:
     - name: Compute Console Helm values
       ansible.builtin.include_role:
         name: combine
@@ -158,7 +154,6 @@
     - name: Apply app (argoCD project)
       kubernetes.core.k8s:
         template: app.yaml.j2
-  when: first_console_deployment is defined
 
 - name: Set alerting rules
   when: dsc.global.alerting.enabled

--- a/roles/console-dso/templates/app.yaml.j2
+++ b/roles/console-dso/templates/app.yaml.j2
@@ -10,7 +10,7 @@ spec:
     namespace: {{ dsc.console.namespace }}
     server: https://kubernetes.default.svc
   project: console-pi-native
-  source: 
+  source:
     chart: cpn-console
     repoURL: "{{ dsc.console.helmRepoUrl }}"
     targetRevision: {{ dsc.console.release }}

--- a/roles/console-dso/templates/values/10-registry.j2
+++ b/roles/console-dso/templates/values/10-registry.j2
@@ -15,6 +15,6 @@ postgres:
 
 {% if use_image_pull_secrets %}
 global:
-  imagePullSecrets: 
+  imagePullSecrets:
   - dso-config-pull-secret
 {% endif %}

--- a/roles/gitlab-catalog/tasks/main.yaml
+++ b/roles/gitlab-catalog/tasks/main.yaml
@@ -16,7 +16,7 @@
   ansible.builtin.git:
     repo: "{{ dsc.gitlabCatalog.catalogRepoUrl }}"
     dest: /tmp/test
-    bare: yes
+    bare: true
   environment:
     GIT_SSL_NO_VERIFY: "1"
 

--- a/roles/gitlab-ci-pipelines-exporter/tasks/main.yaml
+++ b/roles/gitlab-ci-pipelines-exporter/tasks/main.yaml
@@ -43,7 +43,7 @@
         combine_user_values: "{{ dsc.gitlabCiPipelinesExporter['values'] }}"
         combine_dest_var: "gl_ci_pipelines_exporter_values"
 
-    - name: Deploy GitLab CI Pilelines helm
+    - name: Deploy GitLab CI Pipelines helm
       kubernetes.core.helm:
         name: gitlab-ci-pipelines-exporter
         chart_ref: mvisonneau/gitlab-ci-pipelines-exporter

--- a/roles/gitlab-ci-pipelines-exporter/templates/values/00-main.j2
+++ b/roles/gitlab-ci-pipelines-exporter/templates/values/00-main.j2
@@ -3,7 +3,7 @@ config:
     url: https://{{ dsc.gitlab.subDomain }}{{ dsc.global.rootDomain }}
     token: {{ gitlab_token }}
   redis:
-    url: null 
+    url: null
   wildcards:
     - {}
 serviceMonitor :

--- a/roles/gitlab-runner/templates/values/00-main.j2
+++ b/roles/gitlab-runner/templates/values/00-main.j2
@@ -74,7 +74,7 @@ runners:
     {% endif %}
     {% if dsc.gitlabRunner.resources.overwrite.limits != 'none' %}
         memory_limit_overwrite_max_allowed = "{{ dsc.gitlabRunner.resources.overwrite.limits.cpu }}"
-        cpu_limit_overwrite_max_allowed = "{{ dsc.gitlabRunner.resources.overwrite.limits.memory }}"        
+        cpu_limit_overwrite_max_allowed = "{{ dsc.gitlabRunner.resources.overwrite.limits.memory }}"
     {% endif %}
   {% endif %}
 {% endif %}

--- a/roles/gitlab/tasks/add-servicemonitors.yaml
+++ b/roles/gitlab/tasks/add-servicemonitors.yaml
@@ -1,6 +1,6 @@
-- name: Get additionnal metrics endpoint port name
+- name: Get additional metrics endpoint port name
   ansible.builtin.set_fact:
-    additionnal_metrics_port_name: "{{ endpoints.resources
+    additional_metrics_port_name: "{{ endpoints.resources
       | selectattr('metadata.name', 'contains', item.name)
       | selectattr('metadata.name', 'contains', item.metrics_endpoint_name | default(item.name))
       | map(attribute='subsets') | first

--- a/roles/gitlab/tasks/main.yaml
+++ b/roles/gitlab/tasks/main.yaml
@@ -423,7 +423,7 @@
         namespace: "{{ dsc.gitlab.namespace }}"
       register: endpoints
 
-    - name: Declare some additionnal ServiceMonitors
+    - name: Declare some additional ServiceMonitors
       ansible.builtin.include_tasks:
         file: add-servicemonitors.yaml
       loop: "{{ gitlab_additional_service_monitors }}"

--- a/roles/gitlab/templates/npm_file.j2
+++ b/roles/gitlab/templates/npm_file.j2
@@ -1,4 +1,4 @@
-registry=https://registry.npmjs.org 
+registry=https://registry.npmjs.org
 registry=$${NEXUS_HOST_URL}/$${NEXUS_USERNAME}-npm
 //$${NEXUS_HOSTNAME}:username=$${NEXUS_USERNAME}
 //$${NEXUS_HOSTNAME}:_password="$${NEXUS_PASSWORD_B64}"

--- a/roles/gitlab/templates/pg-cluster-gitlab.yaml.j2
+++ b/roles/gitlab/templates/pg-cluster-gitlab.yaml.j2
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ dsc.gitlab.namespace }}
 {% if dsc.global.backup.velero.enabled %}
   annotations:
-    pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d  gitlabhq_production > /var/lib/postgresql/data/app.dump-${index}"]'
+    pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d gitlabhq_production > /var/lib/postgresql/data/app.dump-${index}"]'
     pre.hook.backup.velero.io/container: postgres
     pre.hook.backup.velero.io/on-error: Fail
     pre.hook.backup.velero.io/timeout: 90s

--- a/roles/gitlab/templates/podmonitor.yml.j2
+++ b/roles/gitlab/templates/podmonitor.yml.j2
@@ -14,7 +14,7 @@ spec:
       key: ""
     interval: 30s
     path: {{ item.path }}
-    port: {{ additionnal_metrics_port_name }}
+    port: {{ additional_metrics_port_name }}
   selector:
     matchLabels:
       app: {{ item.name }}

--- a/roles/gitlab/templates/servicemonitor.yml.j2
+++ b/roles/gitlab/templates/servicemonitor.yml.j2
@@ -9,7 +9,7 @@ spec:
       key: ""
     interval: 30s
     path: {{ item.path }}
-    port: {{ additionnal_metrics_port_name }}
+    port: {{ additional_metrics_port_name }}
   namespaceSelector: {}
   selector:
     matchLabels:

--- a/roles/gitlab/templates/values/10-registry.j2
+++ b/roles/gitlab/templates/values/10-registry.j2
@@ -79,6 +79,6 @@ redis:
 {% if use_image_pull_secrets %}
 global:
   image:
-    pullSecrets: 
+    pullSecrets:
     - name: dso-config-pull-secret
 {% endif %}

--- a/roles/grafana-dashboards/templates/gitlab-ci-pipelines-dashboard.yaml.j2
+++ b/roles/grafana-dashboards/templates/gitlab-ci-pipelines-dashboard.yaml.j2
@@ -504,7 +504,7 @@ spec:
               "instant": true,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "                                          {{project}} - {{ref}}",
+              "legendFormat": "{{project}} - {{ref}}",
               "refId": "A"
             }
           ],

--- a/roles/grafana-dashboards/templates/harbor-dashboard.yaml.j2
+++ b/roles/grafana-dashboards/templates/harbor-dashboard.yaml.j2
@@ -1323,7 +1323,7 @@ spec:
                       "refId": "A"
                   }
               ],
-              "title": "go allocated  memory",
+              "title": "go allocated memory",
               "type": "timeseries"
           },
           {

--- a/roles/grafana-dashboards/templates/keycloak-dashboard.yaml.j2
+++ b/roles/grafana-dashboards/templates/keycloak-dashboard.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  name: {{dsc_name}}-keycloak
+  name: {{ dsc_name }}-keycloak
   namespace: {{ dsc.grafana.namespace }}
 spec:
   datasources:
@@ -208,7 +208,7 @@ spec:
             "type": "datasource",
             "uid": "-- Mixed --"
           },
-          "description": "Displays  the \"recent cpu usage\" for the Java Virtual Machine process. This value is a double in the [0.0,1.0] interval. A value of 0.0 means that none of the CPUs were running threads from the JVM process during the recent period of time observed, while a value of 1.0 means that all CPUs were actively running threads from the JVM 100% of the time during the recent period being observed. Threads from the JVM include the application threads as well as the JVM internal threads. All values betweens 0.0 and 1.0 are possible depending of the activities going on in the JVM process and the whole system. If the Java Virtual Machine recent CPU usage is not available, the method returns a negative value.",
+          "description": "Displays the \"recent cpu usage\" for the Java Virtual Machine process. This value is a double in the [0.0,1.0] interval. A value of 0.0 means that none of the CPUs were running threads from the JVM process during the recent period of time observed, while a value of 1.0 means that all CPUs were actively running threads from the JVM 100% of the time during the recent period being observed. Threads from the JVM include the application threads as well as the JVM internal threads. All values betweens 0.0 and 1.0 are possible depending of the activities going on in the JVM process and the whole system. If the Java Virtual Machine recent CPU usage is not available, the method returns a negative value.",
           "fieldConfig": {
             "defaults": {
               "mappings": [],

--- a/roles/grafana-datasource/tasks/main.yaml
+++ b/roles/grafana-datasource/tasks/main.yaml
@@ -22,7 +22,7 @@
   ansible.builtin.fail:
     msg: "Missing Grafana instance. Please execute 'ansible-playbook install.yaml -t grafana' before trying to install the default datasource."
 
-- name: Manage missing defaut datasource URL
+- name: Manage missing default datasource URL
   when: dsc.grafanaDatasource.defaultPrometheusDatasourceUrl is not defined
   block:
     - name: Disclaimer when missing datasource URL in dsc

--- a/roles/grafana-operator/templates/values/00-main.j2
+++ b/roles/grafana-operator/templates/values/00-main.j2
@@ -28,7 +28,7 @@ image:
 
 # -- image pull secrets
 {% if use_image_pull_secrets %}
-imagePullSecrets: 
+imagePullSecrets:
 - name: dso-config-pull-secret
 {% else %}
 imagePullSecrets: []

--- a/roles/grafana/templates/grafana.yaml.j2
+++ b/roles/grafana/templates/grafana.yaml.j2
@@ -35,7 +35,7 @@ spec:
           - image: grafana/grafana:{{ dsc.grafana.imageVersion }}
             name: grafana
 {% if dsc.proxy.enabled %}
-            env: 
+            env:
             - name: HTTP_PROXY
               value: "{{ dsc.proxy.http_proxy }}"
             - name: HTTPS_PROXY
@@ -44,6 +44,6 @@ spec:
               value: "{{ dsc.proxy.no_proxy }}"
 {% endif %}
 {% if use_image_pull_secrets %}
-          imagePullSecrets: 
+          imagePullSecrets:
             - name: dso-config-pull-secret
 {% endif %}

--- a/roles/harbor/tasks/create_proxy_cache.yaml
+++ b/roles/harbor/tasks/create_proxy_cache.yaml
@@ -17,8 +17,8 @@
 - name: Create or Update registry
   vars:
     x_total_count_test: "{{ (result_registry.x_total_count | int) == 0 }}"
-    method: "{{ x_total_count_test | ternary('POST', 'PUT')  }}"
-    url_id_param: "{{ x_total_count_test | ternary('', result_registry.json[0].id)  }}"
+    method: "{{ x_total_count_test | ternary('POST', 'PUT') }}"
+    url_id_param: "{{ x_total_count_test | ternary('', result_registry.json[0].id) }}"
 
     # Harbor n'attend pas la même structure de paramètre pour une création ou une modification
     body_post:
@@ -38,11 +38,11 @@
       name: "{{ proxy_cache.name }}"
       type: "{{ proxy_cache.registry.provider }}"
       url: "{{ proxy_cache.registry.endpointUrl }}"
-    body: "{{ x_total_count_test | ternary(body_post, body_put)  }}"
+    body: "{{ x_total_count_test | ternary(body_post, body_put) }}"
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     method: "{{ method }}"
-    url: https://{{ harbor_domain }}/api/v2.0/registries/{{url_id_param}}
+    url: https://{{ harbor_domain }}/api/v2.0/registries/{{ url_id_param }}
     password: "{{ dsc.harbor.adminPassword }}"
     user: admin
     force_basic_auth: true
@@ -88,8 +88,8 @@
   vars:
     x_total_count_test: "{{ (result_project.x_total_count | int) == 0 }}"
     project_id: "{{ result_project.json[0].project_id | default('-1') }}"
-    method: "{{ x_total_count_test | ternary('POST', 'PUT')  }}"
-    url_id_param: "{{ x_total_count_test | ternary('', project_id)  }}"
+    method: "{{ x_total_count_test | ternary('POST', 'PUT') }}"
+    url_id_param: "{{ x_total_count_test | ternary('', project_id) }}"
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     method: "{{ method }}"

--- a/roles/harbor/tasks/create_proxy_cache.yaml
+++ b/roles/harbor/tasks/create_proxy_cache.yaml
@@ -1,5 +1,6 @@
 ---
-- debug:
+- name: Display proxy cache name
+  ansible.builtin.debug:
     msg: "Proxy cache: {{ proxy_cache.name }}"
 
 - name: Check if registry exists
@@ -75,12 +76,12 @@
   register: result_project
 
 - name: Debug result_project
-  debug:
+  ansible.builtin.debug:
     var: result_project
     verbosity: 1
 
 - name: Debug result_registry
-  debug:
+  ansible.builtin.debug:
     var: result_registry
     verbosity: 1
 
@@ -99,4 +100,4 @@
     force_basic_auth: true
     body_format: json
     status_code: [200, 201]
-    body: "{{ {'project_name': proxy_cache.name, 'metadata': {'public': 'true'},'storage_limit': -1,'registry_id': (result_registry.json[0].id | int)} }}"
+    body: "{{ {'project_name': proxy_cache.name, 'metadata': {'public': 'true'}, 'storage_limit': -1, 'registry_id': (result_registry.json[0].id | int)} }}"

--- a/roles/harbor/tasks/main.yaml
+++ b/roles/harbor/tasks/main.yaml
@@ -268,6 +268,7 @@
   when: get_trivy_schedule_config.json is undefined
 
 - name: Activate proxy cache
+  when: dsc.harbor.proxyCache is defined
   block:
     - name: Enable proxy cache for another registry loop
       ansible.builtin.include_tasks:
@@ -276,7 +277,6 @@
       loop_control:
         loop_var: proxy_cache
         label: "{{ proxy_cache.name }}"
-  when: dsc.harbor.proxyCache is defined
 
 - name: Set alerting rules
   when: dsc.global.alerting.enabled

--- a/roles/harbor/templates/pg-cluster-harbor.yaml.j2
+++ b/roles/harbor/templates/pg-cluster-harbor.yaml.j2
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ dsc.harbor.namespace }}
 {% if dsc.global.backup.velero.enabled %}
   annotations:
-    pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d  registry > /var/lib/postgresql/data/app.dump-${index}"]'
+    pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d registry > /var/lib/postgresql/data/app.dump-${index}"]'
     pre.hook.backup.velero.io/container: postgres
     pre.hook.backup.velero.io/on-error: Fail
     pre.hook.backup.velero.io/timeout: 90s

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -373,7 +373,7 @@
             state: present
           - name: ArgoCDAdmins
             state: present
-#        force: true  ## Ne fontionne pas quand user supprimé via la GUI et tâche relancée.
+#        force: true # Ne fonctionne pas quand user supprimé via l'interface graphique et tâche relancée.
 
 - name: Get dso keycloak client scopes from API
   ansible.builtin.uri:

--- a/roles/keycloak/templates/pg-cluster-keycloak.yaml.j2
+++ b/roles/keycloak/templates/pg-cluster-keycloak.yaml.j2
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ dsc.keycloak.namespace }}
 {% if dsc.global.backup.velero.enabled %}
   annotations:
-    pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d  keycloak > /var/lib/postgresql/data/app.dump-${index}"]'
+    pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d keycloak > /var/lib/postgresql/data/app.dump-${index}"]'
     pre.hook.backup.velero.io/container: postgres
     pre.hook.backup.velero.io/on-error: Fail
     pre.hook.backup.velero.io/timeout: 90s

--- a/roles/keycloak/templates/values/00-main.j2
+++ b/roles/keycloak/templates/values/00-main.j2
@@ -75,16 +75,16 @@ service:
     http: ""
     https: ""
   sessionAffinity: "None"
-  sessionAffinityConfig: 
+  sessionAffinityConfig:
   clusterIP: ""
   loadBalancerIP: ""
   loadBalancerSourceRanges: []
   externalTrafficPolicy: "Cluster"
-  annotations: 
+  annotations:
   extraPorts: []
   extraHeadlessPorts: []
   headless:
-    annotations: 
+    annotations:
     extraPorts: []
 
 ingress:
@@ -100,7 +100,7 @@ ingress:
     {{ key }}: "{{ val }}"
 {% endfor %}
     route.openshift.io/termination: "edge"
-  labels: 
+  labels:
     app: "keycloak"
 {% for key, val in dsc.ingress.labels.items() %}
     {{ key }}: "{{ val }}"

--- a/roles/keycloak/templates/values/10-registry.j2
+++ b/roles/keycloak/templates/values/10-registry.j2
@@ -5,6 +5,6 @@ image:
 
 {% if use_image_pull_secrets %}
 global:
-  imagePullSecrets: 
+  imagePullSecrets:
   - dso-config-pull-secret
 {% endif %}

--- a/roles/kyverno/templates/cis.yml.j2
+++ b/roles/kyverno/templates/cis.yml.j2
@@ -31,7 +31,7 @@ spec:
           - Job
           namespaces:
           - "dso-*"
-          names: 
+          names:
           - "pg-cluster-*"
     mutate:
       patchStrategicMerge:
@@ -94,7 +94,7 @@ spec:
           - Job
           namespaces:
           - "{{ dsc.keycloak.namespace }}"
-          names: 
+          names:
           - "pg-cluster-*"
     mutate:
       patchStrategicMerge:
@@ -136,7 +136,7 @@ metadata:
     pod-policies.kyverno.io/autogen-controllers: none
     policies.kyverno.io/category: Prod
     policies.kyverno.io/severity: medium
-    policies.kyverno.io/subject: Pod 
+    policies.kyverno.io/subject: Pod
 spec:
   validationFailureAction: Enforce
 spec:
@@ -148,7 +148,7 @@ spec:
         - Pod
         namespaces:
         - "{{ dsc.gitlab.namespace }}"
-        names: 
+        names:
         - "runner-*"
     mutate:
       patchStrategicMerge:
@@ -222,7 +222,7 @@ spec:
           - Job
           namespaces:
           - "{{ dsc.gitlab.namespace }}"
-          names: 
+          names:
           - "pg-cluster-*"
           - "gitlab-shared-secrets-*-selfsign"
     mutate:
@@ -274,7 +274,7 @@ spec:
         - Job
         namespaces:
         - "{{ dsc.gitlab.namespace }}"
-        names: 
+        names:
         - "gitlab-shared-secrets-*-selfsign"
     mutate:
       patchStrategicMerge:
@@ -337,7 +337,7 @@ spec:
           - Job
           namespaces:
           - "dso-*"
-          names: 
+          names:
           - "pg-cluster-*"
     mutate:
       patchStrategicMerge:
@@ -400,7 +400,7 @@ spec:
           - Job
           namespaces:
           - "dso-*"
-          names: 
+          names:
           - "pg-cluster-*"
     mutate:
       patchStrategicMerge:
@@ -463,7 +463,7 @@ spec:
           - Job
           namespaces:
           - "dso-*"
-          names: 
+          names:
           - "pg-cluster-*"
     preconditions:
       any:
@@ -519,9 +519,9 @@ spec:
       resources:
         kinds:
         - Job
-        names: 
+        names:
         - "gitlab-minio-create-buckets-*"
-        namespaces: 
+        namespaces:
         - "{{ dsc.gitlab.namespace }}"
     mutate:
       patchStrategicMerge:

--- a/roles/kyverno/templates/exposedCA.yml.j2
+++ b/roles/kyverno/templates/exposedCA.yml.j2
@@ -7,7 +7,7 @@ metadata:
     pod-policies.kyverno.io/autogen-controllers: none
     policies.kyverno.io/category: Prod
     policies.kyverno.io/severity: medium
-    policies.kyverno.io/subject: Pod 
+    policies.kyverno.io/subject: Pod
 spec:
   validationFailureAction: Enforce
 spec:
@@ -19,7 +19,7 @@ spec:
         - Pod
         namespaces:
         - "{{ dsc.gitlab.namespace }}"
-        names: 
+        names:
         - "runner-*"
     mutate:
       patchStrategicMerge:
@@ -64,7 +64,7 @@ spec:
         - StatefulSet
         namespaces:
         - "{{ dsc.vault.namespace }}"
-        names: 
+        names:
         - "conf-dso-vault"
     mutate:
       patchStrategicMerge:

--- a/roles/kyverno/templates/prometheusrule.yml.j2
+++ b/roles/kyverno/templates/prometheusrule.yml.j2
@@ -9,10 +9,10 @@ spec:
   groups:
   - name: Kyverno
     rules:
-    - alert: Kyverno admission controler not available
+    - alert: Kyverno admission controller not available
       annotations:
-        message: Kyverno admission controler in namespace {{ dsc.kyverno.namespace }} has not been available for the last 5 minutes.
-        summary: Kyverno admission controler down (no ready pod)"
+        message: Kyverno admission controller in namespace {{ dsc.kyverno.namespace }} has not been available for the last 5 minutes.
+        summary: Kyverno admission controller down (no ready pod)"
       expr: |
         sum(kube_pod_status_ready{
         pod=~"kyverno-admission-controller-.*",
@@ -21,10 +21,10 @@ spec:
       for: 1m
       labels:
         severity: critical
-    - alert: Kyverno background controler not available
+    - alert: Kyverno background controller not available
       annotations:
-        message: Kyverno background controler in namespace {{ dsc.kyverno.namespace }} has not been available for the last 5 minutes.
-        summary: Kyverno background controler down (no ready pod)"
+        message: Kyverno background controller in namespace {{ dsc.kyverno.namespace }} has not been available for the last 5 minutes.
+        summary: Kyverno background controller down (no ready pod)"
       expr: |
         sum(kube_pod_status_ready{
         pod=~"kyverno-background-controller-.*",

--- a/roles/kyverno/templates/replace-kubed.yml.j2
+++ b/roles/kyverno/templates/replace-kubed.yml.j2
@@ -12,10 +12,10 @@ metadata:
     policies.kyverno.io/minversion: 1.10.0
     kyverno.io/kubernetes-version: "1.23"
     policies.kyverno.io/description: >-
-      Secrets and Configmap like registry credentials, certificates often need 
-      to exist in multiple Namespaces so Pods there have access. Manually 
-      duplicating those Secrets and Configmap is time consuming and error prone. 
-      This policy will copy a Secret and Configmap with label kyverno.io/sync.   
+      Secrets and Configmap like registry credentials, certificates often need
+      to exist in multiple Namespaces so Pods there have access. Manually
+      duplicating those Secrets and Configmap is time consuming and error prone.
+      This policy will copy a Secret and Configmap with label kyverno.io/sync.
 spec:
   validationFailureAction: Enforce
   generateExisting: true
@@ -40,7 +40,7 @@ spec:
           - {{ dsc.kyverno.namespace }}
     generate:
 {% raw %}
-      namespace: "{{request.object.metadata.name}}"
+      namespace: "{{ request.object.metadata.name }}"
 {% endraw %}
       synchronize: true # Cascading deletion form the parent
       cloneList:

--- a/roles/metrics/grafana/change-prom-user.sh
+++ b/roles/metrics/grafana/change-prom-user.sh
@@ -3,7 +3,7 @@
 oc project openshift-monitoring
 oc get secret prometheus-k8s-htpasswd -o jsonpath='{.data.auth}' | base64 -d > /tmp/htpasswd-tmp
 echo "" >> /tmp/htpasswd-tmp
-htpasswd -s -b  /tmp/htpasswd-tmp grafana-user mysupersecretpasswd
+htpasswd -s -b /tmp/htpasswd-tmp grafana-user mysupersecretpasswd
 oc patch secret prometheus-k8s-htpasswd -p "{\"data\":{\"auth\":\"$(base64 -w0 /tmp/htpasswd-tmp)\"}}"
 oc delete pods -l app=prometheus
 sleep 5

--- a/roles/metrics/grafana/install-metrics.sh
+++ b/roles/metrics/grafana/install-metrics.sh
@@ -7,7 +7,7 @@ kubectl apply -f 1-subscription.yaml
 oc project openshift-monitoring
 oc get secret prometheus-k8s-htpasswd -o jsonpath='{.data.auth}' | base64 -d > /tmp/htpasswd-tmp
 echo "" >> /tmp/htpasswd-tmp
-htpasswd -s -b  /tmp/htpasswd-tmp grafana-user mysupersecretpasswd
+htpasswd -s -b /tmp/htpasswd-tmp grafana-user mysupersecretpasswd
 oc patch secret prometheus-k8s-htpasswd -p "{\"data\":{\"auth\":\"$(base64 -w0 /tmp/htpasswd-tmp)\"}}"
 oc delete pods -l app=prometheus
 sleep 5

--- a/roles/nexus/tasks/check-nexus-tasks.yaml
+++ b/roles/nexus/tasks/check-nexus-tasks.yaml
@@ -20,7 +20,7 @@
       | selectattr('name', 'equalto', 'Clean Docker uploads')
       | map(attribute='name') | first | default('missing') }}"
 
-- name: Set Compact_Blob_Stores_task fact
+- name: Set Compact_DSO_Blob_Store_task fact
   ansible.builtin.set_fact:
     Compact_DSO_Blob_Store_task: "{{ nexus_tasks.json['items']
       | selectattr('name', 'equalto', 'Compact DSO Blob Store')

--- a/roles/nexus/tasks/manage-nexus-tasks.yaml
+++ b/roles/nexus/tasks/manage-nexus-tasks.yaml
@@ -6,11 +6,11 @@
     method: GET
     user: admin
     password: "{{ nexus_admin_password }}"
-  register: Clean_Docker_unused_stuff_task_script
+  register: clean_docker_unused_stuff_task_script
   ignore_errors: true
 
 - name: Add Clean_Docker_unused_stuff_task script
-  when: Clean_Docker_unused_stuff_task_script.status != 200
+  when: clean_docker_unused_stuff_task_script.status != 200
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     force_basic_auth: true

--- a/roles/nexus/templates/nexus.yml.j2
+++ b/roles/nexus/templates/nexus.yml.j2
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: {{ dsc.nexus.namespace }}
-  name: nexus  # Sets Deployment name
+  name: nexus # Sets Deployment name
 spec:
   replicas: 1
   strategy:
@@ -19,7 +19,7 @@ spec:
 {% if dsc.global.platform == "kubernetes" %}
       securityContext:
         runAsNonRoot: true
-        runAsGroup: 200 
+        runAsGroup: 200
         runAsUser: 200
         fsGroup: 200
 {% endif %}
@@ -36,8 +36,8 @@ spec:
 {% endif %}
           imagePullPolicy: "IfNotPresent"
           ports:
-            - containerPort: 8081  # Exposes container port
-            - containerPort: 5000  # Exposes container port
+            - containerPort: 8081 # Exposes container port
+            - containerPort: 5000 # Exposes container port
           volumeMounts:
             - mountPath: /nexus-data
               name: nexus-data-volume

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -136,8 +136,8 @@ spec:
                     values:
                       description: |
                         You can add custom values for argocd, they will be merged with roles/argocd/templates/values/
-                        See: https://github.com/argoproj/argo-helm/tree/main/charts/argo-cd
-                        And: https://github.com/argoproj/argo-helm/tree/main/charts/argo-cd/values.yaml
+                        ttps://github.com/argoproj/argo-helm/tree/main/charts/argo-cd
+                        https://github.com/argoproj/argo-helm/tree/main/charts/argo-cd/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     privateGitlabDomain:
@@ -165,8 +165,8 @@ spec:
                     values:
                       description: |
                         You can add custom values for cert-manager, they will be merged with roles/cert-manager/templates/values/
-                        See: https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg
-                        And: https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
+                        ttps://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg
+                        https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
@@ -192,8 +192,8 @@ spec:
                     values:
                       description: |
                         You can add custom values for CloudNativePG, they will be merged with roles/cloudnativepg/templates/values/
-                        See: https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg
-                        And: https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/values.yaml
+                        ttps://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg
+                        https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
@@ -226,7 +226,7 @@ spec:
                         the pg_wal directory at checkpoint time.
                         Default is -1, meaning that replication slots may retain an unlimited amount
                         of WAL files. You can for instance set it to "9GB".
-                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        ttps://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
                         Refer to postgresql.conf for memory units.
                       type: string
                     postgresWalPvcSize:
@@ -256,7 +256,7 @@ spec:
                           description: |
                             Connection parameters used for replication, it should contain
                             'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
-                            See: https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
+                            ttps://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
                   type: object
                 gitlab:
@@ -277,8 +277,8 @@ spec:
                     values:
                       description: |
                         You can add custom values for gitlab, they will be merged with roles/gitlab/templates/values/
-                        See: https://docs.gitlab.com/charts/charts/globals.html
-                        And: https://gitlab.com/gitlab-org/charts/gitlab/-/blob/master/values.yaml
+                        ttps://docs.gitlab.com/charts/charts/globals.html
+                        https://gitlab.com/gitlab-org/charts/gitlab/-/blob/master/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     insecureCI:
@@ -321,7 +321,7 @@ spec:
                         the pg_wal directory at checkpoint time.
                         Default is -1, meaning that replication slots may retain an unlimited amount
                         of WAL files. You can for instance set it to "9GB".
-                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        ttps://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
                         Refer to postgresql.conf for memory units.
                       type: string
                     postgresWalPvcSize:
@@ -351,7 +351,7 @@ spec:
                           description: |
                             Connection parameters used for replication, it should contain
                             'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
-                            See: https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
+                            ttps://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
                   type: object
                 gitlabCiPipelinesExporter:
@@ -367,8 +367,8 @@ spec:
                       description: |
                         You can add custom values for gitLab-ci-pipelines-exporter, they will be
                         merged with roles/gitlab-ci-pipelines-exporter/templates/values/
-                        See: https://github.com/mvisonneau/helm-charts/blob/main/charts/gitlab-ci-pipelines-exporter
-                        And: https://github.com/mvisonneau/helm-charts/blob/main/charts/gitlab-ci-pipelines-exporter/values.yaml
+                        ttps://github.com/mvisonneau/helm-charts/blob/main/charts/gitlab-ci-pipelines-exporter
+                        https://github.com/mvisonneau/helm-charts/blob/main/charts/gitlab-ci-pipelines-exporter/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
@@ -394,8 +394,8 @@ spec:
                     values:
                       description: |
                         You can add custom values for GitLab Operator, they will be merged with roles/gitlab-operator/templates/values/
-                        See: https://docs.gitlab.com/operator/
-                        And: https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/blob/master/deploy/chart/values.yaml
+                        ttps://docs.gitlab.com/operator/
+                        https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/blob/master/deploy/chart/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
@@ -467,8 +467,8 @@ spec:
                     values:
                       description: |
                         You can add custom values for GitLab Runner, they will be merged with roles/gitlab-runner/templates/values/
-                        See: https://docs.gitlab.com/runner/
-                        And: https://gitlab.com/gitlab-org/cloud-native/distroless/gitlab-runner
+                        ttps://docs.gitlab.com/runner/
+                        https://gitlab.com/gitlab-org/cloud-native/distroless/gitlab-runner
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
@@ -708,8 +708,8 @@ spec:
                       description: |
                         You can add custom values for Grafana Operator,
                         they will be merged with roles/grafana-operator/templates/values/
-                        See: https://grafana.github.io/grafana-operator/docs/installation/helm/#values
-                        And: https://github.com/grafana/grafana-operator/tree/master/deploy/helm/grafana-operator
+                        ttps://grafana.github.io/grafana-operator/docs/installation/helm/#values
+                        https://github.com/grafana/grafana-operator/tree/master/deploy/helm/grafana-operator
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
@@ -760,7 +760,7 @@ spec:
                             type: object
                             properties:
                               provider:
-                                description: Specifies the registry provider. Default: docker-hub
+                                description: Specifies the registry provider. Default is docker-hub.
                                 type: string
                                 default: docker-hub
                               endpointUrl:
@@ -768,7 +768,7 @@ spec:
                                 type: string
                                 default: ""
                               insecure:
-                                description: Allows insecure connections. Default: false
+                                description: Allows insecure connections. Default is false.
                                 default: false
                                 type: boolean
                               credential:
@@ -791,8 +791,8 @@ spec:
                     values:
                       description: |
                         You can add custom values for harbor, they will be merged with roles/harbor/templates/values/
-                        See: https://github.com/goharbor/harbor-helm
-                        And: https://github.com/goharbor/harbor-helm/blob/main/values.yaml
+                        ttps://github.com/goharbor/harbor-helm
+                        https://github.com/goharbor/harbor-helm/blob/main/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     postgresPvcSize:
@@ -805,7 +805,7 @@ spec:
                         the pg_wal directory at checkpoint time.
                         Default is -1, meaning that replication slots may retain an unlimited amount
                         of WAL files. You can for instance set it to "9GB".
-                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        ttps://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
                         Refer to postgresql.conf for memory units.
                       type: string
                     postgresWalPvcSize:
@@ -835,7 +835,7 @@ spec:
                           description: |
                             Connection parameters used for replication, it should contain
                             'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
-                            See: https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
+                            ttps://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
                   required:
                     - adminPassword
@@ -870,10 +870,10 @@ spec:
                               description: |
                                 Let's Encrypt environment to use for issuing certificates:
                                 - production : Use this value for production ready certificates.
-                                  Beware of rate limits. See: https://letsencrypt.org/docs/rate-limits/
+                                  Beware of rate limits. See: https://letsencrypt.org/docs/rate-limits/
                                 - staging : Use this value for testing purposes. It has significantly higher
                                   rate limits. Beware of root certificates.
-                                  See: https://letsencrypt.org/docs/staging-environment/
+                                  See: https://letsencrypt.org/docs/staging-environment/
                               enum:
                                 - production
                                 - staging
@@ -955,7 +955,7 @@ spec:
                         the pg_wal directory at checkpoint time.
                         Default is -1, meaning that replication slots may retain an unlimited amount
                         of WAL files. You can for instance set it to "9GB".
-                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        ttps://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
                         Refer to postgresql.conf for memory units.
                       type: string
                     postgresWalPvcSize:
@@ -967,8 +967,8 @@ spec:
                     values:
                       description: |
                         You can add custom values for keycloak, they will be merged with roles/keycloak/templates/values/
-                        See: https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-                        And: https://github.com/bitnami/charts/blob/main/bitnami/keycloak/values.yaml
+                        ttps://github.com/bitnami/charts/tree/main/bitnami/keycloak
+                        https://github.com/bitnami/charts/blob/main/bitnami/keycloak/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     cnpg:
@@ -995,7 +995,7 @@ spec:
                           description: |
                             Connection parameters used for replication, it should contain
                             'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
-                            See: https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
+                            ttps://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
                   type: object
                 kyverno:
@@ -1020,8 +1020,8 @@ spec:
                     values:
                       description: |
                         You can add custom values for Kyverno, they will be merged with roles/kyverno/templates/values/
-                        See: https://github.com/kyverno/kyverno/blob/main/charts/kyverno
-                        And: https://github.com/kyverno/kyverno/blob/main/charts/kyverno/values.yaml
+                        ttps://github.com/kyverno/kyverno/blob/main/charts/kyverno
+                        https://github.com/kyverno/kyverno/blob/main/charts/kyverno/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
@@ -1078,16 +1078,16 @@ spec:
                       description: Distant proxy ip/hostname.
                       type: string
                     http_proxy:
-                      description: URL for http traffic. Format: http://<host>:<port>/
+                      description: URL for http traffic. Format http://<host>:<port>/
                       type: string
                     https_proxy:
-                      description: URL for https traffic. Format: http://<host>:<port>/
+                      description: URL for https traffic. Format http://<host>:<port>/
                       type: string
                     no_proxy:
                       default: .cluster.local,.svc,10.0.0.0/8,127.0.0.1,192.168.0.0/16,localhost,svc.cluster.local,localdomain
                       description: |
                         Networks destination excluded by the proxy. Not so easy to configure.
-                        Default: .cluster.local,.svc,10.0.0.0/8,127.0.0.1,192.168.0.0/16,localhost,svc.cluster.local,localdomain
+                        Default is .cluster.local,.svc,10.0.0.0/8,127.0.0.1,192.168.0.0/16,localhost,svc.cluster.local,localdomain
                       type: string
                     port:
                       description: Distant proxy port listening.
@@ -1120,7 +1120,7 @@ spec:
                         the pg_wal directory at checkpoint time.
                         Default is -1, meaning that replication slots may retain an unlimited amount
                         of WAL files. You can for instance set it to "9GB".
-                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        ttps://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
                         Refer to postgresql.conf for memory units.
                       type: string
                     postgresWalPvcSize:
@@ -1135,8 +1135,8 @@ spec:
                     values:
                       description: |
                         You can add custom values for sonarqube, they will be merged with roles/sonarqube/templates/values/
-                        See: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
-                        And: https://github.com/SonarSource/helm-chart-sonarqube/blob/master/charts/sonarqube/values.yaml
+                        ttps://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
+                        https://github.com/SonarSource/helm-chart-sonarqube/blob/master/charts/sonarqube/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     cnpg:
@@ -1163,7 +1163,7 @@ spec:
                           description: |
                             Connection parameters used for replication, it should contain
                             'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
-                            See: https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
+                            ttps://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
                   type: object
                 vault:
@@ -1187,8 +1187,8 @@ spec:
                     values:
                       description: |
                         You can add custom values for vault, they will be merged with roles/vault/templates/values/
-                        See: https://developer.hashicorp.com/vault/docs/platform/k8s/helm
-                        And: https://github.com/hashicorp/vault-helm/blob/main/values.yaml
+                        ttps://developer.hashicorp.com/vault/docs/platform/k8s/helm
+                        https://github.com/hashicorp/vault-helm/blob/main/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -235,7 +235,7 @@ spec:
                       type: object
                       properties:
                         mode:
-                          description: Determines whether cnpg clusters should be deployed with as a primary cluster (initb from scratch) or replica cluster (initdb from external source).
+                          description: Determines whether cnpg clusters should be deployed with as a primary cluster (initdb from scratch) or replica cluster (initdb from external source).
                           default: primary
                           type: string
                           enum:
@@ -243,7 +243,7 @@ spec:
                             - replica
                             - restore
                         exposed:
-                          description: Whether or not the cnpg cluster shoul be exposed via NodePort.
+                          description: Whether or not the cnpg cluster should be exposed via NodePort.
                           type: boolean
                           default: false
                         nodePort:
@@ -325,7 +325,7 @@ spec:
                       type: object
                       properties:
                         mode:
-                          description: Determines whether cnpg clusters should be deployed with as a primary cluster (initb from scratch) or replica cluster (initdb from external source).
+                          description: Determines whether cnpg clusters should be deployed with as a primary cluster (initdb from scratch) or replica cluster (initdb from external source).
                           default: primary
                           type: string
                           enum:
@@ -333,7 +333,7 @@ spec:
                             - replica
                             - restore
                         exposed:
-                          description: Whether or not the cnpg cluster shoul be exposed via NodePort.
+                          description: Whether or not the cnpg cluster should be exposed via NodePort.
                           type: boolean
                           default: false
                         nodePort:
@@ -480,8 +480,8 @@ spec:
                       minItems: 1
                       type: array
                     rootDomain:
-                      description: The top level of your domain. To expose Argo as "argo.mycompany.com",
-                        the value should be ".mycompany.com" (notice the leading dot).
+                      description: The top level of your domain. To expose Argo as "argo.example.com",
+                        the value should be ".example.com" (notice the leading dot).
                       type: string
                       default: .example.com
                       pattern: "^\\..*$"
@@ -493,7 +493,7 @@ spec:
                           description: Specifies whether metrics should be enabled.
                           type: boolean
                         additionalLabels:
-                          description: Adds aditionnal labels if needed, when metrics are enabled
+                          description: Adds additional labels if needed, when metrics are enabled
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                       required:
@@ -799,7 +799,7 @@ spec:
                       type: object
                       properties:
                         mode:
-                          description: Determines whether cnpg clusters should be deployed with as a primary cluster (initb from scratch) or replica cluster (initdb from external source).
+                          description: Determines whether cnpg clusters should be deployed with as a primary cluster (initdb from scratch) or replica cluster (initdb from external source).
                           default: primary
                           type: string
                           enum:
@@ -807,7 +807,7 @@ spec:
                             - replica
                             - restore
                         exposed:
-                          description: Whether or not the cnpg cluster shoul be exposed via NodePort.
+                          description: Whether or not the cnpg cluster should be exposed via NodePort.
                           type: boolean
                           default: false
                         nodePort:
@@ -826,7 +826,7 @@ spec:
                     annotations:
                       x-kubernetes-preserve-unknown-fields: true
                       default: {}
-                      description: Additionals annotations to add to all tools' ingresses
+                      description: Additional annotations to add to all tools' ingresses
                       type: object
                     className:
                       description: Ingress class name to use for all ingresses
@@ -834,13 +834,13 @@ spec:
                     labels:
                       x-kubernetes-preserve-unknown-fields: true
                       default: {}
-                      description: Additionals labels to add to all tools' ingresses
+                      description: Additional labels to add to all tools' ingresses
                       type: object
                     tls:
                       description: TLS configuration for ingresses.
                       properties:
                         acme:
-                          description: acme/let'sencrypt configuration, only http challenge
+                          description: acme/Let'sEncrypt configuration, only http challenge
                           properties:
                             email:
                               description: User email used for ACME
@@ -953,7 +953,7 @@ spec:
                       type: object
                       properties:
                         mode:
-                          description: Determines whether cnpg clusters should be deployed with as a primary cluster (initb from scratch) or replica cluster (initdb from external source).
+                          description: Determines whether cnpg clusters should be deployed with as a primary cluster (initdb from scratch) or replica cluster (initdb from external source).
                           default: primary
                           type: string
                           enum:
@@ -961,7 +961,7 @@ spec:
                             - replica
                             - restore
                         exposed:
-                          description: Whether or not the cnpg cluster shoul be exposed via NodePort.
+                          description: Whether or not the cnpg cluster should be exposed via NodePort.
                           type: boolean
                           default: false
                         nodePort:
@@ -1061,7 +1061,7 @@ spec:
                         so easy to configure. \nExample: .cluster.local,.svc,10.0.0.0/8,127.0.0.1,192.168.0.0/16,localhost,svc.cluster.local,localdomain\n"
                       type: string
                     port:
-                      description: Distant proxy port listenning
+                      description: Distant proxy port listening
                       type: string
                   required:
                     - enabled
@@ -1113,7 +1113,7 @@ spec:
                       type: object
                       properties:
                         mode:
-                          description: Determines whether cnpg clusters should be deployed with as a primary cluster (initb from scratch) or replica cluster (initdb from external source).
+                          description: Determines whether cnpg clusters should be deployed with as a primary cluster (initdb from scratch) or replica cluster (initdb from external source).
                           default: primary
                           type: string
                           enum:
@@ -1121,7 +1121,7 @@ spec:
                             - replica
                             - restore
                         exposed:
-                          description: Whether or not the cnpg cluster shoul be exposed via NodePort.
+                          description: Whether or not the cnpg cluster should be exposed via NodePort.
                           type: boolean
                           default: false
                         nodePort:

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -136,7 +136,7 @@ spec:
                     values:
                       description: |
                         You can add custom values for argocd, they will be merged with roles/argocd/templates/values/
-                        ttps://github.com/argoproj/argo-helm/tree/main/charts/argo-cd
+                        https://github.com/argoproj/argo-helm/tree/main/charts/argo-cd
                         https://github.com/argoproj/argo-helm/tree/main/charts/argo-cd/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -165,7 +165,7 @@ spec:
                     values:
                       description: |
                         You can add custom values for cert-manager, they will be merged with roles/cert-manager/templates/values/
-                        ttps://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg
+                        https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg
                         https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -192,7 +192,7 @@ spec:
                     values:
                       description: |
                         You can add custom values for CloudNativePG, they will be merged with roles/cloudnativepg/templates/values/
-                        ttps://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg
+                        https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg
                         https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -226,7 +226,7 @@ spec:
                         the pg_wal directory at checkpoint time.
                         Default is -1, meaning that replication slots may retain an unlimited amount
                         of WAL files. You can for instance set it to "9GB".
-                        ttps://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
                         Refer to postgresql.conf for memory units.
                       type: string
                     postgresWalPvcSize:
@@ -256,7 +256,7 @@ spec:
                           description: |
                             Connection parameters used for replication, it should contain
                             'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
-                            ttps://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
+                            https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
                   type: object
                 gitlab:
@@ -277,7 +277,7 @@ spec:
                     values:
                       description: |
                         You can add custom values for gitlab, they will be merged with roles/gitlab/templates/values/
-                        ttps://docs.gitlab.com/charts/charts/globals.html
+                        https://docs.gitlab.com/charts/charts/globals.html
                         https://gitlab.com/gitlab-org/charts/gitlab/-/blob/master/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -321,7 +321,7 @@ spec:
                         the pg_wal directory at checkpoint time.
                         Default is -1, meaning that replication slots may retain an unlimited amount
                         of WAL files. You can for instance set it to "9GB".
-                        ttps://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
                         Refer to postgresql.conf for memory units.
                       type: string
                     postgresWalPvcSize:
@@ -351,7 +351,7 @@ spec:
                           description: |
                             Connection parameters used for replication, it should contain
                             'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
-                            ttps://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
+                            https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
                   type: object
                 gitlabCiPipelinesExporter:
@@ -367,7 +367,7 @@ spec:
                       description: |
                         You can add custom values for gitLab-ci-pipelines-exporter, they will be
                         merged with roles/gitlab-ci-pipelines-exporter/templates/values/
-                        ttps://github.com/mvisonneau/helm-charts/blob/main/charts/gitlab-ci-pipelines-exporter
+                        https://github.com/mvisonneau/helm-charts/blob/main/charts/gitlab-ci-pipelines-exporter
                         https://github.com/mvisonneau/helm-charts/blob/main/charts/gitlab-ci-pipelines-exporter/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -394,7 +394,7 @@ spec:
                     values:
                       description: |
                         You can add custom values for GitLab Operator, they will be merged with roles/gitlab-operator/templates/values/
-                        ttps://docs.gitlab.com/operator/
+                        https://docs.gitlab.com/operator/
                         https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/blob/master/deploy/chart/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -467,7 +467,7 @@ spec:
                     values:
                       description: |
                         You can add custom values for GitLab Runner, they will be merged with roles/gitlab-runner/templates/values/
-                        ttps://docs.gitlab.com/runner/
+                        https://docs.gitlab.com/runner/
                         https://gitlab.com/gitlab-org/cloud-native/distroless/gitlab-runner
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -708,7 +708,7 @@ spec:
                       description: |
                         You can add custom values for Grafana Operator,
                         they will be merged with roles/grafana-operator/templates/values/
-                        ttps://grafana.github.io/grafana-operator/docs/installation/helm/#values
+                        https://grafana.github.io/grafana-operator/docs/installation/helm/#values
                         https://github.com/grafana/grafana-operator/tree/master/deploy/helm/grafana-operator
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -791,7 +791,7 @@ spec:
                     values:
                       description: |
                         You can add custom values for harbor, they will be merged with roles/harbor/templates/values/
-                        ttps://github.com/goharbor/harbor-helm
+                        https://github.com/goharbor/harbor-helm
                         https://github.com/goharbor/harbor-helm/blob/main/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -805,7 +805,7 @@ spec:
                         the pg_wal directory at checkpoint time.
                         Default is -1, meaning that replication slots may retain an unlimited amount
                         of WAL files. You can for instance set it to "9GB".
-                        ttps://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
                         Refer to postgresql.conf for memory units.
                       type: string
                     postgresWalPvcSize:
@@ -835,7 +835,7 @@ spec:
                           description: |
                             Connection parameters used for replication, it should contain
                             'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
-                            ttps://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
+                            https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
                   required:
                     - adminPassword
@@ -955,7 +955,7 @@ spec:
                         the pg_wal directory at checkpoint time.
                         Default is -1, meaning that replication slots may retain an unlimited amount
                         of WAL files. You can for instance set it to "9GB".
-                        ttps://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
                         Refer to postgresql.conf for memory units.
                       type: string
                     postgresWalPvcSize:
@@ -967,7 +967,7 @@ spec:
                     values:
                       description: |
                         You can add custom values for keycloak, they will be merged with roles/keycloak/templates/values/
-                        ttps://github.com/bitnami/charts/tree/main/bitnami/keycloak
+                        https://github.com/bitnami/charts/tree/main/bitnami/keycloak
                         https://github.com/bitnami/charts/blob/main/bitnami/keycloak/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -995,7 +995,7 @@ spec:
                           description: |
                             Connection parameters used for replication, it should contain
                             'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
-                            ttps://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
+                            https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
                   type: object
                 kyverno:
@@ -1020,7 +1020,7 @@ spec:
                     values:
                       description: |
                         You can add custom values for Kyverno, they will be merged with roles/kyverno/templates/values/
-                        ttps://github.com/kyverno/kyverno/blob/main/charts/kyverno
+                        https://github.com/kyverno/kyverno/blob/main/charts/kyverno
                         https://github.com/kyverno/kyverno/blob/main/charts/kyverno/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -1120,7 +1120,7 @@ spec:
                         the pg_wal directory at checkpoint time.
                         Default is -1, meaning that replication slots may retain an unlimited amount
                         of WAL files. You can for instance set it to "9GB".
-                        ttps://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
                         Refer to postgresql.conf for memory units.
                       type: string
                     postgresWalPvcSize:
@@ -1135,7 +1135,7 @@ spec:
                     values:
                       description: |
                         You can add custom values for sonarqube, they will be merged with roles/sonarqube/templates/values/
-                        ttps://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
+                        https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
                         https://github.com/SonarSource/helm-chart-sonarqube/blob/master/charts/sonarqube/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -1163,7 +1163,7 @@ spec:
                           description: |
                             Connection parameters used for replication, it should contain
                             'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
-                            ttps://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
+                            https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
                   type: object
                 vault:
@@ -1187,7 +1187,7 @@ spec:
                     values:
                       description: |
                         You can add custom values for vault, they will be merged with roles/vault/templates/values/
-                        ttps://developer.hashicorp.com/vault/docs/platform/k8s/helm
+                        https://developer.hashicorp.com/vault/docs/platform/k8s/helm
                         https://github.com/hashicorp/vault-helm/blob/main/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -22,25 +22,22 @@ spec:
             spec:
               properties:
                 additionalsCA:
-                  description: Additional CAs to inject into tools; the resources should
-                    be available in all namespaces
+                  description: Additional CAs to inject into tools; the resources should be available in all namespaces.
                   items:
                     properties:
                       key:
-                        description: CA Resource key, optional, if not set, all keys
-                          will be imported
+                        description: Optional CA Resource key. If not set, all keys will be imported.
                         type: string
                       kind:
                         default: ConfigMap
-                        description: CA Resource kind only ConfigMap and Secret are
-                          supported
+                        description: CA Resource kind. Only ConfigMap and Secret are supported.
                         enum:
                           - ConfigMap
                           - Secret
                         type: string
                       name:
                         default: kube-root-ca.crt
-                        description: CA Resource name
+                        description: CA Resource name.
                         type: string
                     required:
                       - kind
@@ -54,41 +51,41 @@ spec:
                     - type
                   properties:
                     configmap:
-                      description: The configmap with private CA
+                      description: The configmap with private CA.
                       type: object
                       properties:
                         namespace:
-                          description: The configmap namespace
+                          description: The configmap namespace.
                           type: string
                         name:
-                          description: The configmap name
+                          description: The configmap name.
                           type: string
                         key:
-                          description: The configmap key providing the Private CA cert
+                          description: The configmap key providing the Private CA cert.
                           type: string
                       required:
                         - namespace
                         - name
                         - key
                     secret:
-                      description: The secret with private CA
+                      description: The secret with private CA.
                       type: object
                       properties:
                         namespace:
-                          description: The secret namespace
+                          description: The secret namespace.
                           type: string
                         name:
-                          description: The secret name
+                          description: The secret name.
                           type: string
                         key:
-                          description: The secret key providing the Private CA cert
+                          description: The secret key providing the Private CA cert.
                           type: string
                       required:
                         - namespace
                         - name
                         - key
                     url:
-                      description: An URL providing the private CA cert (it should be plain text)
+                      description: URL providing the plain text private CA cert.
                       type: string
                     type:
                       description: |
@@ -97,7 +94,8 @@ spec:
                         - configmap: Private CA cert is stored as a configmap
                         - secret: Private CA cert is stored as a secret
                         - url: Private CA cert comes from an external URL
-                        - certmanager: Private CA cert is managed by certmanager, please use ingress.tls.ca accordingly
+                        - certmanager: Private CA cert is managed by cert-manager, please use
+                          ingress.tls.ca accordingly
                       type: string
                       enum:
                         - none
@@ -130,15 +128,16 @@ spec:
                       description: The subdomain for ArgoCD.
                       type: string
                     helmRepoUrl:
-                      description: ArgoCD Bitnami helm repository url.
+                      description: ArgoCD helm repository url.
                       type: string
                     chartVersion:
-                      description: ArgoCD Bitnami helm chart version (e.g., "4.7.13").
+                      description: ArgoCD helm chart version (e.g., "4.7.13").
                       type: string
                     values:
                       description: |
-                        You can merge customs values for argocd, it will be merged with roles/argocd/templates/values/
-                        See https://github.com/bitnami/charts/tree/main/bitnami/argo-cd
+                        You can add custom values for argocd, they will be merged with roles/argocd/templates/values/
+                        See: https://github.com/argoproj/argo-helm/tree/main/charts/argo-cd
+                        And: https://github.com/argoproj/argo-helm/tree/main/charts/argo-cd/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     privateGitlabDomain:
@@ -158,15 +157,16 @@ spec:
                       type: string
                     forcedInstall:
                       description: |
-                        Should we force Cert-manager installation in the desired namespace ?
-                        Default is false, so it won't install (or reinstall) if it's already there.
-                        Set to true for a forced installation.
+                        If set to true, cert-manager will be installed (or reinstalled) in the
+                        desired namespace regardless of its existing state.
+                        The default value is false, which means no forced installation will occur.
                       default: false
                       type: boolean
                     values:
                       description: |
-                        You can merge customs values for CloudNativePG, it will be merged with roles/cert-manager/templates/values/
-                        See https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/README.md#values
+                        You can add custom values for cert-manager, they will be merged with roles/cert-manager/templates/values/
+                        See: https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg
+                        And: https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
@@ -184,15 +184,16 @@ spec:
                       type: string
                     forcedInstall:
                       description: |
-                        Should we force CNPG Operator installation in the desired namespace ?
-                        Default is false, so it won't install (or reinstall) if it's already there.
-                        Set to true for a forced installation.
+                        If set to true, CNPG Operator will be installed (or reinstalled) in the
+                        desired namespace regardless of its existing state.
+                        The default value is false, which means no forced installation will occur.
                       default: false
                       type: boolean
                     values:
                       description: |
-                        You can merge customs values for CloudNativePG, it will be merged with roles/cloudnativepg/templates/values/
-                        See https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/README.md#values
+                        You can add custom values for CloudNativePG, they will be merged with roles/cloudnativepg/templates/values/
+                        See: https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg
+                        And: https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
@@ -212,7 +213,7 @@ spec:
                       description: Console helm repository url.
                       type: string
                     values:
-                      description: Extra helm values for console
+                      description: Extra helm values for console.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     postgresPvcSize:
@@ -221,10 +222,11 @@ spec:
                       default: 10Gi
                     postgresWalMaxSlotKeepSize:
                       description: |
-                        Maximum size of WAL files that replication slots are allowed to retain in the pg_wal directory at checkpoint time.
-                        Default is -1, meaning that replication slots may retain an unlimited amount of WAL files.
-                        You can for instance set it to "9GB".
-                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        Maximum size of WAL files that replication slots are allowed to retain in
+                        the pg_wal directory at checkpoint time.
+                        Default is -1, meaning that replication slots may retain an unlimited amount
+                        of WAL files. You can for instance set it to "9GB".
+                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
                         Refer to postgresql.conf for memory units.
                       type: string
                     postgresWalPvcSize:
@@ -235,7 +237,8 @@ spec:
                       type: object
                       properties:
                         mode:
-                          description: Determines whether cnpg clusters should be deployed with as a primary cluster (initdb from scratch) or replica cluster (initdb from external source).
+                          description: Determines whether cnpg clusters should be deployed as a primary cluster
+                            (initdb from scratch) or replica cluster (initdb from external source).
                           default: primary
                           type: string
                           enum:
@@ -250,7 +253,10 @@ spec:
                           description: NodePort used to expose the cnpg cluster instance.
                           type: string
                         connectionParameters:
-                          description: Connection parameters used for replication, it should contains 'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert' (see. https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup)
+                          description: |
+                            Connection parameters used for replication, it should contain
+                            'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
+                            See: https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
                   type: object
                 gitlab:
@@ -270,9 +276,9 @@ spec:
                       type: string
                     values:
                       description: |
-                        You can merge customs values for gitlab, it will be merged with roles/gitlab/templates/values/
-                        See https://gitlab.com/gitlab-org/charts/gitlab/-/blob/master/values.yaml
-                        And https://docs.gitlab.com/charts/charts/globals.html
+                        You can add custom values for gitlab, they will be merged with roles/gitlab/templates/values/
+                        See: https://docs.gitlab.com/charts/charts/globals.html
+                        And: https://gitlab.com/gitlab-org/charts/gitlab/-/blob/master/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     insecureCI:
@@ -281,8 +287,8 @@ spec:
                         Configuring tools in pipelines container is not an easy job.
                       type: boolean
                     extraCIVars:
-                      description: |
-                        A key value object to inject additional variables into gitlab root group for CI/CD pipelines
+                      description: A key value object to inject additional variables into gitlab root group for
+                        CI/CD pipelines.
                       type: array
                       default: []
                       items:
@@ -311,10 +317,11 @@ spec:
                       default: 10Gi
                     postgresWalMaxSlotKeepSize:
                       description: |
-                        Maximum size of WAL files that replication slots are allowed to retain in the pg_wal directory at checkpoint time.
-                        Default is -1, meaning that replication slots may retain an unlimited amount of WAL files.
-                        You can for instance set it to "9GB".
-                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        Maximum size of WAL files that replication slots are allowed to retain in
+                        the pg_wal directory at checkpoint time.
+                        Default is -1, meaning that replication slots may retain an unlimited amount
+                        of WAL files. You can for instance set it to "9GB".
+                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
                         Refer to postgresql.conf for memory units.
                       type: string
                     postgresWalPvcSize:
@@ -325,7 +332,8 @@ spec:
                       type: object
                       properties:
                         mode:
-                          description: Determines whether cnpg clusters should be deployed with as a primary cluster (initdb from scratch) or replica cluster (initdb from external source).
+                          description: Determines whether cnpg clusters should be deployed as a primary cluster
+                            (initdb from scratch) or replica cluster (initdb from external source).
                           default: primary
                           type: string
                           enum:
@@ -340,7 +348,10 @@ spec:
                           description: NodePort used to expose the cnpg cluster instance.
                           type: string
                         connectionParameters:
-                          description: Connection parameters used for replication, it should contains 'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert' (see. https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup)
+                          description: |
+                            Connection parameters used for replication, it should contain
+                            'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
+                            See: https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
                   type: object
                 gitlabCiPipelinesExporter:
@@ -354,7 +365,10 @@ spec:
                       type: string
                     values:
                       description: |
-                        You can merge customs values for GitLab-ci-pipeline-exporter, they will be merged with roles/gitlab-ci-pipeline-exporter/templates/values/
+                        You can add custom values for gitLab-ci-pipelines-exporter, they will be
+                        merged with roles/gitlab-ci-pipelines-exporter/templates/values/
+                        See: https://github.com/mvisonneau/helm-charts/blob/main/charts/gitlab-ci-pipelines-exporter
+                        And: https://github.com/mvisonneau/helm-charts/blob/main/charts/gitlab-ci-pipelines-exporter/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
@@ -372,16 +386,16 @@ spec:
                       type: string
                     forcedInstall:
                       description: |
-                        Should we force GitLab Operator installation in the desired namespace ?
-                        Default is false, so it won't install (or reinstall) if it's already there.
-                        Set to true for a forced installation.
+                        If set to true, GitLab Operator will be installed (or reinstalled) in the
+                        desired namespace regardless of its existing state.
+                        The default value is false, which means no forced installation will occur.
                       default: false
                       type: boolean
                     values:
                       description: |
-                        You can merge customs values for GitLab Operator, it will be merged with roles/gitlab-operator/templates/values/
-                        See https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/
-                        And https://docs.gitlab.com/operator/
+                        You can add custom values for GitLab Operator, they will be merged with roles/gitlab-operator/templates/values/
+                        See: https://docs.gitlab.com/operator/
+                        And: https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/blob/master/deploy/chart/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
@@ -452,28 +466,27 @@ spec:
                                   type: string
                     values:
                       description: |
-                        You can merge customs values for GitLab Runner, it will be merged with roles/gitlab-runner/templates/values/
-                        See https://gitlab.com/gitlab-org/cloud-native/distroless/gitlab-runner
-                        And https://docs.gitlab.com/runner/
+                        You can add custom values for GitLab Runner, they will be merged with roles/gitlab-runner/templates/values/
+                        See: https://docs.gitlab.com/runner/
+                        And: https://gitlab.com/gitlab-org/cloud-native/distroless/gitlab-runner
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 global:
-                  description: Global configuration not specific to one service
+                  description: Global configuration not specific to one service.
                   properties:
                     environment:
                       default: production
-                      description: |
-                        Defines DSO environment type, i.e. development or production.
+                      description: Defines DSO environment type, i.e. development or production.
                       type: string
                     projectsRootDir:
                       default:
                         - forge
                       description: |
-                        Defines root directory for projects in Gitlab and Vault
+                        Defines root directory for projects in Gitlab and Vault.
                         These values should NEVER be changed once a project is used !
-                        projects will not be migrated automatically
-                        Represented as array of strings (ex: ['company', 'forge', 'projects'])
+                        Projects will not be migrated automatically.
+                        Represented as array of strings (e.g., ['company', 'forge', 'projects'])
                         Cannot be an empty Array
                       items:
                         type: string
@@ -493,7 +506,7 @@ spec:
                           description: Specifies whether metrics should be enabled.
                           type: boolean
                         additionalLabels:
-                          description: Adds additional labels if needed, when metrics are enabled
+                          description: Adds additional labels if needed, when metrics are enabled.
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                       required:
@@ -549,7 +562,8 @@ spec:
                             endpointCA:
                               properties:
                                 namespace:
-                                  description: Defines in which namespace is located the secret containing CA bundle for cnpg backups (it will be copy into each namespace that use cnpg).
+                                  description: Defines the namespace in which the secret containing cnpg backups' CA bundle
+                                    is located. This secret will be copied into each namespace which uses cnpg.
                                   type: string
                                 name:
                                   description: Defines the secret name containing s3 CA for cnpg backups.
@@ -633,8 +647,7 @@ spec:
                       type: string
                     offline:
                       default: false
-                      description: Specifies whether the cluster have access to the
-                        internet or not.
+                      description: Specifies whether the cluster have access to the internet or not.
                       type: boolean
                     registry:
                       description: Specifies the internal registry to use.
@@ -643,7 +656,7 @@ spec:
                       description: Specifies the credentials to use for pulling image, encoded in base64.
                       type: string
                     profile:
-                      description: Specifies security profile (e.g. cis).
+                      description: Specifies security profile (e.g., cis).
                       type: string
                   required:
                     - projectsRootDir
@@ -693,8 +706,10 @@ spec:
                       type: string
                     values:
                       description: |
-                        You can merge customs values for Grafana Operator, it will be merged with roles/grafana-operator/templates/values/
-                        See https://grafana.github.io/grafana-operator/docs/installation/helm/#values
+                        You can add custom values for Grafana Operator,
+                        they will be merged with roles/grafana-operator/templates/values/
+                        See: https://grafana.github.io/grafana-operator/docs/installation/helm/#values
+                        And: https://github.com/grafana/grafana-operator/tree/master/deploy/helm/grafana-operator
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
@@ -732,28 +747,28 @@ spec:
                       description: Size for trivy persistent volume.
                       type: string
                     proxyCache:
-                      description: Array of proxy cache
+                      description: Array of proxy cache configurations.
                       type: array
                       items:
                         type: object
                         properties:
                           name:
-                            description: Name of project and registry
+                            description: Name of project and registry.
                             type: string
                           registry:
-                            description: registry configuration
+                            description: Registry configuration.
                             type: object
                             properties:
                               provider:
-                                description: ID of the provider
+                                description: Specifies the registry provider. Default: docker-hub
                                 type: string
                                 default: docker-hub
                               endpointUrl:
-                                description: URL of the registry
+                                description: URL of the registry endpoint.
                                 type: string
                                 default: ""
                               insecure:
-                                description: Insecure connection
+                                description: Allows insecure connections. Default: false
                                 default: false
                                 type: boolean
                               credential:
@@ -775,8 +790,9 @@ spec:
                           - registry
                     values:
                       description: |
-                        You can merge customs values for harbor, it will be merged with roles/harbor/templates/values/
-                        See https://github.com/goharbor/harbor-helm
+                        You can add custom values for harbor, they will be merged with roles/harbor/templates/values/
+                        See: https://github.com/goharbor/harbor-helm
+                        And: https://github.com/goharbor/harbor-helm/blob/main/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     postgresPvcSize:
@@ -785,10 +801,11 @@ spec:
                       default: 10Gi
                     postgresWalMaxSlotKeepSize:
                       description: |
-                        Maximum size of WAL files that replication slots are allowed to retain in the pg_wal directory at checkpoint time.
-                        Default is -1, meaning that replication slots may retain an unlimited amount of WAL files.
-                        You can for instance set it to "9GB".
-                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        Maximum size of WAL files that replication slots are allowed to retain in
+                        the pg_wal directory at checkpoint time.
+                        Default is -1, meaning that replication slots may retain an unlimited amount
+                        of WAL files. You can for instance set it to "9GB".
+                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
                         Refer to postgresql.conf for memory units.
                       type: string
                     postgresWalPvcSize:
@@ -799,7 +816,8 @@ spec:
                       type: object
                       properties:
                         mode:
-                          description: Determines whether cnpg clusters should be deployed with as a primary cluster (initdb from scratch) or replica cluster (initdb from external source).
+                          description: Determines whether cnpg clusters should be deployed as a primary cluster
+                            (initdb from scratch) or replica cluster (initdb from external source).
                           default: primary
                           type: string
                           enum:
@@ -814,7 +832,10 @@ spec:
                           description: NodePort used to expose the cnpg cluster instance.
                           type: string
                         connectionParameters:
-                          description: Connection parameters used for replication, it should contains 'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert' (see. https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup)
+                          description: |
+                            Connection parameters used for replication, it should contain
+                            'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
+                            See: https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
                   required:
                     - adminPassword
@@ -826,32 +847,33 @@ spec:
                     annotations:
                       x-kubernetes-preserve-unknown-fields: true
                       default: {}
-                      description: Additional annotations to add to all tools' ingresses
+                      description: Additional annotations to add to all tools' ingresses.
                       type: object
                     className:
-                      description: Ingress class name to use for all ingresses
+                      description: Ingress class name to use for all ingresses.
                       type: string
                     labels:
                       x-kubernetes-preserve-unknown-fields: true
                       default: {}
-                      description: Additional labels to add to all tools' ingresses
+                      description: Additional labels to add to all tools' ingresses.
                       type: object
                     tls:
                       description: TLS configuration for ingresses.
                       properties:
                         acme:
-                          description: acme/Let'sEncrypt configuration, only http challenge
+                          description: acme/Let'sEncrypt configuration, only http challenge.
                           properties:
                             email:
-                              description: User email used for ACME
+                              description: User email used for ACME.
                               type: string
                             environment:
                               description: |
-                                Let's encrypt environment to use for issuing certificates:
+                                Let's Encrypt environment to use for issuing certificates:
                                 - production : Use this value for production ready certificates.
-                                  Beware of rate limits. See: https://letsencrypt.org/docs/rate-limits/
-                                - staging : Use this value for testing purposes. It has significantly higher rate limits.
-                                  Beware of root certificates. See: https://letsencrypt.org/docs/staging-environment/
+                                  Beware of rate limits. See: https://letsencrypt.org/docs/rate-limits/
+                                - staging : Use this value for testing purposes. It has significantly higher
+                                  rate limits. Beware of root certificates.
+                                  See: https://letsencrypt.org/docs/staging-environment/
                               enum:
                                 - production
                                 - staging
@@ -862,29 +884,27 @@ spec:
                             - environment
                           type: object
                         ca:
-                          description: CA configuration, need a valid CA key/cert in
-                            cert-manager namespace
+                          description: CA configuration, need a valid CA key/cert in cert-manager namespace.
                           properties:
                             secretName:
-                              description: The TLS secret name available in cert-manager
-                                namespace
+                              description: The TLS secret name available in cert-manager namespace.
                               type: string
                           required:
                             - secretName
                           type: object
                         tlsSecret:
-                          description: Define the tls secret name to use in ingress
+                          description: Define the TLS secret name to use in ingress.
                           properties:
                             method:
                               description: |
                                 How to retrieve the secret names:
-                                - in-namespace: you are in charge to replicate the secret in tools' namespaces
+                                - in-namespace: you are in charge of secret replication in tools' namespaces
                               enum:
                                 - in-namespace
                               type: string
                               default: in-namespace
                             name:
-                              description: tls secret name
+                              description: TLS secret name.
                               type: string
                           required:
                             - name
@@ -892,12 +912,14 @@ spec:
                           type: object
                         type:
                           default: none
-                          description: "- none: no TLS (seems like a bad idea, unstable
-                            deployment). \n- acme: TLS with HTTP ACME challenge -> https://cert-manager.io/docs/configuration/acme/http01/\n-
-                            ca: TLS with custom CA -> https://cert-manager.io/docs/configuration/ca/\n-
-                            tlsSecret: TLS with a custom TLS secret name specified in
-                            ingress.spec.tls.secretName, should be wildcard or include
-                            all hosts -> https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets\n"
+                          description: |
+                            - none: no TLS (seems like a bad idea, unstable deployment).
+                            - acme: TLS with HTTP ACME challenge ->
+                              https://cert-manager.io/docs/configuration/acme/http01/
+                            - ca: TLS with custom CA -> https://cert-manager.io/docs/configuration/ca/
+                            - tlsSecret: TLS with a custom TLS secret name specified in
+                              `ingress.spec.tls.secretName`, should be wildcard or include all hosts ->
+                              https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets
                           enum:
                             - none
                             - acme
@@ -929,10 +951,11 @@ spec:
                       default: 10Gi
                     postgresWalMaxSlotKeepSize:
                       description: |
-                        Maximum size of WAL files that replication slots are allowed to retain in the pg_wal directory at checkpoint time.
-                        Default is -1, meaning that replication slots may retain an unlimited amount of WAL files.
-                        You can for instance set it to "9GB".
-                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        Maximum size of WAL files that replication slots are allowed to retain in
+                        the pg_wal directory at checkpoint time.
+                        Default is -1, meaning that replication slots may retain an unlimited amount
+                        of WAL files. You can for instance set it to "9GB".
+                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
                         Refer to postgresql.conf for memory units.
                       type: string
                     postgresWalPvcSize:
@@ -943,9 +966,9 @@ spec:
                       type: string
                     values:
                       description: |
-                        You can merge customs values for keycloak, they will be merged with roles/keycloak/templates/values/
-                        See https://github.com/bitnami/charts/tree/main/bitnami/keycloak
-                        And https://github.com/bitnami/charts/blob/main/bitnami/keycloak/values.yaml
+                        You can add custom values for keycloak, they will be merged with roles/keycloak/templates/values/
+                        See: https://github.com/bitnami/charts/tree/main/bitnami/keycloak
+                        And: https://github.com/bitnami/charts/blob/main/bitnami/keycloak/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     cnpg:
@@ -953,7 +976,8 @@ spec:
                       type: object
                       properties:
                         mode:
-                          description: Determines whether cnpg clusters should be deployed with as a primary cluster (initdb from scratch) or replica cluster (initdb from external source).
+                          description: Determines whether cnpg clusters should be deployed as a primary cluster
+                            (initdb from scratch) or replica cluster (initdb from external source).
                           default: primary
                           type: string
                           enum:
@@ -968,7 +992,10 @@ spec:
                           description: NodePort used to expose the cnpg cluster instance.
                           type: string
                         connectionParameters:
-                          description: Connection parameters used for replication, it should contains 'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert' (see. https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup)
+                          description: |
+                            Connection parameters used for replication, it should contain
+                            'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
+                            See: https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
                   type: object
                 kyverno:
@@ -979,9 +1006,9 @@ spec:
                       type: string
                     forcedInstall:
                       description: |
-                        Should we force Kyverno installation in the desired namespace ?
-                        Default is false, so it won't install (or reinstall) if it's already there.
-                        Set to true for a forced installation.
+                        If set to true, Kyverno will be installed (or reinstalled) in the
+                        desired namespace regardless of its existing state.
+                        The default value is false, which means no forced installation will occur.
                       default: false
                       type: boolean
                     helmRepoUrl:
@@ -992,8 +1019,9 @@ spec:
                       type: string
                     values:
                       description: |
-                        You can merge customs values for Kyverno, they will be merged with roles/kyverno/templates/values/
-                        See https://github.com/kyverno/kyverno/blob/main/charts/kyverno/values.yaml
+                        You can add custom values for Kyverno, they will be merged with roles/kyverno/templates/values/
+                        See: https://github.com/kyverno/kyverno/blob/main/charts/kyverno
+                        And: https://github.com/kyverno/kyverno/blob/main/charts/kyverno/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
@@ -1019,13 +1047,13 @@ spec:
                       description: Nexus version based on image tag (e.g., "3.56.0").
                       type: string
                     ingressAnnotations:
-                      description: |
-                        You can put here custom annotations for nexus ingress, they will be pushed into the nexus ingress rule combined to `dsc.ingress.annotations`
+                      description: Custom annotations for nexus ingress, they will be pushed into the nexus
+                        ingress rule combined to `dsc.ingress.annotations`.
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
                 prometheus:
-                  description: Minimal configuration for prometheus CRDs
+                  description: Minimal configuration for prometheus CRDs.
                   properties:
                     crd:
                       properties:
@@ -1047,21 +1075,22 @@ spec:
                       description: Enable or disable proxy on tools.
                       type: boolean
                     host:
-                      description: Distant proxy ip/hostname
+                      description: Distant proxy ip/hostname.
                       type: string
                     http_proxy:
-                      description: URL for http traffic, (http://<host>:<port>/)
+                      description: URL for http traffic. Format: http://<host>:<port>/
                       type: string
                     https_proxy:
-                      description: URL for https traffic, (http://<host>:<port>/)
+                      description: URL for https traffic. Format: http://<host>:<port>/
                       type: string
                     no_proxy:
                       default: .cluster.local,.svc,10.0.0.0/8,127.0.0.1,192.168.0.0/16,localhost,svc.cluster.local,localdomain
-                      description: "Networks destination excluded by the proxy. Not
-                        so easy to configure. \nExample: .cluster.local,.svc,10.0.0.0/8,127.0.0.1,192.168.0.0/16,localhost,svc.cluster.local,localdomain\n"
+                      description: |
+                        Networks destination excluded by the proxy. Not so easy to configure.
+                        Default: .cluster.local,.svc,10.0.0.0/8,127.0.0.1,192.168.0.0/16,localhost,svc.cluster.local,localdomain
                       type: string
                     port:
-                      description: Distant proxy port listening
+                      description: Distant proxy port listening.
                       type: string
                   required:
                     - enabled
@@ -1087,10 +1116,11 @@ spec:
                       default: 10Gi
                     postgresWalMaxSlotKeepSize:
                       description: |
-                        Maximum size of WAL files that replication slots are allowed to retain in the pg_wal directory at checkpoint time.
-                        Default is -1, meaning that replication slots may retain an unlimited amount of WAL files.
-                        You can for instance set it to "9GB".
-                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
+                        Maximum size of WAL files that replication slots are allowed to retain in
+                        the pg_wal directory at checkpoint time.
+                        Default is -1, meaning that replication slots may retain an unlimited amount
+                        of WAL files. You can for instance set it to "9GB".
+                        See: https://cloudnative-pg.io/documentation/current/replication/#capping-the-wal-size-retained-for-replication-slots
                         Refer to postgresql.conf for memory units.
                       type: string
                     postgresWalPvcSize:
@@ -1104,8 +1134,9 @@ spec:
                       type: string
                     values:
                       description: |
-                        You can merge customs values for sonarqube, it will be merged with roles/sonarqube/templates/values/
-                        See https://github.com/bitnami/charts/tree/main/bitnami/sonarqube
+                        You can add custom values for sonarqube, they will be merged with roles/sonarqube/templates/values/
+                        See: https://github.com/SonarSource/helm-chart-sonarqube/tree/master/charts/sonarqube
+                        And: https://github.com/SonarSource/helm-chart-sonarqube/blob/master/charts/sonarqube/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                     cnpg:
@@ -1113,7 +1144,8 @@ spec:
                       type: object
                       properties:
                         mode:
-                          description: Determines whether cnpg clusters should be deployed with as a primary cluster (initdb from scratch) or replica cluster (initdb from external source).
+                          description: Determines whether cnpg clusters should be deployed as a primary cluster
+                            (initdb from scratch) or replica cluster (initdb from external source).
                           default: primary
                           type: string
                           enum:
@@ -1128,7 +1160,10 @@ spec:
                           description: NodePort used to expose the cnpg cluster instance.
                           type: string
                         connectionParameters:
-                          description: Connection parameters used for replication, it should contains 'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert' (see. https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup)
+                          description: |
+                            Connection parameters used for replication, it should contain
+                            'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
+                            See: https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
                   type: object
                 vault:
@@ -1151,8 +1186,9 @@ spec:
                       type: string
                     values:
                       description: |
-                        You can merge customs values for vault, it will be merged with roles/vault/templates/values/
-                        See https://github.com/hashicorp/vault-helm
+                        You can add custom values for vault, they will be merged with roles/vault/templates/values/
+                        See: https://developer.hashicorp.com/vault/docs/platform/k8s/helm
+                        And: https://github.com/hashicorp/vault-helm/blob/main/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object

--- a/roles/socle-config/tasks/main.yaml
+++ b/roles/socle-config/tasks/main.yaml
@@ -108,11 +108,11 @@
   ansible.builtin.set_fact:
     dsc: "{{ dsc.spec }}"
 
-- name: set private registry
+- name: Set private registry
   ansible.builtin.set_fact:
     use_private_registry: "{{ dsc.global.registry is defined and dsc.global.registry | length > 0 | bool }}"
 
-- name: use imagePullSecrets
+- name: Use imagePullSecrets
   ansible.builtin.set_fact:
     use_image_pull_secrets: "{{ dsc.global.imagePullSecretsData is defined and dsc.global.imagePullSecretsData | length > 0 | bool }}"
 

--- a/roles/sonarqube/tasks/main.yaml
+++ b/roles/sonarqube/tasks/main.yaml
@@ -309,7 +309,7 @@
       register: sonarqube_pod
 
     - name: Set metrics ports names facts
-      loop: "{{ metrics_ports_names_facts }}"
+      loop: "{{ sonarqube_metrics_ports_names_facts }}"
       ansible.builtin.set_fact:
         "{{ item.fact_name }}": "{{ sonarqube_pod.resources
           | map(attribute='spec.containers') | first
@@ -319,7 +319,7 @@
           | map(attribute='name') | first }}"
 
     - name: Set metrics paths facts
-      loop: "{{ metrics_paths_facts }}"
+      loop: "{{ sonarqube_metrics_paths_facts }}"
       ansible.builtin.set_fact:
         "{{ item.fact_name }}": "{{ item.path }}"
 

--- a/roles/sonarqube/templates/pg-cluster-sonar.yaml.j2
+++ b/roles/sonarqube/templates/pg-cluster-sonar.yaml.j2
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ dsc.sonarqube.namespace }}
 {% if dsc.global.backup.velero.enabled %}
   annotations:
-    pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d  sonardb > /var/lib/postgresql/data/app.dump-${index}"]'
+    pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d sonardb > /var/lib/postgresql/data/app.dump-${index}"]'
     pre.hook.backup.velero.io/container: postgres
     pre.hook.backup.velero.io/on-error: Fail
     pre.hook.backup.velero.io/timeout: 90s

--- a/roles/sonarqube/templates/values/10-offline.j2
+++ b/roles/sonarqube/templates/values/10-offline.j2
@@ -1,8 +1,8 @@
-{% if dsc.global.offline %} 
+{% if dsc.global.offline %}
 prometheusExporter:
   version: {{ dsc.sonarqube.prometheusJavaagentVersion }}
   noCheckCertificate: true
-  downloadURL: {{ dsc.sonarqube.pluginDownloadUrl }}/jmx_prometheus_javaagent-{{ dsc.sonarqube.prometheusJavaagentVersion }}.jar 
+  downloadURL: {{ dsc.sonarqube.pluginDownloadUrl }}/jmx_prometheus_javaagent-{{ dsc.sonarqube.prometheusJavaagentVersion }}.jar
 
 plugins:
   install:

--- a/roles/sonarqube/templates/values/10-registry.j2
+++ b/roles/sonarqube/templates/values/10-registry.j2
@@ -5,6 +5,6 @@ image:
 
 {% if use_image_pull_secrets %}
 image:
-  pullSecrets: 
+  pullSecrets:
   - name: dso-config-pull-secret
 {% endif %}

--- a/roles/sonarqube/vars/main.yaml
+++ b/roles/sonarqube/vars/main.yaml
@@ -1,5 +1,5 @@
 ---
-metrics_ports_names_facts:
+sonarqube_metrics_ports_names_facts:
   - fact_name: api_metrics_port_name
     port: 9000
   - fact_name: web_metrics_port_name
@@ -7,7 +7,7 @@ metrics_ports_names_facts:
   - fact_name: ce_metrics_port_name
     port: 8001
 
-metrics_paths_facts:
+sonarqube_metrics_paths_facts:
   - fact_name: api_metrics_path
     path: /api/monitoring/metrics
   - fact_name: web_metrics_path

--- a/roles/vault/tasks/post-install.yml
+++ b/roles/vault/tasks/post-install.yml
@@ -23,13 +23,13 @@
   vars:
     vault_pod: "{{ dsc_name }}-vault-0"
 
-- name: Check if vaul is coherent
+- name: Check if vault is coherent
   ansible.builtin.assert:
     that:
       - ((vault_status in ['sealed', 'OK']) and (vaut_keys.resources | length > 0)) or ((vault_status == 'not init') and (vaut_keys.resources | length == 0))
     fail_msg:
       - Attention ! Soit le vault n'est pas initialisé mais vous avez un secret {{ dsc_name }}-vault-keys dans {{ dsc.vault.namespace }}
-      - Veuillez le suppripmer et relancer si vous souhaitez lancer une initialisation
+      - Veuillez le supprimer et relancer si vous souhaitez lancer une initialisation
       - Soit le vault est initialisé mais vous n'avez pas de secret {{ dsc_name }}-vault-keys dans {{ dsc.vault.namespace }}, et c'est inquiétant !
 
 # Init Vault - node 1

--- a/roles/vault/tasks/post-install.yml
+++ b/roles/vault/tasks/post-install.yml
@@ -478,7 +478,7 @@
       "canonical_id": "{{ user_group.json.data.id }}"
     body_format: json
 
-- name: set oidc method as default
+- name: Set oidc method as default
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     url: "https://{{ vault_domain }}/v1/sys/auth/oidc/tune"

--- a/roles/vault/templates/values/10-platform.j2
+++ b/roles/vault/templates/values/10-platform.j2
@@ -8,7 +8,7 @@ injector:
   securityContext:
     pod:
       runAsNonRoot: true
-      runAsGroup: 1000 
+      runAsGroup: 1000
       runAsUser: 100
       fsGroup: 1000
     container:
@@ -22,7 +22,7 @@ server:
     securityContext:
       pod:
         runAsNonRoot: true
-        runAsGroup: 1000 
+        runAsGroup: 1000
         runAsUser: 100
         fsGroup: 1000
       container:

--- a/roles/vault/templates/values/10-registry.j2
+++ b/roles/vault/templates/values/10-registry.j2
@@ -19,6 +19,6 @@ csi:
 
 {% if use_image_pull_secrets %}
 global:
-  imagePullSecrets: 
+  imagePullSecrets:
   - name: dso-config-pull-secret
 {% endif %}

--- a/uninstall.yaml
+++ b/uninstall.yaml
@@ -312,7 +312,7 @@
       tags:
         - vault
 
-    - name: "Suppression de l'intance Argo CD"
+    - name: "Suppression de l'instance Argo CD"
       kubernetes.core.helm:
         name: "{{ dsc_name }}"
         release_namespace: "{{ dsc.argocd.namespace }}"

--- a/versions.md
+++ b/versions.md
@@ -1,18 +1,18 @@
-| Outil                     | Version          | Chart version | Source                                                                                  |
-| ------------------------- | ---------------- | ------------- | --------------------------------------------------------------------------------------- |
-| argocd                    | 2.11.7           | 7.3.11        | [argocd](https://artifacthub.io/packages/helm/argo/argo-cd)                             |
-| certmanager               | 1.14.3           | 1.14.3        | [certmanager](https://github.com/cert-manager/cert-manager/releases)                    |
-| cloudnativepg             | 1.22.1           | 0.20.1        | [cloudnativepg](https://artifacthub.io/packages/helm/cloudnative-pg/cloudnative-pg)     |
-| console                   | 8.0.2            | 8.0.2         | [console](https://github.com/cloud-pi-native/console/releases)                          |
-| gitlab                    | 17.4.2           | 8.4.2         | [gitlab](https://artifacthub.io/packages/helm/gitlab/gitlab)                            |
-| gitlabCiPipelinesExporter | 0.5.8            | 0.3.4         | https://github.com/mvisonneau/helm-charts/tree/main/charts/gitlab-ci-pipelines-exporter |
-| gitlabOperator            | 1.4.2            | 1.4.2         | [gitlabOperator](https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/tags)     |
-| gitlabRunner              | 17.4.0           | 0.69.0        | [gitlabRunner](https://gitlab.com/gitlab-org/charts/gitlab-runner/-/tags)               |
-| grafana                   | 10.4.3            | N/A           | [grafana](https://github.com/grafana/grafana/tags)                                      |
-| grafanaOperator           | 5.10.0            | 5.4.2         | [grafanaOperator](https://github.com/grafana/grafana-operator/tags)                     |
-| harbor                    | 2.10.1           | 1.14.1        | [harbor](https://artifacthub.io/packages/helm/harbor/harbor)                            |
-| keycloak                  | 23.0.7           | 19.3.4        | [keycloak](https://artifacthub.io/packages/helm/bitnami/keycloak)                       |
-| kyverno                   | v1.11.4          | 3.1.4         | [kyverno](https://artifacthub.io/packages/helm/kyverno/kyverno)                         |
-| nexus                     | 3.68.1           | N/A           | [nexus](https://hub.docker.com/r/sonatype/nexus3/)                                      |
-| sonarqube                 | 10.6.1-community | 10.6.1+3163   | [sonarqube](https://artifacthub.io/packages/helm/sonarqube/sonarqube)                   |
-| vault                     | 1.14.0           | 0.25.0        | [vault](https://artifacthub.io/packages/helm/hashicorp/vault)                           |
+| Outil                     | Version          | Chart version | Source                                                                                                               |
+| ------------------------- | ---------------- | ------------- |----------------------------------------------------------------------------------------------------------------------|
+| argocd                    | 2.11.7           | 7.3.11        | [argocd](https://artifacthub.io/packages/helm/argo/argo-cd)                                                          |
+| certmanager               | 1.14.3           | 1.14.3        | [certmanager](https://github.com/cert-manager/cert-manager/releases)                                                 |
+| cloudnativepg             | 1.22.1           | 0.20.1        | [cloudnativepg](https://artifacthub.io/packages/helm/cloudnative-pg/cloudnative-pg)                                  |
+| console                   | 8.0.2            | 8.0.2         | [console](https://github.com/cloud-pi-native/console/releases)                                                       |
+| gitlab                    | 17.4.2           | 8.4.2         | [gitlab](https://artifacthub.io/packages/helm/gitlab/gitlab)                                                         |
+| gitlabCiPipelinesExporter | 0.5.8            | 0.3.4         | [gitlabCiPipelinesExporter](https://github.com/mvisonneau/helm-charts/tree/main/charts/gitlab-ci-pipelines-exporter) |
+| gitlabOperator            | 1.4.2            | 1.4.2         | [gitlabOperator](https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/tags)                                  |
+| gitlabRunner              | 17.4.0           | 0.69.0        | [gitlabRunner](https://gitlab.com/gitlab-org/charts/gitlab-runner/-/tags)                                            |
+| grafana                   | 10.4.3           | N/A           | [grafana](https://github.com/grafana/grafana/tags)                                                                   |
+| grafanaOperator           | 5.10.0           | 5.4.2         | [grafanaOperator](https://github.com/grafana/grafana-operator/tags)                                                  |
+| harbor                    | 2.10.1           | 1.14.1        | [harbor](https://artifacthub.io/packages/helm/harbor/harbor)                                                         |
+| keycloak                  | 23.0.7           | 19.3.4        | [keycloak](https://artifacthub.io/packages/helm/bitnami/keycloak)                                                    |
+| kyverno                   | v1.11.4          | 3.1.4         | [kyverno](https://artifacthub.io/packages/helm/kyverno/kyverno)                                                      |
+| nexus                     | 3.68.1           | N/A           | [nexus](https://hub.docker.com/r/sonatype/nexus3/)                                                                   |
+| sonarqube                 | 10.6.1-community | 10.6.1+3163   | [sonarqube](https://artifacthub.io/packages/helm/sonarqube/sonarqube)                                                |
+| vault                     | 1.14.0           | 0.25.0        | [vault](https://artifacthub.io/packages/helm/hashicorp/vault)                                                        |


### PR DESCRIPTION
## Quel est le comportement actuel ?
Beaucoup de typos, erreures de grammaires, double espaces, espaces en bout de ligne, etc.

## Quel est le nouveau comportement ?
Corrige ces typos, etc.
`initb` renommé en `initdb`
`immuable` au lieu de l'anglicisme `imutable`
Suppression de l'un des deux `n` de `additionnal` dans la variable `additional_metrics_port_name`
Ajout d'espaces à l'intérieur de `{{ ` et ` }}` jinja.
Réalignement du tableau de [versions.md](https://github.com/cloud-pi-native/socle/blob/main/versions.md) et ajout du titre de lien pour `gitlabCiPipelinesExporter`

## Cette PR introduit-elle un breaking change ?
Non, mais j'aimerai retirer ou déplacer le `s` de `additionalsCA`. `additionalCAs` serait grammaticalement correct, mais dans ce cas la version snake_case serait moins lisible. ex: `additional_cas_pem`

## Autres informations
Je n'ai pas touché à tous les valeurs de `legendFormat` (manque des espaces entre le contenu et les `{{}}`)  ainsi qu'aux ``{{`{{`}}`` des fichiers `.tpl` de metrics.