### PR TITLE
Fix/gitlab metrics additional labels

### DIFF
--- a/roles/gitops/rendering-apps-files/gitlab/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/gitlab/values/00-main.j2
@@ -16,7 +16,9 @@ gitlab:
         enabled: true
 {% if dsc.global.metrics.additionalLabels is defined %} 
         additionalLabels:
-          "{{ dsc.global.metrics.additionalLabels }}"
+{% for key, value in dsc.global.metrics.additionalLabels.items() %}
+          {{ key }}: {{ value }}
+{% endfor %}
 {% endif %}
 {% endif %}
   sidekiq:
@@ -28,7 +30,9 @@ gitlab:
         enabled: true
 {% if dsc.global.metrics.additionalLabels is defined %} 
         additionalLabels:
-          "{{ dsc.global.metrics.additionalLabels }}"
+{% for key, value in dsc.global.metrics.additionalLabels.items() %}
+          {{ key }}: {{ value }}
+{% endfor %}
 {% endif %}
 {% endif %}
   unicorn:
@@ -51,7 +55,9 @@ gitlab:
         enabled: true
 {% if dsc.global.metrics.additionalLabels is defined %} 
         additionalLabels:
-          "{{ dsc.global.metrics.additionalLabels }}"
+{% for key, value in dsc.global.metrics.additionalLabels.items() %}
+          {{ key }}: {{ value }}
+{% endfor %}
 {% endif %}
 {% endif %}
     persistence:
@@ -63,7 +69,9 @@ gitlab:
         enabled: true
 {% if dsc.global.metrics.additionalLabels is defined %} 
         additionalLabels:
-          "{{ dsc.global.metrics.additionalLabels }}"
+{% for key, value in dsc.global.metrics.additionalLabels.items() %}
+          {{ key }}: {{ value }}
+{% endfor %}
 {% endif %}
 {% endif %}
   kas:
@@ -74,7 +82,9 @@ gitlab:
         enabled: true
 {% if dsc.global.metrics.additionalLabels is defined %} 
         additionalLabels:
-          "{{ dsc.global.metrics.additionalLabels }}"
+{% for key, value in dsc.global.metrics.additionalLabels.items() %}
+          {{ key }}: {{ value }}
+{% endfor %}
 {% endif %}
 {% endif %}
   toolbox:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

En cas d'activation des métriques dans la dsc avec des additionalLabels, ces derniers ne sont pas positionnés correctement dans le template gitlab généré par le role gitops/rendering-apps-files.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Les values gitlab générées sont correctes pour la partie additionalLabels lorsque les métriques sont activées.
Les labels additionnels remontent bien dans les ressources de métriques générées (podMonitor ou serviceMonitor).

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.
