### PR TITLE
Fix/keycloak admin

### DIFF
--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -6,6 +6,8 @@
     kind: Namespace
     state: present
 
+# Setup CNPG s3 secret
+
 - name: CNPG s3 CA (secret)
   when: >
     dsc.global.backup.cnpg.enabled and
@@ -34,7 +36,10 @@
           data:
             ca.pem: "{{ cnpg_s3_ca_pem }}"
 
+# Setup CNPG backup
+
 - name: Set cnpg backup secret
+  when: dsc.global.backup.cnpg.enabled
   kubernetes.core.k8s:
     name: "{{ dsc.global.backup.s3.credentials.name }}"
     namespace: "{{ dsc.keycloak.namespace }}"
@@ -44,7 +49,6 @@
       data:
         accessKeyId: "{{ dsc.global.backup.s3.credentials.accessKeyId.value | b64encode }}"
         secretAccessKey: "{{ dsc.global.backup.s3.credentials.secretAccessKey.value | b64encode }}"
-  when: dsc.global.backup.cnpg.enabled
 
 - name: Remove cnpg scheduled backup
   kubernetes.core.k8s:
@@ -55,7 +59,9 @@
     state: absent
   when: not dsc.global.backup.cnpg.enabled
 
-- name: Create PostgreSQL cluster and keycloak database
+# Create CNPG cluster and Keycloak database
+
+- name: Create PostgreSQL cluster and Keycloak database
   kubernetes.core.k8s:
     template: "{{ item }}"
   with_items:
@@ -95,6 +101,8 @@
   retries: 30
   delay: 5
 
+# Set Keycloak admin password
+
 - name: Get Keycloak admin password secret
   kubernetes.core.k8s_info:
     namespace: "{{ dsc.keycloak.namespace }}"
@@ -115,6 +123,8 @@
         name: keycloak
         namespace: "{{ dsc.keycloak.namespace }}"
       type: Opaque
+
+# Deploy Keycloak
 
 - name: Add bitnami helm repo
   kubernetes.core.helm_repository:
@@ -153,6 +163,8 @@
   until: kc_response is not failed
   retries: 30
   delay: 5
+
+# Set admin facts and check access to Keycloak API
 
 - name: Get Keycloak admin password
   kubernetes.core.k8s_info:
@@ -195,6 +207,8 @@
 - name: Set kc_access_token fact
   ansible.builtin.set_fact:
     kc_access_token: "{{ kc_token.json.access_token }}"
+
+# Create permanent Keycloak admin and update DSO Console inventory
 
 - name: Get keycloak master realm users from API
   ansible.builtin.uri:
@@ -279,6 +293,8 @@
         KEYCLOAK_ADMIN_PASSWORD: "{{ keycloak_admin_password | b64encode }}"
         KEYCLOAK_ADMIN: "{{ 'dsoadmin' | b64encode }}"
 
+# Remove Keycloak temporary admin
+
 - name: Set temporary_admin_present fact
   ansible.builtin.set_fact:
     temporary_admin_present: false
@@ -300,6 +316,8 @@
     state: absent
     realm: master
     username: admin
+
+# Ensure we will use permanent admin for subsequent tasks
 
 - name: Get Keycloak API token
   ansible.builtin.uri:
@@ -330,6 +348,8 @@
 - name: Set kc_access_token fact
   ansible.builtin.set_fact:
     kc_access_token: "{{ kc_token.json.access_token }}"
+
+# Create and setup dso realm
 
 - name: Create dso realm
   community.general.keycloak_realm:
@@ -510,6 +530,8 @@
     auth_password: "{{ keycloak_admin_password }}"
     realm: dso
     otp_policy_algorithm: SHA256
+
+# Patch some metrics resources
 
 - name: Patch serviceMonitors
   when: >

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -189,21 +189,22 @@
   register: kc_token
   ignore_errors: true
 
-- name: Reset Keycloak admin fact
+- name: Reset Keycloak admin fact and API token
   when: kc_token is failed
-  ansible.builtin.set_fact:
-    keycloak_admin: dsoadmin
+  block:
+    - name: Reset Keycloak admin fact
+      ansible.builtin.set_fact:
+        keycloak_admin: dsoadmin
 
