### PR TITLE
Feat/upgrade nexus

### DIFF
--- a/roles/nexus/tasks/main.yaml
+++ b/roles/nexus/tasks/main.yaml
@@ -1,4 +1,21 @@
 ---
+- name: Check if first install
+  block:
+    - name: Initialize first_install fact
+      ansible.builtin.set_fact:
+        first_install: false
+
+    - name: Check Nexus Pod
+      kubernetes.core.k8s_info:
+        kind: Pod
+        namespace: "{{ dsc.nexus.namespace }}"
+      register: check_nx_pod
+
+    - name: Set first_install fact
+      when: check_nx_pod.resources | length == 0
+      ansible.builtin.set_fact:
+        first_install: true
+
 - name: Create nexus Namespace
   kubernetes.core.k8s:
     definition:
@@ -41,6 +58,7 @@
   delay: 5
 
 - name: Retrieve initial admin password on first install
+  when: first_install
   block:
     - name: Get nexus pod's name
       kubernetes.core.k8s_info:
@@ -62,7 +80,7 @@
       ignore_errors: true
 
 - name: Change Nexus password on first install
-  when: initial_admin_password.stdout | length > 0
+  when: first_install
   block:
     - name: Generate random password
       ansible.builtin.set_fact:

--- a/roles/nexus/tasks/main.yaml
+++ b/roles/nexus/tasks/main.yaml
@@ -40,32 +40,8 @@
   retries: 25
   delay: 5
 
-- name: Find nexus admin password in inventory
-  kubernetes.core.k8s_info:
-    namespace: "{{ dsc.console.namespace }}"
-    kind: Secret
-    name: dso-config
-  register: ansible_inventory
-
-- name: Cache admin password
-  ansible.builtin.set_fact:
-    nexus_admin_password: "{{ ansible_inventory.resources[0].data.NEXUS_ADMIN_PASSWORD | b64decode }}"
-  register: set_nx_pass
-  when: ansible_inventory.resources | length > 0 and ansible_inventory.resources[0].data.NEXUS_ADMIN_PASSWORD is defined
-
-- name: Change Nexus password
-  when: set_nx_pass.skipped is defined and set_nx_pass.skipped
+- name: Retrieve initial admin password on first install
   block:
-    - name: Wait nexus to initialize
-      kubernetes.core.k8s_info:
-        kind: Endpoints
-        namespace: "{{ dsc.nexus.namespace }}"
-        name: nexus
-      register: endpoint
-      until: endpoint.resources[0].subsets is defined and endpoint.resources[0].subsets | selectattr('addresses')
-      retries: 30
-      delay: 5
-
     - name: Get nexus pod's name
       kubernetes.core.k8s_info:
         kind: Endpoints
@@ -77,38 +53,17 @@
       ansible.builtin.set_fact:
         nx_pod: "{{ nx_ep.resources[0].subsets[0].addresses[0].targetRef.name }}"
 
-    - name: Set default_pass fact
-      ansible.builtin.set_fact:
-        default_pass: "\\\\\\$shiro1\\\\\\$SHA-512\\\\\\$1024\\\\\\$NE+wqQq/TmjZMvfI7ENh/g==\\\\\\$V4yPw8T64UQ6GfJfxYq2hLsVrBY8D1v+bktfOxGdt4b/9BthpWPNUy/CBk6V9iA0nHpzYzJFWO8v/tZFtES8CA=="
-
-    - name: Temporarily reset admin password to admin123
+    - name: Get initial admin password
       kubernetes.core.k8s_exec:
         pod: "{{ nx_pod }}"
         namespace: "{{ dsc.nexus.namespace }}"
-        command: |
-          sh -c "cd /nexus-data ; \
-          java -jar $NEXUS_HOME/lib/support/nexus-orient-console.jar \
-          connect plocal:./db/security admin admin \; update user SET password=\\\""{{ default_pass }}"\\\" UPSERT WHERE id=\\\"admin\\\" \;"
+        command: cat /nexus-data/admin.password
+      register: initial_admin_password
+      ignore_errors: true
 
