### PR TITLE
refactor: :recycle: common vault values

### DIFF
--- a/gitops/envs/conf-dso/apps/keycloak/templates/pg-cluster-keycloak.yaml
+++ b/gitops/envs/conf-dso/apps/keycloak/templates/pg-cluster-keycloak.yaml
@@ -32,6 +32,8 @@ spec:
       owner: keycloak
     recovery: null
   enableSuperuserAccess: true
+  imageName: <path:forge-dso/data/env/conf-dso/apps/common/values#image | jsonPath
+    {.repository.ghcr}>/cloudnative-pg/postgresql:16.1
   instances: 3
   monitoring:
     enablePodMonitor: false

--- a/gitops/envs/conf-dso/apps/keycloak/values.yaml
+++ b/gitops/envs/conf-dso/apps/keycloak/values.yaml
@@ -26,8 +26,8 @@ keycloak:
     port: 5432
   extraEnvVars:
   - name: DSFR_THEME_HOME_URL
-    value: https://<path:forge-dso/data/env/conf-dso/apps/keycloak/values#extraEnvVars
-      | jsonPath {.consoleDomain}>
+    value: https://<path:forge-dso/data/env/conf-dso/apps/common/values#domain | jsonPath
+      {.console}>
   - name: DSFR_THEME_SERVICE_TITLE
     value: Cloud Pi Native
   - name: DSFR_THEME_BRAND_TOP
@@ -50,8 +50,8 @@ keycloak:
     extraHosts: []
     extraPaths: []
     extraRules: []
-    hostname: <path:forge-dso/data/env/conf-dso/apps/keycloak/values#ingress | jsonPath
-      {.hostname}>
+    hostname: <path:forge-dso/data/env/conf-dso/apps/common/values#domain | jsonPath
+      {.keycloak}>
     ingressClassName: nginx
     labels:
       app: keycloak
@@ -68,7 +68,7 @@ keycloak:
       | jsonPath {.pluginDownloadUrl}>
     command:
     - sh
-    image: docker.io/curlimages/curl:8.12.1
+    image: <path:forge-dso/data/env/conf-dso/apps/common/values#image | jsonPath {.repository.docker}>/curlimages/curl:8.12.1
     imagePullPolicy: IfNotPresent
     name: realm-ext-provider
     volumeMounts:

--- a/roles/gitops/rendering-apps-files/templates/keycloak/Chart.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/Chart.yaml.j2
@@ -7,4 +7,4 @@ dependencies:
 - name: keycloak
   alias: keycloak
   version: {{ dsc.keycloak.chartVersion }}
-  repository: {{ dsc.keycloak.helmRepoUrl }}
+  repository: "{{ dsc.keycloak.helmRepoUrl if 'oci://' in dsc.keycloak.helmRepoUrl else dsc.keycloak.helmRepoUrl ~ '/keycloak' }}"

--- a/roles/gitops/rendering-apps-files/templates/keycloak/templates/pg-cluster-keycloak.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/templates/pg-cluster-keycloak.yaml.j2
@@ -15,10 +15,10 @@ spec:
   instances: 3
   # Parameters and pg_hba configuration will be append
   # to the default ones to make the cluster work
-{% if use_private_registry %}
-  imageName: "{{ dsc.global.registry }}/cloudnative-pg/postgresql:16.1"
-{% elif dsc.keycloak.cnpg.imageName is defined %}
+{% if dsc.keycloak.cnpg.imageName is defined %}
   imageName: "{{ dsc.keycloak.cnpg.imageName }}"
+{% else %}
+  imageName: "<path:forge-dso/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.ghcr}>/cloudnative-pg/postgresql:16.1"
 {% endif %}
 {% if use_image_pull_secrets %}
   imagePullSecrets:

--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/00-main.j2
@@ -87,7 +87,7 @@ keycloak:
     ingressClassName: {{ dsc.ingress.className | default('') }}
     pathType: "Prefix"
     apiVersion: ""
