### PR TITLE
fix: :bug: Fix some alert rules (missing namespace label)

### DIFF
--- a/observability/files/rules/metrics/argo-cd-alerts.yaml.tpl
+++ b/observability/files/rules/metrics/argo-cd-alerts.yaml.tpl
@@ -30,7 +30,7 @@ groups:
           message: Argo CD Redis HA in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: Argo CD Redis HA down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"(.*-)*argo-redis-ha-server-.*",
           namespace="{{ .Values.app.namespacePrefix }}argocd",
           condition="true"}) == 0
@@ -42,7 +42,7 @@ groups:
           message: Argo CD Redis HA Haproxy has not been available for the last 5 minutes.
           summary: Argo CD Redis HA Haproxy down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"(.*-)*argo-redis-ha-haproxy-.*",
           namespace="{{ .Values.app.namespacePrefix }}argocd",
           condition="true"}) == 0
@@ -54,7 +54,7 @@ groups:
           message: Argo CD Server has not been available for the last 5 minutes.
           summary: Argo CD Server down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"(.*-)*argo-argocd-server-.*",
           namespace="{{ .Values.app.namespacePrefix }}argocd",
           condition="true"}) == 0
@@ -66,7 +66,7 @@ groups:
           message: Argo CD Repo Server has not been available for the last 5 minutes.
           summary: Argo CD Repo Server down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"(.*-)*argo-argocd-repo-server-.*",
           namespace="{{ .Values.app.namespacePrefix }}argocd",
           condition="true"}) == 0
@@ -78,7 +78,7 @@ groups:
           message: Argo CD Applicationset Controller has not been available for the last 5 minutes.
           summary: Argo CD Applicationset Controller down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"(.*-)*argocd-applicationset-controller-.*",
           namespace="{{ .Values.app.namespacePrefix }}argocd",
           condition="true"}) == 0
@@ -90,7 +90,7 @@ groups:
           message: Argo CD Application Controller has not been available for the last 5 minutes.
           summary: Argo CD Application Controller down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"(.*-)*argocd-application-controller-.*",
           namespace="{{ .Values.app.namespacePrefix }}argocd",
           condition="true"}) == 0

--- a/observability/files/rules/metrics/console-alerts.yaml.tpl
+++ b/observability/files/rules/metrics/console-alerts.yaml.tpl
@@ -6,7 +6,7 @@ groups:
           message: DSO Console client in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: DSO Console client down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"dso-cpn-console-client-.*",
           namespace="{{ .Values.app.namespacePrefix }}console",
           condition="true"}) == 0
@@ -18,7 +18,7 @@ groups:
           message: DSO Console server in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: DSO Console server down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"dso-cpn-console-server-.*",
           namespace="{{ .Values.app.namespacePrefix }}console",
           condition="true"}) == 0

--- a/observability/files/rules/metrics/gitlab-alerts.yaml.tpl
+++ b/observability/files/rules/metrics/gitlab-alerts.yaml.tpl
@@ -6,7 +6,7 @@ groups:
           message: GitLab webservice in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: GitLab webservice down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"gitlab-webservice-.*",
           namespace="{{ .Values.app.namespacePrefix }}gitlab",
           condition="true"}) == 0
@@ -18,7 +18,7 @@ groups:
           message: GitLab toolbox in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: GitLab toolbox down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"gitlab-toolbox-.*",
           namespace="{{ .Values.app.namespacePrefix }}gitlab",
           condition="true"}) == 0
@@ -30,7 +30,7 @@ groups:
           message: GitLab sidekiq in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: GitLab sidekiq down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"gitlab-sidekiq-.*",
           namespace="{{ .Values.app.namespacePrefix }}gitlab",
           condition="true"}) == 0
@@ -42,7 +42,7 @@ groups:
           message: GitLab runner in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: GitLab runner down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"gitlab-runner-.*",
           namespace="{{ .Values.app.namespacePrefix }}gitlab",
           condition="true"}) == 0
@@ -54,7 +54,7 @@ groups:
           message: GitLab redis in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: GitLab redis down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"gitlab-redis-.*",
           namespace="{{ .Values.app.namespacePrefix }}gitlab",
           condition="true"}) == 0
@@ -66,7 +66,7 @@ groups:
           message: GitLab minio in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: GitLab minio down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"gitlab-minio-.*",
           namespace="{{ .Values.app.namespacePrefix }}gitlab",
           condition="true"}) == 0
@@ -78,7 +78,7 @@ groups:
           message: GitLab kas in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: GitLab kas down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"gitlab-kas-.*",
           namespace="{{ .Values.app.namespacePrefix }}gitlab",
           condition="true"}) == 0