-- name: Get Keycloak API token
-  when: kc_token is failed
-  ansible.builtin.uri:
-    url: https://{{ keycloak_domain }}/realms/master/protocol/openid-connect/token
-    method: POST
-    status_code: [200, 202]
-    validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    return_content: true
-    body: username={{ keycloak_admin }}&password={{ keycloak_admin_password }}&grant_type=password&client_id=admin-cli
-  register: kc_token
+    - name: Get Keycloak API token
+      ansible.builtin.uri:
+        url: https://{{ keycloak_domain }}/realms/master/protocol/openid-connect/token
+        method: POST
+        status_code: [200, 202]
+        validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
+        return_content: true
+        body: username={{ keycloak_admin }}&password={{ keycloak_admin_password }}&grant_type=password&client_id=admin-cli
+      register: kc_token
 
 - name: Set kc_access_token fact
   ansible.builtin.set_fact:

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -116,68 +116,6 @@
         namespace: "{{ dsc.keycloak.namespace }}"
       type: Opaque
 
-- name: Check Keycloak helm release
-  kubernetes.core.helm_info:
-    name: keycloak
-    namespace: "{{ dsc.keycloak.namespace }}"
-  register: kc_helm_release
-
-- name: Reset Keycloak admin password
-  when: >
-    kc_helm_release.status is defined and
-    kc_adm_pass_secret.resources | length == 0
-  block:
-    - name: Get Keycloak primary BDD pod
-      kubernetes.core.k8s_info:
-        kind: Pod
-        label_selectors:
-          - "cnpg.io/cluster=pg-cluster-keycloak"
-          - "cnpg.io/instanceRole=primary"
-      register: kc_bdd_pod
-
-    - name: Get Keycloak admin ID from database
-      kubernetes.core.k8s_exec:
-        pod: "{{ kc_bdd_pod.resources[0].metadata.name }}"
-        namespace: "{{ dsc.keycloak.namespace }}"
-        command: >
-          psql -U postgres -d keycloak --csv -c "\x" -c "select id from user_entity where username = 'admin';"
-      register: kc_admin_id
-
-    - name: Set kc_admin_id fact
-      ansible.builtin.set_fact:
-        kc_admin_id: "{{ kc_admin_id.stdout | regex_search('^id.*', multiline=True) | regex_search('id,(.+)', '\\1') | first }}"
-
-    - name: Delete Keycloak admin in database
-      kubernetes.core.k8s_exec:
-        pod: "{{ kc_bdd_pod.resources[0].metadata.name }}"
-        namespace: "{{ dsc.keycloak.namespace }}"
-        command: >
-          psql -U postgres -d keycloak -c "delete from credential where user_id = '"{{ kc_admin_id }}"';"
-          -c "delete from user_role_mapping where user_id = '"{{ kc_admin_id }}"';"
-          -c "delete from user_entity where id = '"{{ kc_admin_id }}"';"
-          -c "delete from user_required_action where user_id = '"{{ kc_admin_id }}"';"
-
-    - name: Restart Keycloak pods to reset admin password
-      kubernetes.core.k8s:
-        kind: Pod
-        namespace: "{{ dsc.keycloak.namespace }}"
-        label_selectors:
-          - "app.kubernetes.io/component=keycloak"
-          - "app.kubernetes.io/instance=keycloak"
-        state: absent
-
-    - name: Wait Keycloak URL
-      ansible.builtin.uri:
-        url: https://{{ keycloak_domain }}
-        validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-        method: GET
-        status_code: [200, 202]
-        return_content: false
-      register: kc_response
-      until: kc_response is not failed
-      retries: 30
-      delay: 5
-
 - name: Add bitnami helm repo
   kubernetes.core.helm_repository:
     name: bitnami
@@ -223,10 +161,112 @@
     name: keycloak
   register: kc_adm_pass
 
-- name: Set Keycloak admin name fact
+- name: Set Keycloak admin facts
   ansible.builtin.set_fact:
     keycloak_admin_password: "{{ kc_adm_pass.resources[0].data['admin-password'] | b64decode }}"
     keycloak_admin: admin
