### PR TITLE
fix: :wrench: keycloak pod label

### DIFF
--- a/admin-tools/infra-keycloak-admin-password-reset.yaml
+++ b/admin-tools/infra-keycloak-admin-password-reset.yaml
@@ -65,7 +65,7 @@
         namespace: "{{ dsc.keycloakInfra.namespace }}"
         kind: Pod
         label_selectors:
-          - app.kubernetes.io/instance=keycloak
+          - app.kubernetes.io/name=keycloak
       register: kc_pods
 
     - name: Set kc_pod fact

--- a/admin-tools/keycloak-admin-password-reset.yaml
+++ b/admin-tools/keycloak-admin-password-reset.yaml
@@ -65,7 +65,7 @@
         namespace: "{{ dsc.keycloak.namespace }}"
         kind: Pod
         label_selectors:
-          - app.kubernetes.io/instance=keycloak
+          - app.kubernetes.io/name=keycloak
       register: kc_pods
 
     - name: Set kc_pod fact

--- a/admin-tools/keycloak-user-unlock.yaml
+++ b/admin-tools/keycloak-user-unlock.yaml
@@ -87,7 +87,7 @@
         namespace: "{{ dsc.keycloak.namespace }}"
         kind: Pod
         label_selectors:
-          - app.kubernetes.io/instance=keycloak
+          - app.kubernetes.io/name=keycloak
       register: kc_pods
 
     - name: Set kc_pod fact


### PR DESCRIPTION
## Issues liées

Issues numéro:  #474 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Since Keycloak GitOps deployment, the label `app.kubernetes.io/instance=keycloak` is not correct anymore (it could become `app.kubernetes.io/instance=dso-keycloak` or something else depending of the prefix).

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Fix with `app.kubernetes.io/name=keycloak`.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
No.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
No.
