### PR TITLE
fix: adding kubeinfra var before checks

### DIFF
--- a/roles/check-prerequisite/tasks/main.yml
+++ b/roles/check-prerequisite/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Check Argo CD infra namespace
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ kubeconfig_infra }}"
-    proxy: "{{ kubeconfig_proxy_infra | default('')}}"
+    kubeconfig: "{{ lookup('ansible.builtin.env', 'KUBECONFIG_INFRA' ) }}"
+    proxy: "{{ lookup('ansible.builtin.env', 'KUBECONFIG_PROXY_INFRA', default='') }}"
     name: "{{ dsc.argocdInfra.namespace }}"
     kind: Namespace
   register: argo_infra_ns_check


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Lorsque le check est fait, la variable `kubeconfig_infra` n'a pas encore été settée, donc le test tombe en erreur.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
La variable `kubeconfig_infra` est settée juste avant afin de permettre le check.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
