### PR TITLE
feat: :arrow_up: Upgrade GitLab Operator and GitLab

### DIFF
--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -24,16 +24,16 @@ spec:
     chartVersion: 2.3.1
   gitlab:
     # https://artifacthub.io/packages/helm/gitlab/gitlab
-    chartVersion: "8.11.2"
+    chartVersion: "9.0.2"
   gitlabCiPipelinesExporter:
     # https://github.com/mvisonneau/helm-charts/tree/main/charts/gitlab-ci-pipelines-exporter
     chartVersion: "0.3.5"
   gitlabOperator:
     # https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/tags
-    chartVersion: "1.12.2"
+    chartVersion: "2.0.2"
   gitlabRunner:
     # https://gitlab.com/gitlab-org/charts/gitlab-runner/-/tags
-    chartVersion: "0.76.1"
+    chartVersion: "0.77.2"
   grafana:
     # https://github.com/grafana/grafana/tags
     imageVersion: "10.4.3"

--- a/versions.md
+++ b/versions.md
@@ -5,10 +5,10 @@
 | cloudnativepg             | 1.22.1           | 0.20.1        | [cloudnativepg](https://artifacthub.io/packages/helm/cloudnative-pg/cloudnative-pg)                                  |
 | console                   | 9.\*.\*          | 2.\*.\*       | [console](https://github.com/cloud-pi-native/helm-charts)                                                            |
 | cpn-cnpg                  | 2.3.1            | 2.3.1         | [cpn-cnpg](https://github.com/cloud-pi-native/helm-charts)                                                           |
-| gitlab                    | 17.11.2          | 8.11.2        | [gitlab](https://artifacthub.io/packages/helm/gitlab/gitlab)                                                         |
+| gitlab                    | 18.0.2          | 9.0.2        | [gitlab](https://artifacthub.io/packages/helm/gitlab/gitlab)                                                         |
 | gitlabCiPipelinesExporter | 0.5.10           | 0.3.5         | [gitlabCiPipelinesExporter](https://github.com/mvisonneau/helm-charts/tree/main/charts/gitlab-ci-pipelines-exporter) |
-| gitlabOperator            | 1.12.2           | 1.12.2        | [gitlabOperator](https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/tags)                                  |
-| gitlabRunner              | 17.11.1          | 0.76.1        | [gitlabRunner](https://gitlab.com/gitlab-org/charts/gitlab-runner/-/tags)                                            |
+| gitlabOperator            | 2.0.2           | 2.0.2        | [gitlabOperator](https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/tags)                                  |
+| gitlabRunner              | 18.0.2          | 0.77.2        | [gitlabRunner](https://gitlab.com/gitlab-org/charts/gitlab-runner/-/tags)                                            |
 | grafana                   | 10.4.3           | N/A           | [grafana](https://github.com/grafana/grafana/tags)                                                                   |
 | grafanaOperator           | 5.10.0           | 5.4.2         | [grafanaOperator](https://github.com/grafana/grafana-operator/tags)                                                  |
 | harbor                    | 2.12.0           | 1.16.0        | [harbor](https://artifacthub.io/packages/helm/harbor/harbor)                                                         |


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
Installe les version suivantes des composants GitLab :

    GitLab Operator 1.12.2 (chart 1.12.2)
    GitLab 17.11.2 (chart 8.11.2)
    Gitlab Runner 17.11.1 (chart 0.76.1)


## Quel est le nouveau comportement ?
Installe les version suivantes des composants GitLab :

    GitLab Operator 2.0.2 (chart 2.0.2)
    GitLab 18.0.2 (chart 9.0.2)
    Gitlab Runner 17.11.1 (chart 0.76.1)


## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
