### PR TITLE
fix: :art: JSON conf generation

### DIFF
--- a/roles/gitops/rendering-apps-files/config/dsc.json.j2
+++ b/roles/gitops/rendering-apps-files/config/dsc.json.j2
@@ -15,7 +15,7 @@
   "region": "fr-par",
   "prefix": prefix | default("dso-"),
   "destination": {
-    "clusterName": clusterName | default("sdid-hp")
+    "clusterName": dsc.global.gitOps.envName | default("")
   },
   "targetRevision": "main",
   "apps": apps

--- a/roles/gitops/rendering-apps-files/tasks/generate_dsc_json.yml
+++ b/roles/gitops/rendering-apps-files/tasks/generate_dsc_json.yml
@@ -2,20 +2,12 @@
 - name: Define template dsc.json.j2 path
   ansible.builtin.set_fact:
     json_template_path: "{{ role_path }}/config/dsc.json.j2"
-  tags: apps-files
 
-- block:
-    - name: Render dsc.json.j2 template into config directory
-      ansible.builtin.copy:
-        content: "{{ lookup('ansible.builtin.template', json_template_path) }}"
-        dest: "{{ role_path }}/config/dsc.json"
-        mode: "0644"
-      tags: apps-files
-
-    - name: Format JSON and generate to destination
-      ansible.builtin.shell:
-        cmd: "jq '.' {{ role_path }}/config/dsc.json > {{ gitops_local_repo }}/{{ dsc.global.gitOps.repo.path }}/envs/{{ envs[0].name }}/{{ socle_config.resources[0].metadata.name }}.json"
-      tags: apps-files
+- name: Render dsc.json.j2 into local repository
+  ansible.builtin.copy:
+    content: "{{ lookup('ansible.builtin.template', json_template_path) | from_json | to_json(indent=2) }}"
+    dest: "{{ gitops_local_repo }}/{{ dsc.global.gitOps.repo.path }}/envs/{{ envs[0].name }}/{{ socle_config.resources[0].metadata.name }}.json"
+    mode: "0644"
   vars:
     envs:
       - name: "{{ dsc_name }}"


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Les tasks du fichier `generate_dsc_json.yaml` dans le role `gitops/rendering-apps-files` génèrent un fichier `dsc.json` dans le répertoire `rendering-apps-files/config` du code du Socle.
Elles s'appuient ensuite sur la commande `jq` pour générer le fichier `conf.json` final dans le dépôt local GitOps de l'utilisateur.

Par ailleurs le `destination.clusterName` généré par défaut dans les fichiers correspond à un cluster de développement qui nous est propre.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Simplifie la génération du fichier  `conf.json` final dans le dépôt local GitOps de l'utilisateur, en évitant la génération du fichier `dsc.json` dans le code du Socle, ce qui permet de faire l'économie d'une action manuelle ou automatisée de suppression de ce fichier suite à la génération.

Récupère dynamiquement la valeur par défaut du paramètre clusterName.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé via génération du fichier `conf.json` dans mon propre repo GitOps local.
