### PR TITLE
feat: :sparkles: Add keycloak admin reset playbook

### DIFF
--- a/admin-tools/keycloak-admin-password-reset.yaml
+++ b/admin-tools/keycloak-admin-password-reset.yaml
@@ -158,3 +158,58 @@
         state: absent
         realm: master
         username: tmpadm
+
+    - name: Get DSO Console server deployment
+      kubernetes.core.k8s_info:
+        kind: Deployment
+        namespace: "{{ dsc.console.namespace }}"
+        label_selectors:
+          - app.kubernetes.io/name=cpn-console-server
+      register: console_server_deploy
+
+    - name: Set console_server_deploy_name fact
+      when: console_server_deploy.resources | length > 0
+      ansible.builtin.set_fact:
+        console_server_deploy_name: "{{ console_server_deploy.resources[0].metadata.name }}"
+
+    - name: Restart DSO Console server deployment
+      when: console_server_deploy.resources | length > 0
+      kubernetes.core.k8s:
+        kind: Deployment
+        name: "{{ console_server_deploy_name }}"
+        namespace: "{{ dsc.console.namespace }}"
+        definition:
+          spec:
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/restartedAt: "{{ now(fmt='%Y-%m-%dT%H:%M:%SZ') }}"
+        state: patched
+      register: console_server_restart
+
+    - name: Info message
+      block:
+        - name: Keycloak admin password changed
+          when: not console_server_restart is changed
+          ansible.builtin.debug:
+            msg:
+              - "Réinitialisation du mot de passe administrateur de l'instancce Keycloak suivante effectué :"
+              - "    URL : https://{{ dsc.keycloak.subDomain }}{{ dsc.global.rootDomain }}"
+              - "    Namespace : {{ dsc.keycloak.namespace }}"
+              - ""
+              - "Nouveaux identifiants :"
+              - "    Utilisateur : dsoadmin "
+              - "    Mot de passe : {{ kc_adm_pass }} "
+        - name: Keycloak admin password changed and Console server restarted
+          when: console_server_restart is changed
+          ansible.builtin.debug:
+            msg:
+              - "Réinitialisation du mot de passe administrateur de l'instancce Keycloak suivante effectué :"
+              - "    URL : https://{{ dsc.keycloak.subDomain }}{{ dsc.global.rootDomain }}"
+              - "    Namespace : {{ dsc.keycloak.namespace }}"
+              - ""
+              - "Nouveaux identifiants :"
+              - "    Utilisateur : dsoadmin "
+              - "    Mot de passe : {{ kc_adm_pass }} "
+              - ""
+              - "Le deployment {{ console_server_deploy_name }} a été redémarré dans le namespace {{ dsc.console.namespace }}."

--- a/admin-tools/keycloak-admin-password-reset.yaml
+++ b/admin-tools/keycloak-admin-password-reset.yaml
@@ -102,18 +102,6 @@
           kc.sh bootstrap-admin user --username tmpadm --password:env PASS_VAR"
       register: tmp_adm
 
-    - name: Remove dsoadmin user
-      community.general.keycloak_user:
-        validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-        auth_client_id: admin-cli
-        auth_keycloak_url: https://{{ dsc.keycloak.subDomain }}{{ dsc.global.rootDomain }}
-        auth_realm: master
-        auth_username: tmpadm
-        auth_password: "{{ tmp_adm_pass }}"
-        state: absent
-        realm: master
-        username: dsoadmin
-
     - name: Update dsoadmin user
       community.general.keycloak_user:
         validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
@@ -137,6 +125,7 @@
         groups:
           - name: admin
             state: present
+        force: true
 
     - name: Update keycloak secret
       kubernetes.core.k8s:

