### PR TITLE
fix(1580): Fix Ephemeral storage issue

### DIFF
--- a/roles/gitlab-runner/templates/values/00-main.j2
+++ b/roles/gitlab-runner/templates/values/00-main.j2
@@ -29,6 +29,12 @@ rbac:
   podSecurityPolicy:
     enabled: true
 
+resources:
+  requests:
+    ephemeral-storage: "500Mi"
+  limits:
+    ephemeral-storage: "2Gi"
+
 {% if dsc.global.metrics.enabled %}
 metrics:
   enabled: true


### PR DESCRIPTION
## Issues liées

Issues numéro: 
[#1580](https://github.com/cloud-pi-native/socle/issues/533)
---------

## Quel est le comportement actuel ?
The node was low on resource: ephemeral-storage. Threshold quantity: 16023864137, available: 12671572Ki. Container build was using 1639680Ki, request is 0, has larger consumption of ephemeral-storage. Container helper was using 8Ki, request is 0, has larger consumption of ephemeral-storage. WARNING: Event retrieved from the cluster: Container runtime did not kill the pod within specified grace period. Cleaning up project directory and file based variables 00:00 WARNING: Event retrieved from the cluster: The node was low on resource: ephemeral-storage. Threshold quantity: 16023864137, available: 12671572Ki. Container build was using 1639680Ki, request is 0, has larger consumption of ephemeral-storage. Container helper was using 8Ki, request is 0, has larger consumption of ephemeral-storage. WARNING: Event retrieved from the cluster: Container runtime did not kill the pod within specified grace period. ERROR: Job failed (system failure): pod "dso-gitlab/runner-t1n3fbpd-project-339-concurrent-0-xj0lkphx" is disrupted: reason "TerminationByKubelet", message "The node was low on resource: ephemeral-storage. Threshold quantity: 16023864137, available: 12671572Ki. Container build was using 1639680Ki, request is 0, has larger consumption of ephemeral-storage. Container helper was using 8Ki, request is 0, has larger consumption of ephemeral-storage. "

## Quel est le nouveau comportement ?
Les limit et request sont désormais fixées

## Cette PR introduit-elle un breaking change ?
Non

## Autres informations
N/A