@@ -90,7 +90,7 @@ groups:
           message: GitLab shell in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: GitLab shell down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"gitlab-gitlab-shell-.*",
           namespace="{{ .Values.app.namespacePrefix }}gitlab",
           condition="true"}) == 0
@@ -102,7 +102,7 @@ groups:
           message: GitLab exporter in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: GitLab exporter down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"gitlab-gitlab-exporter-.*",
           namespace="{{ .Values.app.namespacePrefix }}gitlab",
           condition="true"}) == 0
@@ -114,7 +114,7 @@ groups:
           message: GitLab gitaly in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: GitLab gitaly down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"gitlab-gitaly-.*",
           namespace="{{ .Values.app.namespacePrefix }}gitlab",
           condition="true"}) == 0
@@ -126,7 +126,7 @@ groups:
           message: GitLab ci-pipelines-exporter in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: GitLab ci-pipelines-exporter down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"gitlab-ci-pipelines-exporter-.*",
           namespace="{{ .Values.app.namespacePrefix }}gitlab",
           condition="true"}) == 0

--- a/observability/files/rules/metrics/harbor-alerts.yaml.tpl
+++ b/observability/files/rules/metrics/harbor-alerts.yaml.tpl
@@ -6,7 +6,7 @@ groups:
           message: Harbor core in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: Harbor core down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"harbor-core-.*",
           namespace="{{ .Values.app.namespacePrefix }}harbor",
           condition="true"}) == 0
@@ -18,7 +18,7 @@ groups:
           message: Harbor exporter in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: Harbor exporter down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"harbor-exporter-.*",
           namespace="{{ .Values.app.namespacePrefix }}harbor",
           condition="true"}) == 0
@@ -30,7 +30,7 @@ groups:
           message: Harbor jobservice in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: Harbor jobservice down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"harbor-jobservice-.*",
           namespace="{{ .Values.app.namespacePrefix }}harbor",
           condition="true"}) == 0
@@ -42,7 +42,7 @@ groups:
           message: Harbor portal in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: Harbor portal down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"harbor-portal-.*",
           namespace="{{ .Values.app.namespacePrefix }}harbor",
           condition="true"}) == 0
@@ -54,7 +54,7 @@ groups:
           message: Harbor redis in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: Harbor redis down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"harbor-redis-.*",
           namespace="{{ .Values.app.namespacePrefix }}harbor",
           condition="true"}) == 0
@@ -66,7 +66,7 @@ groups:
           message: Harbor registry in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: Harbor registry down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"harbor-registry-.*",
           namespace="{{ .Values.app.namespacePrefix }}harbor",
           condition="true"}) == 0
@@ -78,7 +78,7 @@ groups:
           message: Harbor trivy in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: Harbor trivy down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"harbor-trivy-.*",
           namespace="{{ .Values.app.namespacePrefix }}harbor",
           condition="true"}) == 0

--- a/observability/files/rules/metrics/kyverno-alerts.yaml.tpl
+++ b/observability/files/rules/metrics/kyverno-alerts.yaml.tpl
@@ -6,7 +6,7 @@ groups:
           message: Kyverno admission controler in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: Kyverno admission controler down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"kyverno-admission-controller-.*",
           namespace="{{ .Values.app.namespacePrefix }}kyverno",
           condition="true"}) == 0
@@ -18,7 +18,7 @@ groups:
           message: Kyverno background controler in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: Kyverno background controler down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"kyverno-background-controller-.*",
           namespace="{{ .Values.app.namespacePrefix }}kyverno",
           condition="true"}) == 0
@@ -30,7 +30,7 @@ groups:
           message: Kyverno cleanup controller in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: Kyverno cleanup controller down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"kyverno-cleanup-controller-.*",
           namespace="{{ .Values.app.namespacePrefix }}kyverno",
           condition="true"}) == 0
@@ -42,7 +42,7 @@ groups:
           message: Kyverno reports controller in namespace {{`{{`}} $labels.namespace {{`}}`}} has not been available for the last 5 minutes.
           summary: Kyverno reports controller down (no ready pod)"
         expr: |
-          sum(kube_pod_status_ready{
+          sum by(namespace) (kube_pod_status_ready{
           pod=~"kyverno-reports-controller-.*",
           namespace="{{ .Values.app.namespacePrefix }}kyverno",
           condition="true"}) == 0


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

L'expression utilisée dans certaines règles d'alerting ne fait pas remonter le label "namespace".
Il en résulte que, selon le paramétrage des policies de notification dans Grafana, lesquelles peuvent justement filtrer sur certains namespaces, les alertes en question ne remontent pas car le namespace n'est pas identifié.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Expressions problématiques corrigées pour remontée du label "namespace".

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.