--- a/admin-tools/keycloak-admin-password-reset.yaml
+++ b/admin-tools/keycloak-admin-password-reset.yaml
@@ -1,0 +1,171 @@
+---
+- name: Reset Keycloak admin password
+  hosts: localhost
+  gather_facts: false
+  tasks:
+
+    - name: "Get socle config from conf-dso dsc (default)"
+      kubernetes.core.k8s_info:
+        kind: dsc
+        name: conf-dso
+        api_version: cloud-pi-native.fr/v1alpha
+      register: socle_config
+      tags:
+        - always
+
+    - name: Get socle config from dsc_cr extra var when defined
+      when: dsc_cr is defined
+      kubernetes.core.k8s_info:
+        kind: dsc
+        name: "{{ dsc_cr }}"
+        api_version: cloud-pi-native.fr/v1alpha
+      register: socle_config_custom
+      tags:
+        - always
+
+    - name: Check socle_config_custom and exit if empty
+      when: (dsc_cr is defined) and (socle_config_custom.resources | length == 0)
+      tags:
+        - always
+      block:
+        - name: Warning message
+          ansible.builtin.debug:
+            msg:
+              - "Attention ! Vous avez lancé le playbook avec l'option '-e dsc_cr={{ dsc_cr }}'"
+              - "mais la ressource dsc nommée '{{ dsc_cr }}' est vide ou inexistante côté cluster !"
+              - ""
+              - "Vérifiez que vous ne vous êtes pas trompé de nom et que la ressource existe bien, via la commande suivante :"
+              - ""
+              - " kubectl get dsc {{ dsc_cr }} "
+              - ""
+              - "Si elle n'est pas trouvée (not found), listez simplement les resources dsc actuellement déclarées :"
+              - ""
+              - " kubectl get dsc "
+              - ""
+              - "Puis relancez le playbook avec une resource dsc existante."
+              - ""
+              - "Rappel : le présent playbook lancé seul, sans extra vars, utilisera la configuration dsc par défaut (conf-dso)."
+              - "Il réinitialisera donc le mot de passe de l'administrateur Keycloak du namespace associé."
+
+        - name: Exit playbook
+          ansible.builtin.meta: end_play
+
+    - name: Set socle_config fact when dsc_cr defined and not empty
+      ansible.builtin.set_fact:
+        socle_config: "{{ socle_config_custom }}"
+      when: (socle_config_custom is not skipped) and (socle_config_custom.resources | length > 0)
+      tags:
+        - always
+
+    - name: Set DSC facts
+      ansible.builtin.set_fact:
+        dsc_name: "{{ socle_config.resources[0].metadata.name }}"
+        dsc: "{{ socle_config.resources[0] }}"
+        dsc_default_config: "{{ lookup('ansible.builtin.file', '../roles/socle-config/files/config.yaml') | from_yaml }}"
+        dsc_default_releases: "{{ lookup('ansible.builtin.file', '../roles/socle-config/files/releases.yaml') | from_yaml }}"
+      tags:
+        - always
+
+    - name: Combine DSC with config and releases
+      ansible.builtin.set_fact:
+        dsc: "{{ (dsc_default_releases | combine(dsc_default_config, recursive=True) | combine(dsc, recursive=True)).spec }}"
+      tags:
+        - always
+
+    - name: Get Keycloak pods
+      kubernetes.core.k8s_info:
+        namespace: "{{ dsc.keycloak.namespace }}"
+        kind: Pod
+        label_selectors:
+          - app.kubernetes.io/instance=keycloak
+      register: kc_pods
+
+    - name: Set kc_pod fact
+      ansible.builtin.set_fact:
+        kc_pod: "{{ kc_pods.resources[0].metadata.name }}"
+
+    - name: Set tmp_adm_pass fact
+      ansible.builtin.set_fact:
+        tmp_adm_pass: "{{ lookup('password', '/dev/null length=24 chars=ascii_letters,digits') }}"
+
+    - name: Set kc_adm_pass fact
+      ansible.builtin.set_fact:
+        kc_adm_pass: "{{ lookup('password', '/dev/null length=24 chars=ascii_letters,digits') }}"
+
+    - name: Create temporary admin user
+      kubernetes.core.k8s_exec:
+        pod: "{{ kc_pod }}"
+        namespace: "{{ dsc.keycloak.namespace }}"
+        command: >
+          bash -c "JAVA_OPTS_APPEND='-Djgroups.dns.query=keycloak-headless.{{ dsc.keycloak.namespace }}.svc.cluster.local -Djgroups.bind.port=7900';
+          export PASS_VAR='{{ tmp_adm_pass }}';
+          kc.sh bootstrap-admin user --username tmpadm --password:env PASS_VAR"
+      register: tmp_adm
+
+    - name: Remove dsoadmin user
+      community.general.keycloak_user:
+        validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
+        auth_client_id: admin-cli
+        auth_keycloak_url: https://{{ dsc.keycloak.subDomain }}{{ dsc.global.rootDomain }}
+        auth_realm: master
+        auth_username: tmpadm
+        auth_password: "{{ tmp_adm_pass }}"
+        state: absent
+        realm: master
+        username: dsoadmin
+
+    - name: Update dsoadmin user
+      community.general.keycloak_user:
+        validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
+        auth_client_id: admin-cli
+        auth_keycloak_url: https://{{ dsc.keycloak.subDomain }}{{ dsc.global.rootDomain }}
+        auth_realm: master
+        auth_username: tmpadm
+        auth_password: "{{ tmp_adm_pass }}"
+        state: present
+        realm: master
+        credentials:
+          - temporary: false
+            type: password
+            value: "{{ kc_adm_pass }}"
+        username: dsoadmin
+        first_name: Admin
+        last_name: Admin
+        email: admin@example.com
+        enabled: true
+        email_verified: true
+        groups:
+          - name: admin
+            state: present
+
+    - name: Update keycloak secret
+      kubernetes.core.k8s:
+        kind: Secret
+        name: keycloak
+        namespace: "{{ dsc.keycloak.namespace }}"
+        state: patched
+        definition:
+          data:
+            admin-password: "{{ kc_adm_pass | b64encode }}"
+
+    - name: Update console inventory
+      kubernetes.core.k8s:
+        kind: Secret
+        name: dso-config
+        namespace: "{{ dsc.console.namespace }}"
+        state: patched
+        definition:
+          data:
+            KEYCLOAK_ADMIN_PASSWORD: "{{ kc_adm_pass | b64encode }}"
+
+    - name: Remove temporary admin from master realm
+      community.general.keycloak_user:
+        validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
+        auth_client_id: admin-cli
+        auth_keycloak_url: https://{{ dsc.keycloak.subDomain }}{{ dsc.global.rootDomain }}
+        auth_realm: master
+        auth_username: dsoadmin
+        auth_password: "{{ kc_adm_pass }}"
+        state: absent
+        realm: master
+        username: tmpadm


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Nous ne disposons pas de solution automatisée de reset du MDP admin Keycloak.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Ajout du playbook "./admin-tools/keycloak-admin-password-reset.yaml" qui automatise le reset du MDP admin Keycloak.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.
