### PR TITLE
fix: :bug: Fix Harbor ingress values

### DIFF
--- a/roles/harbor/templates/values/00-main.j2
+++ b/roles/harbor/templates/values/00-main.j2
@@ -6,23 +6,9 @@ expose:
     hosts:
       core: {{ harbor_domain }}
       notary: {{ dsc.harbor.subDomain }}-notary{{ root_domain }}
-    notary:
-      annotations:
+    annotations:
 {% for key, val in dsc.ingress.annotations.items() %}
-        {{ key }}: {{ val }}
-{% endfor %}
-      labels:
-{% for key, val in dsc.ingress.labels.items() %}
-        {{ key }}: {{ val }}
-{% endfor %}
-    harbor:
-      annotations:
-{% for key, val in dsc.ingress.annotations.items() %}
-        {{ key }}: {{ val }}
-{% endfor %}
-      labels:
-{% for key, val in dsc.ingress.labels.items() %}
-        {{ key }}: {{ val }}
+      {{ key }}: {{ val }}
 {% endfor %}
 externalURL: https://{{ harbor_domain }}
 persistence:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Une installation de Harbor s'appuyant par exemple sur cert-manager pour la signature de l'ingress n'est pas fonctionnelle.
Le secret `harbor-ingress` n'est pas créé, car il manque l'annotation nécessaire.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Une installation de Harbor dans le contexte indiqué est fonctionnelle.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Le problème était lié au fait que les sections `expose.ingress.harbor` et `expose.ingress.notary` des values n'existent plus dans la version 1.16.0 du chart Helm que nous déployons.
Au lieu de nous appuyer sur ces éléments, nous utilisons la section `expose.ingress.annotations` à la place.

Comportement testé et validé dans un cluster de développement.