### PR TITLE
fix: :bug: ignore proxy in kaniko args if not in dsc

### DIFF
--- a/roles/gitlab/tasks/main.yaml
+++ b/roles/gitlab/tasks/main.yaml
@@ -386,6 +386,7 @@
   ansible.builtin.set_fact:
     extra_kaniko_args: "{{ extra_kaniko_args | default('') }} --registry-mirror {{ item.registry.endpointUrl | regex_replace('^https?://', '') }}/{{ item.name }}"
   loop: "{{ dsc.harbor.proxyCache }}"
+  when: dsc.harbor.proxyCache is defined
 
 - name: Set or update insecure args variables
   community.general.gitlab_group_variable:
@@ -397,7 +398,7 @@
     state: "{{ dsc.gitlab.insecureCI | ternary('present', 'absent') }}"
     variables:
       - name: EXTRA_KANIKO_ARGS
-        value: --skip-tls-verify {{ extra_kaniko_args }}
+        value: --skip-tls-verify {{ extra_kaniko_args | default('') }}
       - name: EXTRA_GIT_ARGS
         value: -c http.sslVerify=false
       - name: EXTRA_VAULT_ARGS


### PR DESCRIPTION
## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
La tâche ansible échoue si `dsc.harbor.proxyCache` n'est pas déclarée.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
La tâche ansible ignore `extra_kaniko_args` si `dsc.harbor.proxyCache` n'est pas déclarée.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
