### PR TITLE
fix: :bug: add missing keycloak default client scope

### DIFF
--- a/roles/keycloak/vars/main.yaml
+++ b/roles/keycloak/vars/main.yaml
@@ -8,6 +8,7 @@ keycloak_clients:
     webOrigins:
       - https://{{ gitlab_domain }}
     defaultClientScopes:
+      - basic
       - generic
     publicClient: false
 
@@ -17,6 +18,7 @@ keycloak_clients:
     redirectUris: "{{ lookup('ansible.builtin.template', 'console-redirectUris.yaml.j2') | from_yaml }}"
     webOrigins: "{{ lookup('ansible.builtin.template', 'console-webOrigins.yaml.j2') | from_yaml }}"
     defaultClientScopes:
+      - basic
       - generic
     publicClient: true
 
@@ -26,6 +28,7 @@ keycloak_clients:
     redirectUris: "{{ lookup('ansible.builtin.template', 'console-redirectUris.yaml.j2') | from_yaml }}"
     webOrigins: "{{ lookup('ansible.builtin.template', 'console-webOrigins.yaml.j2') | from_yaml }}"
     defaultClientScopes:
+      - basic
       - generic
     publicClient: false
 
@@ -39,6 +42,7 @@ keycloak_clients:
     webOrigins:
       - https://{{ argocd_domain }}
     defaultClientScopes:
+      - basic
       - generic
     publicClient: false
 
@@ -50,6 +54,7 @@ keycloak_clients:
     webOrigins:
       - "*"
     defaultClientScopes:
+      - basic
       - generic
     publicClient: false
 
@@ -61,6 +66,7 @@ keycloak_clients:
     webOrigins:
       - https://{{ sonar_domain }}
     defaultClientScopes:
+      - basic
       - generic
     publicClient: false
 
@@ -72,6 +78,7 @@ keycloak_clients:
     webOrigins:
       - https://{{ harbor_domain }}
     defaultClientScopes:
+      - basic
       - generic
     publicClient: false
 
@@ -84,6 +91,7 @@ keycloak_clients:
     webOrigins:
       - https://{{ grafana_domain }}
     defaultClientScopes:
+      - basic
       - generic
     publicClient: false
 
@@ -96,5 +104,6 @@ keycloak_clients:
     webOrigins:
       - https://{{ vault_domain }}
     defaultClientScopes:
+      - basic
       - generic
     publicClient: false


### PR DESCRIPTION
<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Par défaut, Keycloak n'ajoute plus le client scope `basic` sur les client générés, or ce client scope contient notamment l'ID (sub) de l'utilisateur.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Nous ajoutons nous même ce client scope via Ansible.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
