### PR TITLE
feat: :sparkles: Add keycloak user unlock playbook

### DIFF
--- a/admin-tools/keycloak-user-unlock.yaml
+++ b/admin-tools/keycloak-user-unlock.yaml
@@ -1,0 +1,169 @@
+---
+- name: Unlock Keycloak user
+  hosts: localhost
+  gather_facts: false
+  tasks:
+
+    - name: Check user fact and exit if not defined
+      when: user is not defined
+      tags:
+        - always
+      block:
+        - name: Warning message
+          ansible.builtin.debug:
+            msg:
+              - "Attention ! Vous avez lancé le playbook sans indiquer l'utilisateur à déverrouiller."
+              - ""
+              - "Pour préciser l'utilisateur à déverrouiller, veuiller utiliser l'extra variable 'user' comme ceci :"
+              - ""
+              - " ansible-playbook admin-tools/keycloak-unlock-user.yaml -e user=utilisateur-souhaité-ici "
+              - ""
+              - "Rappel : si vous n'utilisez pas l'extra variable 'dsc_cr', le présent playbook s'appuiera sur la configuration dsc par défaut (conf-dso)."
+              - "Il traitera donc l'instance Keycloak du namespace associé (par défaut 'dso-keycloak')."
+              - ""
+              - "Si vous voulez traiter une autre instance Keycloak, utilisant donc une autre dsc, veuillez utiliser l'extra variable 'dsc_cr', exemple :"
+              - ""
+              - " ansible-playbook admin-tools/keycloak-unlock-user.yaml -e user=utilisateur-souhaité-ici -e dsc_cr=ma-conf-dso"
+
+        - name: Exit playbook
+          ansible.builtin.meta: end_play
+
+    - name: "Get socle config from conf-dso dsc (default)"
+      kubernetes.core.k8s_info:
+        kind: dsc
+        name: conf-dso
+        api_version: cloud-pi-native.fr/v1alpha
+      register: socle_config
+
+    - name: Get socle config from dsc_cr extra var when defined
+      when: dsc_cr is defined
+      kubernetes.core.k8s_info:
+        kind: dsc
+        name: "{{ dsc_cr }}"
+        api_version: cloud-pi-native.fr/v1alpha
+      register: socle_config_custom
+
+    - name: Check socle_config_custom and exit if empty
+      when: (dsc_cr is defined) and (socle_config_custom.resources | length == 0)
+      block:
+        - name: Warning message
+          ansible.builtin.debug:
+            msg:
+              - "Attention ! Vous avez lancé le playbook avec l'option '-e dsc_cr={{ dsc_cr }}'"
+              - "mais la ressource dsc nommée '{{ dsc_cr }}' est vide ou inexistante côté cluster !"
+              - ""
+              - "Vérifiez que vous ne vous êtes pas trompé de nom et que la ressource existe bien, via la commande suivante :"
+              - ""
+              - " kubectl get dsc {{ dsc_cr }} "
+              - ""
+              - "Si elle n'est pas trouvée (not found), listez simplement les resources dsc actuellement déclarées :"
+              - ""
+              - " kubectl get dsc "
+              - ""
+              - "Puis relancez le playbook avec une resource dsc existante."
+              - ""
+              - "Rappel : le présent playbook lancé seul, sans extra vars, utilisera la configuration dsc par défaut (conf-dso)."
+              - "Il réinitialisera donc le mot de passe de l'administrateur Keycloak du namespace associé."
+
+        - name: Exit playbook
+          ansible.builtin.meta: end_play
+
+    - name: Set socle_config fact when dsc_cr defined and not empty
+      ansible.builtin.set_fact:
+        socle_config: "{{ socle_config_custom }}"
+      when: (socle_config_custom is not skipped) and (socle_config_custom.resources | length > 0)
+
+    - name: Set DSC facts
+      ansible.builtin.set_fact:
+        dsc_name: "{{ socle_config.resources[0].metadata.name }}"
+        dsc: "{{ socle_config.resources[0] }}"
+        dsc_default_config: "{{ lookup('ansible.builtin.file', '../roles/socle-config/files/config.yaml') | from_yaml }}"
+        dsc_default_releases: "{{ lookup('ansible.builtin.file', '../roles/socle-config/files/releases.yaml') | from_yaml }}"
+
+    - name: Combine DSC with config and releases
+      ansible.builtin.set_fact:
+        dsc: "{{ (dsc_default_releases | combine(dsc_default_config, recursive=True) | combine(dsc, recursive=True)).spec }}"
+
+    - name: Get Keycloak pods
+      kubernetes.core.k8s_info:
+        namespace: "{{ dsc.keycloak.namespace }}"
+        kind: Pod
+        label_selectors:
+          - app.kubernetes.io/instance=keycloak
+      register: kc_pods
+
+    - name: Set kc_pod fact
+      ansible.builtin.set_fact:
+        kc_pod: "{{ kc_pods.resources[0].metadata.name }}"
+
+    - name: Set temporary admin facts
+      ansible.builtin.set_fact:
+        tmp_admin_pass: "{{ lookup('password', '/dev/null length=24 chars=ascii_letters,digits') }}"
+        tmp_admin: tmpadm
+
+    - name: Create temporary admin user
+      kubernetes.core.k8s_exec:
+        pod: "{{ kc_pod }}"
+        namespace: "{{ dsc.keycloak.namespace }}"
+        command: >
+          bash -c "JAVA_OPTS_APPEND='-Djgroups.dns.query=keycloak-headless.{{ dsc.keycloak.namespace }}.svc.cluster.local -Djgroups.bind.port=7900';
+          export PASS_VAR='{{ tmp_admin_pass }}';
+          kc.sh bootstrap-admin user --username {{ tmp_admin }} --password:env PASS_VAR"
+      register: tmp_adm
+
+    - name: Get Keycloak API token
+      ansible.builtin.uri:
+        url: https://{{ dsc.keycloak.subDomain }}{{ dsc.global.rootDomain }}/realms/master/protocol/openid-connect/token
+        method: POST
+        status_code: [200, 202]
+        validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
+        return_content: true
+        body: username={{ tmp_admin }}&password={{ tmp_admin_pass }}&grant_type=password&client_id=admin-cli
+      register: kc_token
+      ignore_errors: true
+
+    - name: Set kc_access_token fact
+      ansible.builtin.set_fact:
+        kc_access_token: "{{ kc_token.json.access_token }}"
+
+    - name: Retrieve users from API
+      ansible.builtin.uri:
+        url: https://{{ dsc.keycloak.subDomain }}{{ dsc.global.rootDomain }}/admin/realms/master/users
+        method: GET
+        status_code: [200, 204]
+        return_content: true
+        validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
+        body_format: json
+        headers:
+          Authorization: bearer {{ kc_access_token }}
+      register: kc_users
+
+    - name: Set user_id fact
+      ansible.builtin.set_fact:
+        user_id: "{{ kc_users.json | selectattr('username', 'equalto', user) | map(attribute='id') | first }}"
+
+# Unlocking user using Attack Detection API endpoint
+# See: https://www.keycloak.org/docs-api/latest/rest-api/index.html#_attack_detection
+
+    - name: Unlock user
+      ansible.builtin.uri:
+        url: https://{{ dsc.keycloak.subDomain }}{{ dsc.global.rootDomain }}/admin/realms/master/attack-detection/brute-force/users/{{ user_id }}
+        method: DELETE
+        status_code: [200, 204]
+        return_content: true
+        validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
+        body_format: json
+        headers:
+          Authorization: bearer {{ kc_access_token }}
+
+    - name: Remove temporary admin from master realm
+      community.general.keycloak_user:
+        validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
+        auth_client_id: admin-cli
+        auth_keycloak_url: https://{{ dsc.keycloak.subDomain }}{{ dsc.global.rootDomain }}
+        auth_realm: master
+        auth_username: "{{ tmp_admin }}"
+        auth_password: "{{ tmp_admin_pass }}"
+        state: absent
+        realm: master
+        username: "{{ tmp_admin }}"

