### PR TITLE
feat: :sparkles: handle CNPG cluster images override

### DIFF
--- a/roles/console-dso/templates/values/00-main.j2
+++ b/roles/console-dso/templates/values/00-main.j2
@@ -37,6 +37,11 @@ cnpg:
 {% if dsc.console.postgresWalPvcSize is defined %}
   walPvcSize: "{{ dsc.console.postgresWalPvcSize }}"
 {% endif %}
+{% if use_private_registry %}
+  imageName: "{{ dsc.global.registry }}/cloudnative-pg/postgresql:16.1"
+{% elif dsc.console.cnpg.imageName %}
+  imageName: "{{ dsc.console.cnpg.imageName }}"
+{% endif %}
 {% if dsc.global.backup.velero.enabled %}
   annotations:
     pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d  dso-console-db > /var/lib/postgresql/data/app.dump-${index}"]'

--- a/roles/gitlab/templates/pg-cluster-gitlab.yaml.j2
+++ b/roles/gitlab/templates/pg-cluster-gitlab.yaml.j2
@@ -17,6 +17,8 @@ spec:
   # to the default ones to make the cluster work
 {% if use_private_registry %}
   imageName: "{{ dsc.global.registry }}/cloudnative-pg/postgresql:16.1"
+{% elif dsc.gitlab.cnpg.imageName %}
+  imageName: "{{ dsc.gitlab.cnpg.imageName }}"
 {% endif %}
 {% if use_image_pull_secrets %}
   imagePullSecrets:

--- a/roles/harbor/templates/pg-cluster-harbor.yaml.j2
+++ b/roles/harbor/templates/pg-cluster-harbor.yaml.j2
@@ -17,6 +17,8 @@ spec:
   # to the default ones to make the cluster work
 {% if use_private_registry %}
   imageName: "{{ dsc.global.registry }}/cloudnative-pg/postgresql:16.1"
+{% elif dsc.harbor.cnpg.imageName %}
+  imageName: "{{ dsc.harbor.cnpg.imageName }}"
 {% endif %}
 {% if use_image_pull_secrets %}
   imagePullSecrets:

--- a/roles/keycloak/templates/pg-cluster-keycloak.yaml.j2
+++ b/roles/keycloak/templates/pg-cluster-keycloak.yaml.j2
@@ -17,6 +17,8 @@ spec:
   # to the default ones to make the cluster work
 {% if use_private_registry %}
   imageName: "{{ dsc.global.registry }}/cloudnative-pg/postgresql:16.1"
+{% elif dsc.keycloak.cnpg.imageName %}
+  imageName: "{{ dsc.keycloak.cnpg.imageName }}"
 {% endif %}
 {% if use_image_pull_secrets %}
   imagePullSecrets:

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -245,6 +245,9 @@ spec:
                             - primary
                             - replica
                             - restore
+                        imageName:
+                          description: Name of the container image, supporting both tags (`<image>:<tag>`) and digests for deterministic and repeatable deployments (`<image>:<tag>@sha256:<digestValue>`). See. https://cloudnative-pg.io/documentation/1.24/operator_capability_levels/#override-of-operand-images-through-the-crd
+                          type: string
                         exposed:
                           description: Whether or not the cnpg cluster should be exposed via NodePort.
                           type: boolean
@@ -340,6 +343,9 @@ spec:
                             - primary
                             - replica
                             - restore
+                        imageName:
+                          description: Name of the container image, supporting both tags (`<image>:<tag>`) and digests for deterministic and repeatable deployments (`<image>:<tag>@sha256:<digestValue>`). See. https://cloudnative-pg.io/documentation/1.24/operator_capability_levels/#override-of-operand-images-through-the-crd
+                          type: string
                         exposed:
                           description: Whether or not the cnpg cluster should be exposed via NodePort.
                           type: boolean
@@ -824,6 +830,9 @@ spec:
                             - primary
                             - replica
                             - restore
+                        imageName:
+                          description: Name of the container image, supporting both tags (`<image>:<tag>`) and digests for deterministic and repeatable deployments (`<image>:<tag>@sha256:<digestValue>`). See. https://cloudnative-pg.io/documentation/1.24/operator_capability_levels/#override-of-operand-images-through-the-crd
+                          type: string
                         exposed:
                           description: Whether or not the cnpg cluster should be exposed via NodePort.
                           type: boolean
@@ -984,6 +993,9 @@ spec:
                             - primary
                             - replica
                             - restore
+                        imageName:
+                          description: Name of the container image, supporting both tags (`<image>:<tag>`) and digests for deterministic and repeatable deployments (`<image>:<tag>@sha256:<digestValue>`). See. https://cloudnative-pg.io/documentation/1.24/operator_capability_levels/#override-of-operand-images-through-the-crd
+                          type: string
                         exposed:
                           description: Whether or not the cnpg cluster should be exposed via NodePort.
                           type: boolean
@@ -1152,6 +1164,9 @@ spec:
                             - primary
                             - replica
                             - restore
+                        imageName:
+                          description: Name of the container image, supporting both tags (`<image>:<tag>`) and digests for deterministic and repeatable deployments (`<image>:<tag>@sha256:<digestValue>`). See. https://cloudnative-pg.io/documentation/1.24/operator_capability_levels/#override-of-operand-images-through-the-crd
+                          type: string
                         exposed:
                           description: Whether or not the cnpg cluster should be exposed via NodePort.
                           type: boolean

--- a/roles/sonarqube/templates/pg-cluster-sonar.yaml.j2
+++ b/roles/sonarqube/templates/pg-cluster-sonar.yaml.j2
@@ -17,6 +17,8 @@ spec:
   # to the default ones to make the cluster work
 {% if use_private_registry %}
   imageName: "{{ dsc.global.registry }}/cloudnative-pg/postgresql:16.1"
+{% elif dsc.sonarqube.cnpg.imageName %}
+  imageName: "{{ dsc.sonarqube.cnpg.imageName }}"
 {% endif %}
 {% if use_image_pull_secrets %}
   imagePullSecrets:


### PR DESCRIPTION
<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Les images utilisées par nos cluster Postgres ne sont pas personnalisables.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Il est désormais possible de surcharger l'image Postgres par défaut via la DSC.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
https://cloudnative-pg.io/documentation/1.24/operator_capability_levels/#override-of-operand-images-through-the-crd