+
+- name: Get Keycloak API token
+  ansible.builtin.uri:
+    url: https://{{ keycloak_domain }}/realms/master/protocol/openid-connect/token
+    method: POST
+    status_code: [200, 202]
+    validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
+    return_content: true
+    body: username={{ keycloak_admin }}&password={{ keycloak_admin_password }}&grant_type=password&client_id=admin-cli
+  register: kc_token
+  ignore_errors: true
+
+- name: Reset Keycloak admin fact
+  when: kc_token is failed
+  ansible.builtin.set_fact:
+    keycloak_admin: dsoadmin
+
+- name: Get Keycloak API token
+  ansible.builtin.uri:
+    url: https://{{ keycloak_domain }}/realms/master/protocol/openid-connect/token
+    method: POST
+    status_code: [200, 202]
+    validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
+    return_content: true
+    body: username={{ keycloak_admin }}&password={{ keycloak_admin_password }}&grant_type=password&client_id=admin-cli
+  register: kc_token
+
+- name: Set kc_access_token fact
+  ansible.builtin.set_fact:
+    kc_access_token: "{{ kc_token.json.access_token }}"
+
+- name: Get keycloak master realm users from API
+  ansible.builtin.uri:
+    url: https://{{ keycloak_domain }}/admin/realms/master/users
+    method: GET
+    status_code: [200, 202]
+    return_content: true
+    validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
+    body_format: json
+    headers:
+      Authorization: bearer {{ kc_access_token }}
+  register: kc_master_users
+
+- name: Set permanent_admin_present fact
+  ansible.builtin.set_fact:
+    permanent_admin_present: false
+
+- name: Update admin_present fact
+  when: kc_master_users.json | selectattr('username', 'equalto', 'dsoadmin')
+  ansible.builtin.set_fact:
+    permanent_admin_present: true
+
+- name: Create permanent admin group and user into master realm
+  when: not permanent_admin_present
+  block:
+    - name: Create admin group
+      community.general.keycloak_group:
+        auth_client_id: admin-cli
+        auth_keycloak_url: https://{{ keycloak_domain }}
+        auth_realm: master
+        auth_username: "{{ keycloak_admin }}"
+        auth_password: "{{ keycloak_admin_password }}"
+        name: admin
+        realm: master
+        state: present
+
+    - name: Map admin realm role from admin group
+      community.general.keycloak_realm_rolemapping:
+        realm: master
+        auth_client_id: admin-cli
+        auth_keycloak_url: https://{{ keycloak_domain }}
+        auth_realm: master
+        auth_username: "{{ keycloak_admin }}"
+        auth_password: "{{ keycloak_admin_password }}"
+        state: present
+        group_name: admin
+        roles:
+          - name: admin
+
+    - name: Create master realm permanent admin user
+      community.general.keycloak_user:
+        validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
+        auth_client_id: admin-cli
+        auth_keycloak_url: https://{{ keycloak_domain }}
+        auth_realm: master
+        auth_username: "{{ keycloak_admin }}"
+        auth_password: "{{ keycloak_admin_password }}"
+        state: present
+        realm: master
+        credentials:
+          - temporary: false
+            type: password
+            value: "{{ keycloak_admin_password }}"
+        username: dsoadmin
+        first_name: Admin
+        last_name: Admin
+        email: admin@example.com
+        enabled: true
+        email_verified: true
+        groups:
+          - name: admin
+            state: present
 
 - name: Update console inventory
   kubernetes.core.k8s:
@@ -237,7 +277,45 @@
     definition:
       data:
         KEYCLOAK_ADMIN_PASSWORD: "{{ keycloak_admin_password | b64encode }}"