-    hostname: <path:forge-dso/data/env/{{ dsc_name }}/apps/keycloak/values#ingress | jsonPath {.hostname}>
+    hostname: <path:forge-dso/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.keycloak}>
     path: /
     servicePort: "http"
     annotations:
@@ -300,7 +300,7 @@ keycloak:
 
   extraEnvVars:
     - name: DSFR_THEME_HOME_URL
-      value: https://<path:forge-dso/data/env/{{ dsc_name }}/apps/keycloak/values#extraEnvVars | jsonPath {.consoleDomain}>
+      value: https://<path:forge-dso/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.console}>
     - name: DSFR_THEME_SERVICE_TITLE
       value: Cloud Pi Native
     - name: DSFR_THEME_BRAND_TOP
@@ -309,11 +309,7 @@ keycloak:
       value: cloudpinative-relations@interieur.gouv.fr
   initContainers:
     - name: realm-ext-provider
-{% if use_private_registry %}
-      image: "{{ dsc.global.registry }}/curlimages/curl:8.12.1"
-{% else %}
-      image: "docker.io/curlimages/curl:8.12.1"
-{% endif %}
+      image: "<path:forge-dso/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/curlimages/curl:8.12.1"
       imagePullPolicy: IfNotPresent
       command:
         - sh

--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/10-platform.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/10-platform.j2
@@ -1,7 +1,8 @@
 {% if dsc.global.platform == "openshift" %}
-podSecurityContext:
-  enabled: false
-
-containerSecurityContext:
-  enabled: false
+keycloak:
+  podSecurityContext:
+    enabled: false
+  
+  containerSecurityContext:
+    enabled: false
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/10-proxy.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/10-proxy.j2
@@ -1,9 +1,10 @@
 {% if dsc.proxy.enabled %}
-extraEnvVars:
-  - name: HTTP_PROXY
-    value: <path:forge-dso/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>
-  - name: HTTPS_PROXY
-    value: <path:forge-dso/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>
-  - name: NO_PROXY
-    value: <path:forge-dso/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>
+keycloak:
+  extraEnvVars:
+    - name: HTTP_PROXY
+      value: <path:forge-dso/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>
+    - name: HTTPS_PROXY
+      value: <path:forge-dso/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>
+    - name: NO_PROXY
+      value: <path:forge-dso/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/10-registry.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/10-registry.j2
@@ -1,10 +1,15 @@
 {% if use_private_registry %}
-image:
-  registry: <path:forge-dso/data/env/{{ dsc_name }}/apps/common/values#registry>
+keycloak:
+  global:                                                                                                                                       
+    security:
+      allowInsecureImages: true
+  image:
+    registry: <path:forge-dso/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>
 {% endif %}
 
 {% if use_image_pull_secrets %}
-global:
-  imagePullSecrets:
-  - dso-config-pull-secret
+keycloak:
+  global:
+    imagePullSecrets:
+    - dso-config-pull-secret
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/10-tls.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/10-tls.j2
@@ -1,7 +1,8 @@
 {% if dsc.ingress.tls.type == "tlsSecret" %}
-ingress:
-  extraTls:
-    - hosts:
-      - <path:forge-dso/data/env/{{ dsc_name }}/apps/keycloak/values#ingress | jsonPath {.hostname}>
-      secretName: "{{ dsc.ingress.tls.tlsSecret.name }}"
+keycloak:
+  ingress:
+    extraTls:
+      - hosts:
+        - <path:forge-dso/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.keycloak}>
+        secretName: "{{ dsc.ingress.tls.tlsSecret.name }}"
 {% endif %}

--- a/roles/gitops/vault-secrets/vars/main.yaml
+++ b/roles/gitops/vault-secrets/vars/main.yaml
@@ -4,11 +4,19 @@ envs:
     apps:
       - argocd_app: "common"
         vault_values:
