### PR TITLE
fix: :bug: Vault backups (DSO + infra)

### DIFF
--- a/roles/infra/vault-infra/tasks/main.yml
+++ b/roles/infra/vault-infra/tasks/main.yml
@@ -68,25 +68,25 @@
       kubernetes.core.helm:
         name: "{{ dsc_name }}-vault-backup"
         chart_ref: dso/cpn-backup-utils
-        chart_version: "{{ dsc.global.backup.vault.chartVersion }}"
+        chart_version: "{{ dsc.global.backup.vaultInfra.chartVersion }}"
         release_namespace: "{{ dsc.vaultInfra.namespace }}"
         values:
           vault:
             enabled: true
             secrets:
               S3_BUCKET_NAME: "{{ dsc.global.backup.s3.bucketName }}"
-              S3_BUCKET_PREFIX: "{{ dsc.global.backup.vault.pathPrefix }}"
+              S3_BUCKET_PREFIX: "{{ dsc.global.backup.vaultInfra.pathPrefix }}"
               S3_ENDPOINT: "{{ dsc.global.backup.s3.endpointURL }}"
-              VAULT_ADDR: "http://{{ dsc_name }}-vault-active:8200"
+              VAULT_ADDR: "http://{{ dsc_name }}-vault-infra-active:8200"
               VAULT_TOKEN: "{{ vault_token }}"
               S3_ACCESS_KEY: "{{ dsc.global.backup.s3.credentials.accessKeyId.value }}"
               S3_SECRET_KEY: "{{ dsc.global.backup.s3.credentials.secretAccessKey.value }}"
             env:
-              RETENTION: "{{ dsc.global.backup.vault.retentionPolicy }}"
-              MC_EXTRA_ARGS: "{{ dsc.global.backup.vault.mcExtraArgs }}"
+              RETENTION: "{{ dsc.global.backup.vaultInfra.retentionPolicy }}"
+              MC_EXTRA_ARGS: "{{ dsc.global.backup.vaultInfra.mcExtraArgs }}"
             job:
-              schedule: "{{ dsc.global.backup.vault.cron }}"
-        state: "{{ dsc.global.backup.vault.enabled | ternary('present', 'absent') }}"
+              schedule: '"{{ dsc.global.backup.vaultInfra.cron }}"'
+        state: "{{ dsc.global.backup.vaultInfra.enabled | ternary('present', 'absent') }}"
 
 - name: Patch serviceMonitors
   when: >

--- a/roles/socle-config/files/config.yaml
+++ b/roles/socle-config/files/config.yaml
@@ -63,6 +63,8 @@ spec:
         enabled: false
       vault:
         enabled: false
+      vaultInfra:
+        enabled: false
     metrics:
       enabled: false
     alerting:

--- a/roles/socle-config/files/cr-conf-dso-default.yaml
+++ b/roles/socle-config/files/cr-conf-dso-default.yaml
@@ -34,6 +34,9 @@ spec:
         vault:
           enabled: false
           pathPrefix: vault
+        vaultInfra:
+          enabled: false
+          pathPrefix: vault-infra
     gitOps:
       watchpointEnabled: true
   argocd:

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -665,6 +665,34 @@ spec:
                               type: string
                               default: "30d"
                           type: object
+                        vaultInfra:
+                          properties:
+                            enabled:
+                              description: Enable s3 vault infra backups.
+                              default: false
+                              type: boolean
+                            helmRepoUrl:
+                              description: Vault infra backup-utils helm repository url.
+                              type: string
+                            chartVersion:
+                              description: Vault infra backup-utils helm chart version (e.g., "1.12.2").
+                              type: string
+                            pathPrefix:
+                              description: Defines the s3 destination path for vault infra backups.
+                              type: string
+                              default: "vault-infra"
+                            mcExtraArgs:
+                              description: Extra args to pass to minio cli for the backups.
+                              type: string
+                            cron:
+                              description: Defines the cron rule used for vault infra backups. By default it runs every 6 hours.
+                              type: string
+                              default: "0 */6 * * *"
+                            retentionPolicy:
+                              description: Defines retention policy for vault infra backups recurrences.
+                              type: string
+                              default: "30d"
+                          type: object
                         cnpg:
                           properties:
                             enabled:

--- a/roles/vault/tasks/main.yml
+++ b/roles/vault/tasks/main.yml
@@ -84,7 +84,7 @@
               RETENTION: "{{ dsc.global.backup.vault.retentionPolicy }}"
               MC_EXTRA_ARGS: "{{ dsc.global.backup.vault.mcExtraArgs }}"
             job:
-              schedule: "{{ dsc.global.backup.vault.cron }}"
+              schedule: '"{{ dsc.global.backup.vault.cron }}"'
         state: "{{ dsc.global.backup.vault.enabled | ternary('present', 'absent') }}"
 
 - name: Patch serviceMonitors


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

La partie backup du Vault d'infra n'est pas correctement paramétrée. Les backups échouent donc.

Les parties backup du Vault DSO et du Vault d'infra ne permet pas de paramétrer le cronjob sur une périodicité utilisant une "step value" (par exemple toutes les 5 minutes comme ceci : */5 * * * *).

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Corrige le paramétrage des backups du Vault d'infra, en introduisant notamment un paramètre `spec.global.backup.vaultInfra` dans la dsc.

Corrige la partie cronjob de manière à permettre l'usage d'une step value si besoin (en encadrant simplement le job.schedule avec des guillemets simples, une step value est maintenant acceptée).

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.
