### PR TITLE
fix: :bug: add proxycache into gitlab-ci kaniko args

### DIFF
--- a/roles/gitlab/tasks/main.yaml
+++ b/roles/gitlab/tasks/main.yaml
@@ -378,6 +378,11 @@
         value: "{{ [additionals_ca_pem, exposed_ca_pem] | join('\n') }}"
         variable_type: file
 
+- name: Append registry mirror arguments to extra_kaniko_args
+  ansible.builtin.set_fact:
+    extra_kaniko_args: "{{ extra_kaniko_args | default('') }} --registry-mirror {{ item.registry.endpointUrl | regex_replace('^https?://', '') }}/{{ item.name }}"
+  loop: "{{ dsc.harbor.proxyCache }}"
+
 - name: Set or update insecure args variables
   community.general.gitlab_group_variable:
     api_url: https://{{ gitlab_domain }}
@@ -388,7 +393,7 @@
     state: "{{ dsc.gitlab.insecureCI | ternary('present', 'absent') }}"
     variables:
       - name: EXTRA_KANIKO_ARGS
-        value: --skip-tls-verify
+        value: --skip-tls-verify {{ extra_kaniko_args }}
       - name: EXTRA_GIT_ARGS
         value: -c http.sslVerify=false
       - name: EXTRA_VAULT_ARGS


### PR DESCRIPTION
## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Lorsque l'on ajoute des proxyCache Harbor dans la DSC, ces derniers ne sont pas automatiquement ajoutés dans la variable de gitlab-ci `KANIKO_EXTRA_ARGS`.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Les proxy sont automatiquement ajoutés dans la variable de gitlab-ci et donc prêt à l'emploi pour les utilisateurs.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
cf. https://github.com/GoogleContainerTools/kaniko/blob/main/README.md#flag---registry-mirror
