### PR TITLE
fix: :bug: Adapt get-credentials admin tool

### DIFF
--- a/admin-tools/get-credentials.yaml
+++ b/admin-tools/get-credentials.yaml
@@ -134,8 +134,39 @@
       tags:
         - keycloak
 
+    - name: Check if infra tools exist in the cluster
+      tags:
+        - argo-infra
+        - argocd-infra
+        - vault-infra
+        - keycloak-infra
+      block:
+        - name: Check Keycloak infra pods
+          kubernetes.core.k8s_info:
+            namespace: "{{ dsc.keycloakInfra.namespace }}"
+            kind: Pod
+            label_selectors:
+              - app.kubernetes.io/name = keycloak
+          register: keycloak_infra_pods
+
+        - name: Check Argo CD infra pods
+          kubernetes.core.k8s_info:
+            namespace: "{{ dsc.argocdInfra.namespace }}"
+            kind: Pod
+            label_selectors:
+              - app.kubernetes.io/part-of = argocd
+          register: argocd_infra_pods
+
+        - name: Check Vault infra pods
+          kubernetes.core.k8s_info:
+            namespace: "{{ dsc.vaultInfra.namespace }}"
+            kind: Pod
+            label_selectors:
+              - app.kubernetes.io/name = vault
+          register: vault_infra_pods
+
     - name: Retrieve Infra user infos
-      when: dsc.argocdInfra.installEnabled
+      when: keycloak_infra_pods.resources | length > 0
       tags:
         - argo-infra
         - argocd-infra
@@ -154,7 +185,7 @@
             keycloak_infra_user_password: "{{ keycloak_infra_user_creds.resources[0].data.ADMIN_USER_PASSWORD | b64decode }}"
 
     - name: Display Keycloak Infra credentials
-      when: dsc.keycloakInfra.installEnabled
+      when: keycloak_infra_pods.resources | length > 0
       tags:
         - keycloak-infra
       block:
@@ -171,6 +202,16 @@
               - "URL : https://{{ dsc.keycloakInfra.subDomain }}{{ dsc.global.rootDomain }} "
               - "Admin username: admininfra "
               - "Admin password: {{ keycloak_infra_admin_creds.resources[0].data['admin-password'] | b64decode }} "
+
+    - name: Display message if no Keycloak infra pod found
+      tags:
+        - keycloak-infra
+      when: keycloak_infra_pods.resources | length == 0
+      ansible.builtin.debug:
+        msg:
+          - "Aucun pod Keycloak trouvé dans le namespace {{ dsc.keycloakInfra.namespace }}."
+          - "Vérifiez le namespace indiqué dans votre dsc"
+          - "et assurez-vous du bon déploiement du Keycloak d'infra dans ce namespace."
 
     - name: Display Nexus credentials
       ansible.builtin.debug:
@@ -235,9 +276,10 @@
         - vault
 
     - name: Get Vault Infra secrets
-      when: dsc.vaultInfra.installEnabled
+      when: vault_infra_pods.resources | length > 0
       tags:
         - vault-infra
+      ignore_errors: true
       block:
         - name: Get Vault Infra secrets
           kubernetes.core.k8s_info:
@@ -269,12 +311,37 @@
           ansible.builtin.debug:
             msg:
               - "URL: https://{{ dsc.vaultInfra.subDomain }}{{ dsc.global.rootDomain }} "
-              - "Admin username: {{ keycloak_infra_user }} "
-              - "Admin password: {{ keycloak_infra_user_password }} "
               - "root_token: {{ vault_infra_keys.resources[0].data.root_token | b64decode }} "
               - "key1: {{ vault_infra_keys.resources[0].data.key1 | b64decode }} "
               - "key2: {{ vault_infra_keys.resources[0].data.key2 | b64decode }} "
               - "key3: {{ vault_infra_keys.resources[0].data.key3 | b64decode }} "
+
+        - name: Display Vault infra URL with OIDC method and credentials
+          ansible.builtin.debug:
+            msg:
+              - "URL: https://{{ dsc.vaultInfra.subDomain }}{{ dsc.global.rootDomain }}/ui/vault/auth?with=oidc "
+              - "Admin username: {{ keycloak_infra_user }} "
+              - "Admin password: {{ keycloak_infra_user_password }} "
+
+    - name: Display message if no Vault infra pod found
+      tags:
+        - vault-infra
+      when: vault_infra_pods.resources | length == 0
+      ansible.builtin.debug:
+        msg:
+          - "Aucun pod Vault trouvé dans le namespace {{ dsc.vaultInfra.namespace }}."
+          - "Vérifiez le namespace indiqué dans votre dsc"
+          - "et assurez-vous du bon déploiement du Vault d'infra dans ce namespace."
+
+    - name: Display message if no Keycloak infra pod found
+      tags:
+        - vault-infra
+      when: keycloak_infra_pods.resources | length == 0
+      ansible.builtin.debug:
+        msg:
+          - "Aucun pod Keycloak trouvé dans le namespace {{ dsc.keycloakInfra.namespace }}."
+          - "Vérifiez le namespace indiqué dans votre dsc"
+          - "et assurez-vous du bon déploiement du Keycloak d'infra dans ce namespace."
 
     - name: Display Argo CD URL and credentials
       ansible.builtin.debug:
@@ -287,7 +354,7 @@
         - argocd
 
     - name: Display Argo CD infra URL and credentials
-      when: dsc.argocdInfra.installEnabled
+      when: argocd_infra_pods.resources | length > 0
       ansible.builtin.debug:
         msg:
           - "URL: https://{{ dsc.argocdInfra.subDomain }}{{ dsc.global.rootDomain }} "
@@ -296,6 +363,17 @@
       tags:
         - argo-infra
         - argocd-infra
+
+    - name: Display message if no Argo CD infra pod found
+      tags:
+        - argo-infra
+        - argocd-infra
+      when: argocd_infra_pods.resources | length == 0
+      ansible.builtin.debug:
+        msg:
+          - "Aucun pod Argo CD trouvé dans le namespace {{ dsc.argocdInfra.namespace }}."
+          - "Vérifiez le namespace indiqué dans votre dsc"
+          - "et assurez-vous du bon déploiement de l'Argo CD d'infra dans ce namespace."
 
     - name: Display Harbor URL and credentials
       ansible.builtin.debug:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Compte tenu des dernières évolutions dans les méthodes d'installation du Socle (GitOps), le playbook admin-tools/get-credentials.yaml ne retourne aucune information ou échoue pour les outils d'infrastructure (Argo CD d'infra, Keycloak d'infra et Vault d'infra) s'ils n'existent pas dans le cluster ou n'ont pas été installés via la dsc spécifiée.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Le playbook tient compte du fait que les outils d'infrastructure peuvent ne pas être présents dans le cluster ou ne pas avoir été installés via la dsc utilisée. Il délivre alors un message en ce sens.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.