-        KEYCLOAK_ADMIN: "{{ keycloak_admin | b64encode }}"
+        KEYCLOAK_ADMIN: "{{ 'dsoadmin' | b64encode }}"
+
+- name: Set temporary_admin_present fact
+  ansible.builtin.set_fact:
+    temporary_admin_present: false
+
+- name: Update temporary_admin_present fact
+  when: kc_master_users.json | selectattr('username', 'equalto', 'admin')
+  ansible.builtin.set_fact:
+    temporary_admin_present: true
+
+- name: Remove temporary admin from master realm
+  when: temporary_admin_present
+  community.general.keycloak_user:
+    validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
+    auth_client_id: admin-cli
+    auth_keycloak_url: https://{{ keycloak_domain }}
+    auth_realm: master
+    auth_username: "{{ keycloak_admin }}"
+    auth_password: "{{ keycloak_admin_password }}"
+    state: absent
+    realm: master
+    username: admin
+
+- name: Get Keycloak API token
+  ansible.builtin.uri:
+    url: https://{{ keycloak_domain }}/realms/master/protocol/openid-connect/token
+    method: POST
+    status_code: [200, 202]
+    validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
+    return_content: true
+    body: username={{ keycloak_admin }}&password={{ keycloak_admin_password }}&grant_type=password&client_id=admin-cli
+  register: kc_token
+  ignore_errors: true
+
+- name: Reset Keycloak admin fact
+  when: kc_token is failed
+  ansible.builtin.set_fact:
+    keycloak_admin: dsoadmin
 
 - name: Get Keycloak API token
   ansible.builtin.uri:

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -195,6 +195,7 @@
     keycloak_admin: dsoadmin
 
 - name: Get Keycloak API token
+  when: kc_token is failed
   ansible.builtin.uri:
     url: https://{{ keycloak_domain }}/realms/master/protocol/openid-connect/token
     method: POST


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Installe Keycloak avec un utilisateur admin temporaire dans le realm master. Ceci étant lié aux dernières évolutions de l'outil à partir de la version 26.0.0.
Tente de réinitialiser le mot de passe admin en cas de perte du secret keycloak, via une méthode dépréciée.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Déploie Keycloak en créant un administrateur permanent et en supprimant l'administrateur temporaire.
Ne tente pas de réinitialiser le mot de passe admin en cas de perte du secret. Il faut pour l'instant le faire manuellement si besoin (voir section « Autres informations » ci-dessous).

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.

Pour réinitialiser le mot de passe admin Keycloak en cas de perte, se référer à la documentation officielle suivante :
- https://www.keycloak.org/server/bootstrap-admin-recovery

Plus précisément, il s'agira de [créer un compte administrateur temporaire](https://www.keycloak.org/server/bootstrap-admin-recovery#_create_an_admin_user) et de l'utiliser pour aller rétablir le mot de passe de notre compte administrateur habituel.

La documentation sur ce point est incomplète dans un contexte Kubernetes et doit être adaptée comme suit.

Vérifier dans notre namespace Keycloak la présence et le nom du service Keycloak headless qui devrait en principe être `keycloak-headless`.

Ouvrir un shell dans le container `keycloak` sur l'un des pods Keycloak, exemple :
```bash
kubectl exec -it -c keycloak -n dso-keycloak keycloak-0 -- bash
```

Nous allons devoir injecter les options suivantes à la variable d'environnement `JAVA_OPTS_APPEND`, en adaptant l'option `-Djgroups.dns.query` avec notre service headless et notre namespace, et en positionnant l'option `-Djgroups.bind.port` sur le port 7900, exemple :
```bash
JAVA_OPTS_APPEND='-Djgroups.dns.query=keycloak-headless.dso-keycloak.svc.cluster.local -Djgroups.bind.port=7900'
```

Puis nous lançons la commande indiquée dans la documentation et qui permet de créer un utilisateur admin temporaire :
```bash
kc.sh bootstrap-admin user
```

La commande étant interactive, elle nous demandera de précider le nom de l'admin temporaire souhaité et son mot de passe.

Nous pourrons ensuite nous connecter avec cet admin temporaire à l'interface web de notre instance de Keycloak, puis aller **rétablir le mot de passe de notre utilisateur admin habituel**.

Une fois le mot de passe admin rétabli dans Keycloak :
- Se déconnecter de Keycloak et se reconnecter avec l'utilisateur admin habituel, avec le MDP rétabli.
- Supprimer l'utilisateur admin temporaire que nous avons créé précédemment. 
- Penser à noter le MDP rétabli dans un gestionnaire de mots de passe sécurisé.
- Éditer si besoin le secret approprié de notre namespace Keycloak (en principe le secret nommé `keycloak`) afin d'y injecter le bon mot de passe.
- Actualiser si besoin le secret `dso-config` du namespace de la Console DSO afin d'y injecter le bon mot de passe.
- Redémarrer si besoin (rollout restart) le deployment `dso-cpn-console-server` dans le namespace de la Console DSO. 