+          image:
+            repository:
+              docker: "{{ dsc.global.registry | default('docker.io') }}"
+              ghcr: "{{ dsc.global.registry | default('ghcr.io') }}"
+          domain:
+            keycloak: "{{ keycloak_domain }}"
+            console: "{{ console_domain }}"
           proxy:
             httpProxy: "{{ dsc.proxy.http_proxy | default('') }}"
             httpsProxy: "{{ dsc.proxy.https_proxy | default('') }}"
             noProxy: "{{ dsc.proxy.no_proxy | default('') }}"
-          registry: "{{ dsc.global.registry | default('') }}"
+            hostProxy: "{{ dsc.proxy.host }}"
+            portProxy: "{{ dsc.proxy.port }}"
       - argocd_app: "keycloak"
         vault_values:
           auth:
@@ -25,17 +33,5 @@ envs:
                   secretAccessKey:
                     name: "{{ dsc.global.backup.s3.credentials.name | default('') }}"
                     key: "{{ dsc.global.backup.s3.credentials.secretAccessKey.key | default('') }}"
-          extraEnvVars:
-            consoleDomain: "{{ console_domain }}"
           initcontainers:
             pluginDownloadUrl: "{{ dsc.keycloak.pluginDownloadUrl }}"
-          ingress:
-            hostname: "{{ keycloak_domain }}"
-      - argocd_app: "vault"
-        vault_values:
-          global:
-            image:
-              repository: "{{ dsc.global.registry | default('docker.io') }}"
-          server:
-            ha:
-              apiAddr: "https://{{ vault_domain }}"

--- a/roles/infra/keycloak-infra/tasks/main.yml
+++ b/roles/infra/keycloak-infra/tasks/main.yml
@@ -141,7 +141,7 @@
 - name: Deploy helm
   kubernetes.core.helm:
     name: keycloak
-    chart_ref: "{{ dsc.keycloakInfra.helmRepoUrl }}/keycloak"
+    chart_ref: "{{ dsc.keycloakInfra.helmRepoUrl }}/keycloak/keycloak-{{ dsc.keycloakInfra.chartVersion }}.tgz"
     chart_version: "{{ dsc.keycloakInfra.chartVersion }}"
     release_namespace: "{{ dsc.keycloakInfra.namespace }}"
     release_name: keycloak

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -141,7 +141,7 @@
 - name: Deploy helm
   kubernetes.core.helm:
     name: keycloak
-    chart_ref: "{{ dsc.keycloak.helmRepoUrl }}/keycloak"
+    chart_ref: "{{ dsc.keycloak.helmRepoUrl }}/keycloak/keycloak-{{ dsc.keycloak.chartVersion }}.tgz"
     chart_version: "{{ dsc.keycloak.chartVersion }}"
     release_namespace: "{{ dsc.keycloak.namespace }}"
     release_name: keycloak


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
- Certaines values venant de vault pourraient être global au déploiement tels que les noms de domaines.
- C'est du tout ou rien pour le choix des registres privées.
- Problème lorsque `dsc.keycloak.helmRepoUrl` n'est pas de l'oci.
- Absence du niveau `keycloak` dans les `roles/gitops/rendering-apps-files/templates/keycloak/values/10-*.j2`.
- Absence de  `global.security.allowInsecureImages: true` en cas d'utilisation d'image différent du défaut Bitnami.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
- Mise en place dans le path common pour les values concernant les noms de domaines.
- Possibilité de registres privée selon la source (docker.io, ghcr.io...).
- Fix du problème lorsque `dsc.keycloak.helmRepoUrl` n'est pas de l'oci.
- Mise en place du niveau `keycloak` dans les `roles/gitops/rendering-apps-files/templates/keycloak/values/10-*.j2`.
- Mise en place du `global.security.allowInsecureImages: true` en cas d'utilisation d'image différent du défaut Bitnami.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Oui. Comme il y a de la refacto dans les path des values vault, il faudra rejouer le playbook sur le tag `rendering-apps-files` pour générer les values correspondantes à rajouter à cette MR.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Non.