### PR TITLE
fix: :bug: Gitlab Runner resources overwrite condition

### DIFF
--- a/roles/gitlab-runner/templates/values/00-main.j2
+++ b/roles/gitlab-runner/templates/values/00-main.j2
@@ -67,7 +67,7 @@ runners:
         cpu_limit = "{{ dsc.gitlabRunner.resources.limits.cpu }}"
         memory_limit = "{{ dsc.gitlabRunner.resources.limits.memory }}"
   {% endif %}
-  {% if dsc.gitlabRunner.resources.overwrite != 'none' %}
+  {% if dsc.gitlabRunner.resources.overwrite is defined and dsc.gitlabRunner.resources.overwrite != 'none' %}
     {% if dsc.gitlabRunner.resources.overwrite.requests != 'none' %}
         cpu_request_overwrite_max_allowed = "{{ dsc.gitlabRunner.resources.overwrite.requests.cpu }}"
         memory_request_overwrite_max_allowed = "{{ dsc.gitlabRunner.resources.overwrite.requests.memory }}"


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Ne vérifie pas si le paramètre "dsc.gitlabRunner.resources.overwrite" est bien défini dans la dsc.
Ceci fait échouer le déploiement du GitLab Runner si ce paramètre est absent de la dsc et qu'il n'est pas entièrement rempli avec les sous-paramètres associés.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Vérifie si le paramètre "dsc.gitlabRunner.resources.overwrite" est bien défini dans la dsc, ce qui évite un échec du calcul des values lorsque ce paramètre est absent.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster hors production.
