### PR TITLE
fix: :arrow_up: Upgrade GitLab to 18.1.2

### DIFF
--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -27,13 +27,13 @@ spec:
     chartVersion: 2.3.1
   gitlab:
     # https://artifacthub.io/packages/helm/gitlab/gitlab
-    chartVersion: "9.1.1"
+    chartVersion: "9.1.2"
   glexporter:
     # https://github.com/mvisonneau/helm-charts/tree/main/charts/gitlab-ci-pipelines-exporter
     chartVersion: "0.3.5"
   gitlabOperator:
     # https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/tags
-    chartVersion: "2.1.1"
+    chartVersion: "2.1.2"
   gitlabrunner:
     # https://gitlab.com/gitlab-org/charts/gitlab-runner/-/tags
     chartVersion: "0.78.1"

--- a/versions.md
+++ b/versions.md
@@ -6,9 +6,9 @@
 | console                   | 9.\*.\*          | 2.\*.\*       | [console](https://github.com/cloud-pi-native/helm-charts)                                                            |
 | cpn-ansible-job           | 1.\*.\*            | 1.\*.\*         | [cpn-ansible-job](https://github.com/cloud-pi-native/helm-charts)                                                    |
 | cpn-cnpg                  | 2.3.1            | 2.3.1         | [cpn-cnpg](https://github.com/cloud-pi-native/helm-charts)                                                           |
-| gitlab                    | 18.1.1          | 9.1.1        | [gitlab](https://artifacthub.io/packages/helm/gitlab/gitlab)                                                         |
+| gitlab                    | 18.1.2          | 9.1.2        | [gitlab](https://artifacthub.io/packages/helm/gitlab/gitlab)                                                         |
 | glexporter | 0.5.10           | 0.3.5         | [glexporter](https://github.com/mvisonneau/helm-charts/tree/main/charts/gitlab-ci-pipelines-exporter) |
-| gitlabOperator            | 2.1.1           | 2.1.1        | [gitlabOperator](https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/tags)                                  |
+| gitlabOperator            | 2.1.2           | 2.1.2        | [gitlabOperator](https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/tags)                                  |
 | gitlabrunner              | 18.1.1          | 0.78.1        | [gitlabrunner](https://gitlab.com/gitlab-org/charts/gitlab-runner/-/tags)                                            |
 | grafana                   | 10.4.3           | N/A           | [grafana](https://github.com/grafana/grafana/tags)                                                                   |
 | grafanaOperator           | 5.10.0           | 5.4.2         | [grafanaOperator](https://github.com/grafana/grafana-operator/tags)                                                  |


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Installe les versions suivantes des composants GitLab :
- GitLab Operator 2.1.1 (chart 2.1.1)
- GitLab 18.1.1 (chart 9.1.1)
- Gitlab Runner 18.1.1 (chart 0.78.1)
- gitlabCiPipelinesExporter 0.5.10 (chart 0.3.5)

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Installe les versions suivantes des composants GitLab :
- GitLab Operator 2.1.2 (chart 2.1.2)
- GitLab 18.1.2 (chart 9.1.2)
- Gitlab Runner 18.1.1 (chart 0.78.1), pas de changement.
- gitlabCiPipelinesExporter 0.5.10 (chart 0.3.5), pas de changement.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Montée de version réalisée pour prise en compte de l'annonce de patch release suivante :
- https://about.gitlab.com/releases/2025/07/09/patch-release-gitlab-18-1-2-released/

Mise à niveau testée et validée dans un cluster de développement.