--- a/admin-tools/keycloak-user-unlock.yaml
+++ b/admin-tools/keycloak-user-unlock.yaml
@@ -142,8 +142,8 @@
       ansible.builtin.set_fact:
         user_id: "{{ kc_users.json | selectattr('username', 'equalto', user) | map(attribute='id') | first }}"
 
-# Unlocking user using Attack Detection API endpoint
-# See: https://www.keycloak.org/docs-api/latest/rest-api/index.html#_attack_detection
+    # Unlocking user using Attack Detection API endpoint
+    # See: https://www.keycloak.org/docs-api/latest/rest-api/index.html#_attack_detection
 
     - name: Unlock user
       ansible.builtin.uri:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Si nous n'avons qu'un seul compte d'administration dans un realm Keycloak (cas du realm master) et que ce compte se retrouve verrouillé suite à une attaque par force brute, ou des échec répétés d'authentification, alors nous n'avons pas de solution automatisée pour déverrouiller le compte en question.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Le playbook `keycloak-user-unlock.yaml`, qui est introduit par la présente PR, fournit une solution automatisée de déverrouillage de compte Keycloak (administrateur ou autre).

Il s'appuie sur l'extra variable `user` pour déterminer le compte à déverrouiller.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.

Le playbook est d'autant plus utile qu'il peut arriver que le déverrouillage d'un utilisateur échoue via la web UI, alors qu'il s'effectue correctement via un appel API (solution utilisée par le playbook).