-    - name: Restart Nexus pod
-      kubernetes.core.k8s:
-        kind: Pod
-        namespace: "{{ dsc.nexus.namespace }}"
-        name: "{{ nx_pod }}"
-        state: absent
-
-    - name: Wait Nexus URL
-      ansible.builtin.uri:
-        url: https://{{ nexus_domain }}
-        method: GET
-        validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-        status_code: [200, 202]
-        return_content: false
-      register: nexus_response
-      until: nexus_response is not failed
-      retries: 60
-      delay: 5
-
+- name: Change Nexus password on first install
+  when: initial_admin_password.stdout | length > 0
+  block:
     - name: Generate random password
       ansible.builtin.set_fact:
         new_pass: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters') }}"
@@ -120,7 +75,7 @@
         url: https://{{ nexus_domain }}/service/rest/v1/security/users/admin/change-password
         method: PUT
         user: admin
-        password: admin123
+        password: "{{ initial_admin_password.stdout }}"
         body: "{{ new_pass }}"
         body_format: raw
         headers:

--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -44,7 +44,7 @@ spec:
     chartVersion: 3.1.4
   nexus:
     # https://hub.docker.com/r/sonatype/nexus3/
-    imageTag: 3.75.1
+    imageTag: 3.76.0
   sonarqube:
     # https://artifacthub.io/packages/helm/sonarqube/sonarqube
     chartVersion: 10.7.0+3598

--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -44,7 +44,7 @@ spec:
     chartVersion: 3.1.4
   nexus:
     # https://hub.docker.com/r/sonatype/nexus3/
-    imageTag: 3.68.1
+    imageTag: 3.75.1
   sonarqube:
     # https://artifacthub.io/packages/helm/sonarqube/sonarqube
     chartVersion: 10.7.0+3598

--- a/versions.md
+++ b/versions.md
@@ -13,6 +13,6 @@
 | harbor                    | 2.12.0           | 1.16.0        | [harbor](https://artifacthub.io/packages/helm/harbor/harbor)                                                         |
 | keycloak                  | 26.0.7           | 24.2.3        | [keycloak](https://artifacthub.io/packages/helm/bitnami/keycloak)                                                    |
 | kyverno                   | v1.11.4          | 3.1.4         | [kyverno](https://artifacthub.io/packages/helm/kyverno/kyverno)                                                      |
-| nexus                     | 3.75.1           | N/A           | [nexus](https://hub.docker.com/r/sonatype/nexus3/)                                                                   |
+| nexus                     | 3.76.0           | N/A           | [nexus](https://hub.docker.com/r/sonatype/nexus3/)                                                                   |
 | sonarqube                 | 10.7.0-community | 10.7.0+3598   | [sonarqube](https://artifacthub.io/packages/helm/sonarqube/sonarqube)                                                |
 | vault                     | 1.18.1           | 0.29.1        | [vault](https://artifacthub.io/packages/helm/hashicorp/vault)                                                        |

--- a/versions.md
+++ b/versions.md
@@ -13,6 +13,6 @@
 | harbor                    | 2.12.0           | 1.16.0        | [harbor](https://artifacthub.io/packages/helm/harbor/harbor)                                                         |
 | keycloak                  | 26.0.7           | 24.2.3        | [keycloak](https://artifacthub.io/packages/helm/bitnami/keycloak)                                                    |
 | kyverno                   | v1.11.4          | 3.1.4         | [kyverno](https://artifacthub.io/packages/helm/kyverno/kyverno)                                                      |
-| nexus                     | 3.68.1           | N/A           | [nexus](https://hub.docker.com/r/sonatype/nexus3/)                                                                   |
+| nexus                     | 3.75.1           | N/A           | [nexus](https://hub.docker.com/r/sonatype/nexus3/)                                                                   |
 | sonarqube                 | 10.7.0-community | 10.7.0+3598   | [sonarqube](https://artifacthub.io/packages/helm/sonarqube/sonarqube)                                                |
 | vault                     | 1.18.1           | 0.29.1        | [vault](https://artifacthub.io/packages/helm/hashicorp/vault)                                                        |


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Installe la version 3.68.1 de Nexus.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Installe la version 3.76.0 de Nexus.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Oui.
Comme indiqué sur la [page de téléchargement](https://help.sonatype.com/en/download.html), au-delà des versions 3.70.x de Nexus, la BDD orientdb est abandonnée et doit être migrée.
Un breaking change est donc introduit, qui nécessite d'avoir préalablement migré vers un autre SGBD.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Upgrade de version et migration de la BDD depuis orientdb vers H2 testés avec succès dans un cluster de développement.
Une fois pas PR merged dans develop, nous prévoyons une nouvelle release du socle, accompagnée de la documentation d'upgrade.

