### PR TITLE
fix: :bug: Renaming infra Vault path for global values

### DIFF
--- a/roles/gitops/rendering-apps-files/gitlab/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/gitlab/values/00-main.j2
@@ -125,16 +125,16 @@ global:
       - secret: exposed-ca
 {% endif %}
   hosts:
-    domain: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#rootDomain>
+    domain: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#rootDomain>
     registry:
       name: gitlab-registry.example.com
     minio:
-      name: "{{ dsc_name }}-minio.<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#rootDomain>"
+      name: "{{ dsc_name }}-minio.<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#rootDomain>"
     kas:
-      name: "{{ dsc_name }}-kas.<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#rootDomain>"
+      name: "{{ dsc_name }}-kas.<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#rootDomain>"
 {% if gitlab_domain %}
     gitlab:
-      name: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.gitlab}>
+      name: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.gitlab}>
 {% endif %}
 
   appConfig:
@@ -154,7 +154,7 @@ global:
       providers:
         - secret: openid-connect
     backups:
-      bucket: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3BucketName}>
+      bucket: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>
 
   extraEnv:
     GITLAB_ROOT_EMAIL: "admin@example.com"

--- a/roles/gitops/rendering-apps-files/gitlab/values/10-proxy.j2
+++ b/roles/gitops/rendering-apps-files/gitlab/values/10-proxy.j2
@@ -1,10 +1,10 @@
 {% if dsc.proxy.enabled %}
 global:
   extraEnv:
-    http_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>
-    https_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>
-    no_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>
-    HTTP_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>
-    HTTPS_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>
-    NO_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>
+    http_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
+    https_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
+    no_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
+    HTTP_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
+    HTTPS_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
+    NO_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/gitlab/values/10-registry.j2
+++ b/roles/gitops/rendering-apps-files/gitlab/values/10-registry.j2
@@ -1,78 +1,78 @@
 gitlab:
   gitaly:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitaly"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitaly"
   gitlab-exporter:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-exporter"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-exporter"
   gitlab-shell:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-shell"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-shell"
   kas:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-kas"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-kas"
   toolbox:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-toolbox-ee"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-toolbox-ee"
 
 global:
   kubectl:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/kubectl"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/kubectl"
   gitlabBase:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-base"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-base"
   certificates:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/certificates"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/certificates"
   enterpriseImages:
     migrations:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-toolbox-ee"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-toolbox-ee"
     sidekiq:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-sidekiq-ee"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-sidekiq-ee"
     toolbox:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-toolbox-ee"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-toolbox-ee"
     webservice:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-webservice-ee"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-webservice-ee"
     workhorse:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-workhorse-ee"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-workhorse-ee"
     geo-logcursor:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-geo-logcursor"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-geo-logcursor"
   communityImages:
     migrations:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-toolbox-ce"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-toolbox-ce"
     sidekiq:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-sidekiq-ce"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-sidekiq-ce"
     toolbox:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-toolbox-ce"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-toolbox-ce"
     webservice:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-webservice-ce"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-webservice-ce"
     workhorse:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-workhorse-ce"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/gitlab-workhorse-ce"
 
 shared-secrets:
   selfsign:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/cfssl-self-sign"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>/gitlab-org/build/cng/cfssl-self-sign"
 
 minio:
-  image: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.minio}>/minio"
+  image: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.minio}>/minio"
   minioMc:
-    image: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.minio}>/mc"
+    image: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.minio}>/mc"
 
 postgresql:
   image:
-    registry: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>"
+    registry: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>"
   metrics:
     image:
-      registry: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>"
+      registry: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>"
 
 redis:
   image:
-    registry: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>"
+    registry: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>"
   metrics:
     image:
-      registry: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>"
+      registry: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>"
 
 {% if use_image_pull_secrets %}
 global:

--- a/roles/gitops/rendering-apps-files/gitlab/values/10-tls.j2
+++ b/roles/gitops/rendering-apps-files/gitlab/values/10-tls.j2
@@ -1,6 +1,6 @@
 global:
   ingress:
-    class: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#ingressClassName>
+    class: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#ingressClassName>
     annotations:
 {% for key, val in dsc.ingress.annotations.items() %}
       {{ key }}: {{ val }}

--- a/roles/gitops/rendering-apps-files/templates/argocd/templates/helm-docker-registry-secret.yml.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/templates/helm-docker-registry-secret.yml.j2
@@ -7,6 +7,6 @@ metadata:
   namespace: {{ dsc.argocd.namespace }}
 type: Opaque
 stringData:
-  username: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#dockerAccount | jsonPath {.username}>
-  password: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#dockerAccount | jsonPath {.password}>
+  username: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#dockerAccount | jsonPath {.username}>
+  password: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#dockerAccount | jsonPath {.password}>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/argocd/templates/ingress.yml.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/templates/ingress.yml.j2
@@ -13,11 +13,11 @@ metadata:
     {{ key }}: {{ val }}
 {% endfor %}
 spec:
-  ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#ingressClassName>
+  ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#ingressClassName>
 {% if not dsc.ingress.tls.type == 'none' %}
   tls:
   - hosts:
-    - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.argocd}>
+    - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.argocd}>
 {% if dsc.ingress.tls.type == 'tlsSecret' %}
     secretName: {{ dsc.ingress.tls.tlsSecret.name }}
 {% else %}
@@ -25,7 +25,7 @@ spec:
 {% endif %}
 {% endif %}
   rules:
-    - host: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.argocd}>
+    - host: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.argocd}>
       http:
         paths:
           - path: /
@@ -51,11 +51,11 @@ metadata:
     {{ key }}: {{ val }}
 {% endfor %}
 spec:
-  ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#ingressClassName>
+  ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#ingressClassName>
 {% if not dsc.ingress.tls.type == 'none' %}
   tls:
   - hosts:
-    - appset.<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.argocd}>
+    - appset.<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.argocd}>
 {% if dsc.ingress.tls.type == 'tlsSecret' %}
     secretName: {{ dsc.ingress.tls.tlsSecret.name }}
 {% else %}
@@ -63,7 +63,7 @@ spec:
 {% endif %}
 {% endif %}
   rules:
-    - host: appset.<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.argocd}>
+    - host: appset.<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.argocd}>
       http:
         paths:
           - path: /api/webhook

--- a/roles/gitops/rendering-apps-files/templates/argocd/templates/repo-creds.yml.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/templates/repo-creds.yml.j2
@@ -9,7 +9,7 @@ metadata:
 type: Opaque
 stringData:
   password: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/gitlab/values#gitlabToken>
-  url: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.gitlab}>/{{ dsc.global.projectsRootDir | flatten | join ('/') }}"
+  url: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.gitlab}>/{{ dsc.global.projectsRootDir | flatten | join ('/') }}"
   username: "root"
 ---
 apiVersion: v1
@@ -24,8 +24,8 @@ stringData:
   name: bitnamicharts
   type: helm
   enableOCI: "true"
-  username: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#dockerAccount | jsonPath {.username}>
-  password: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#dockerAccount | jsonPath {.password}>
+  username: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#dockerAccount | jsonPath {.username}>
+  password: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#dockerAccount | jsonPath {.password}>
 {% if dsc.proxy.enabled %}
-  proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}> 
+  proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}> 
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/argocd/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/values/00-main.j2
@@ -19,7 +19,7 @@ argocd:
       application.instanceLabelKey: argocd.argoproj.io/instance.{{ instance_name }}
 {% endif %}
       clusterResources: "true"
-      url: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.argocd}>"
+      url: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.argocd}>"
       users.anonymous.enabled: "false"
       admin.enabled: "{{ dsc.argocd.admin.enabled }}"
       kustomize.buildOptions: "--enable-helm"
@@ -36,9 +36,9 @@ argocd:
   server:
     replicas: 3
     ingress:
-      ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#ingressClassName>
+      ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#ingressClassName>
     ingressGrpc:
-      ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#ingressClassName>
+      ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#ingressClassName>
   repoServer:
     replicas: 3
     initContainers:
@@ -95,11 +95,11 @@ argocd:
         value: /helm-working-dir
 {% if dsc.proxy.enabled %}
       - name: HTTP_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
       - name: HTTPS_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
       - name: NO_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>,{{ dsc_name }}-argocd-repo-server
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>,{{ dsc_name }}-argocd-repo-server
 {% endif %}
     volumes:
     - name: helm-custom-binary
@@ -117,9 +117,9 @@ argocd:
     replicas: 2
     webhook:
       ingress:
-        ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#ingressClassName>
+        ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#ingressClassName>
   notifications:
     enabled: false
     webhook:
       ingress:
-        ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#ingressClassName>
+        ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#ingressClassName>

--- a/roles/gitops/rendering-apps-files/templates/argocd/values/10-exposed-ca.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/values/10-exposed-ca.j2
@@ -3,5 +3,5 @@ argocd:
   configs:
     tls:
       certificates:
-        {{ gitlab_domain }}: <path:{{ vaultinfra_kv_name }}/data/env/conf-dso/apps/common/values#exposedCa>
+        {{ gitlab_domain }}: <path:{{ vaultinfra_kv_name }}/data/env/conf-dso/apps/global/values#exposedCa>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/argocd/values/10-metrics.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/values/10-metrics.j2
@@ -3,7 +3,7 @@ argocd:
   redis-ha:
     exporter:
       enabled: true
-      image: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.ghcr}>/oliver006/redis_exporter
+      image: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/oliver006/redis_exporter
       serviceMonitor:
         enabled: true
         namespace: "{{ dsc.argocd.namespace }}"
@@ -12,7 +12,7 @@ argocd:
 {% endif %}
     haproxy:
       image:
-        repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/library/haproxy
+        repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/library/haproxy
       metrics:
         enabled: true
         serviceMonitor:

--- a/roles/gitops/rendering-apps-files/templates/argocd/values/10-offline.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/values/10-offline.j2
@@ -3,5 +3,5 @@ argocd:
   configs:
     tls:
       certificates:
-        {{ dsc.argocd.privateGitlabDomain }}: <path:{{ vaultinfra_kv_name }}/data/env/conf-dso/apps/common/values#exposedCa>
+        {{ dsc.argocd.privateGitlabDomain }}: <path:{{ vaultinfra_kv_name }}/data/env/conf-dso/apps/global/values#exposedCa>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/argocd/values/10-proxy.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/values/10-proxy.j2
@@ -3,11 +3,11 @@ argocd:
   server:
     env: &extraEnvVars
       - name: HTTP_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
       - name: HTTPS_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
       - name: NO_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>,{{ dsc_name }}-argocd-repo-server
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>,{{ dsc_name }}-argocd-repo-server
       - name: GIT_HTTP_PROXY_AUTHMETHOD
         value: basic 
   

--- a/roles/gitops/rendering-apps-files/templates/argocd/values/10-registry.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/values/10-registry.j2
@@ -1,14 +1,14 @@
 argocd:
   image:
-    repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.quay}>
+    repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.quay}>
   
   redis:
     image:
-      repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>
+      repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>
 
   redis-ha:
     image:
-      repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/library/redis
+      repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/library/redis
       tag: 7.4.1-alpine
 
 {% if use_image_pull_secrets %}

--- a/roles/gitops/rendering-apps-files/templates/certmanager/values/10-proxy.j2
+++ b/roles/gitops/rendering-apps-files/templates/certmanager/values/10-proxy.j2
@@ -1,6 +1,6 @@
 {% if dsc.proxy.enabled %}
 certmanager:
-    http_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>
-    https_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>
-    no_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>
+    http_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
+    https_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
+    no_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/certmanager/values/10-registry.j2
+++ b/roles/gitops/rendering-apps-files/templates/certmanager/values/10-registry.j2
@@ -1,19 +1,19 @@
 certmanager:
   image:
-    repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.quay}>/jetstack/cert-manager-controller"
+    repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.quay}>/jetstack/cert-manager-controller"
 
   webhook:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.quay}>/jetstack/cert-manager-webhook"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.quay}>/jetstack/cert-manager-webhook"
 
   cainjector:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.quay}>/jetstack/cert-manager-cainjector"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.quay}>/jetstack/cert-manager-cainjector"
 
   acmesolver:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.quay}>/jetstack/cert-manager-acmesolver"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.quay}>/jetstack/cert-manager-acmesolver"
 
   startupapicheck:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.quay}>/jetstack/cert-manager-startupapicheck"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.quay}>/jetstack/cert-manager-startupapicheck"

--- a/roles/gitops/rendering-apps-files/templates/console/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/console/values/00-main.j2
@@ -7,27 +7,27 @@ console:
     projectsRootDir: "{{ dsc.global.projectsRootDir | flatten | join ('/') }}"
     secrets:
       ARGO_NAMESPACE: {{ dsc.argocd.namespace }}
-      ARGOCD_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain| jsonPath {.argocd}>/"
+      ARGOCD_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.argocd}>/"
       GITLAB_TOKEN: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/gitlab/values#gitlabToken>
-      GITLAB_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain| jsonPath {.gitlab}>/"
+      GITLAB_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.gitlab}>/"
       HARBOR_ADMIN: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/harbor/values#global| jsonPath {.harborAdmin}>
       HARBOR_ADMIN_PASSWORD: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/harbor/values#global| jsonPath {.harborAdminPassword}>
-      HARBOR_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain| jsonPath {.harbor}>/"
+      HARBOR_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.harbor}>/"
       KEYCLOAK_ADMIN: "dsoadmin"
       KEYCLOAK_ADMIN_PASSWORD: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/keycloak/values#auth| jsonPath {.adminPassword}>
-      KEYCLOAK_URL:  "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain| jsonPath {.keycloak}>/"
+      KEYCLOAK_URL:  "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.keycloak}>/"
       NEXUS_ADMIN: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/nexus/values#auth| jsonPath {.adminUsername}>
       NEXUS_ADMIN_PASSWORD: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/nexus/values#auth| jsonPath {.adminPassword}>
-      NEXUS_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain| jsonPath {.nexus}>/"
+      NEXUS_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.nexus}>/"
       SONAR_API_TOKEN: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/sonarqube/values#auth| jsonPath {.sonarApiToken}>"
-      SONARQUBE_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain| jsonPath {.sonarqube}>/"
+      SONARQUBE_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.sonarqube}>/"
       VAULT_TOKEN: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/vault/values#vaultToken>
-      VAULT_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain| jsonPath {.vault}>/"
+      VAULT_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.vault}>/"
   global:
     env:
       NODE_ENV: "production"
     keycloak:
-      domain: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain| jsonPath {.keycloak}>"
+      domain: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.keycloak}>"
       realm: "dso"
       protocol: "https"
       clientIds:
@@ -35,16 +35,16 @@ console:
         frontend: "console-frontend"
       clientSecrets:
         backend: ""
-      redirectUri: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain| jsonPath {.console}>"
+      redirectUri: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.console}>"
       sessionSecret: "a-very-strong-secret-with-more-than-32-char"
       devRealm: false
     postgresql:
       dbUrl: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/console/values#uri>?schema=public"
   ingress:
-    className: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#ingressClassName>
+    className: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#ingressClassName>
     enabled: true
     hosts:
-    - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain| jsonPath {.console}>
+    - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.console}>
     annotations: {{ dsc.ingress.annotations }}
     labels: {{ dsc.ingress.labels }}
   client:

--- a/roles/gitops/rendering-apps-files/templates/console/values/10-proxy.j2
+++ b/roles/gitops/rendering-apps-files/templates/console/values/10-proxy.j2
@@ -2,10 +2,10 @@
 console:
   global:
     env:
-      HTTP_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>
-      HTTPS_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>
-      NO_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>,<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.kubeIp}>
-      http_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>
-      https_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>
-      no_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>,<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.kubeIp}>
+      HTTP_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
+      HTTPS_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
+      NO_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>,<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.kubeIp}>
+      http_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
+      https_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
+      no_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>,<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.kubeIp}>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/console/values/10-registry.j2
+++ b/roles/gitops/rendering-apps-files/templates/console/values/10-registry.j2
@@ -1,15 +1,15 @@
 console:
   server:
     container:
-      image: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.ghcr}>/cloud-pi-native/console/server"
+      image: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloud-pi-native/console/server"
       
   client:
     container:
-      image: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.ghcr}>/cloud-pi-native/console/client"
+      image: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloud-pi-native/console/client"
 
   postgres:
     container:
-      image: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.ghcr}>/postgres:15.3"
+      image: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/postgres:15.3"
 
 {% if use_image_pull_secrets %}
   global:

--- a/roles/gitops/rendering-apps-files/templates/console/values/10-tls.j2
+++ b/roles/gitops/rendering-apps-files/templates/console/values/10-tls.j2
@@ -4,5 +4,5 @@ console:
     tls:
       - secretName: {{ dsc.ingress.tls.tlsSecret.name | default('tls-secret') }}
         hosts:
-          - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain| jsonPath {.console}>
+          - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.console}>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/console/values/100-cnpg.j2
+++ b/roles/gitops/rendering-apps-files/templates/console/values/100-cnpg.j2
@@ -3,7 +3,7 @@ cpn-cnpg:
 {% if dsc.console.cnpg.imageName is defined %}
   imageName: "{{ dsc.console.cnpg.imageName }}"
 {% else %}
-  imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.ghcr}>/cloudnative-pg/postgresql:16.1"
+  imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloudnative-pg/postgresql:16.1"
 {% endif %}
 {% if use_image_pull_secrets %}
   imagePullSecrets:
@@ -58,8 +58,8 @@ cpn-cnpg:
 {% endif %}
 {% if dsc.global.backup.cnpg.enabled or dsc.console.cnpg.mode == "restore" %}
   backup:
-    destinationPath: "s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3BucketName}>/{{ dsc.global.backup.cnpg.pathPrefix | default('') }}"
-    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3Endpoint}>
+    destinationPath: "s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>/{{ dsc.global.backup.cnpg.pathPrefix | default('') }}"
+    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>
 {% if dsc.global.backup.cnpg.enabled and dsc.console.cnpg.mode != "restore" %}
     enabled: true
 {% if dsc.global.backup.s3.endpointCA.key is defined %}
@@ -67,7 +67,7 @@ cpn-cnpg:
       create: true
       name: "bundle-cnpg-s3"
       key: "ca.pem"
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#cnpgS3CaPem>
+      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#cnpgS3CaPem>
 {% endif %}
 {% endif %}
     s3Credentials:
@@ -75,10 +75,10 @@ cpn-cnpg:
       secretName: pg-cluster-backup
       accessKeyId:
         key: {{ dsc.global.backup.s3.credentials.accessKeyId.key | default ('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3AccessKey}>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>
       secretAccessKey:
         key: {{ dsc.global.backup.s3.credentials.secretAccessKey.key | default('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3SecretKey}>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>
 {% if dsc.global.backup.cnpg.compression != 'none' %}
     compression: "{{ dsc.global.backup.cnpg.compression }}"
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/gitlab/templates/backup-helper-cronjob.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlab/templates/backup-helper-cronjob.yaml.j2
@@ -11,22 +11,22 @@ spec:
         spec:
           containers:
           - name: gitlab-backup-helper
-            image: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/minio/mc:latest
+            image: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/minio/mc:latest
             env:
             - name: S3_ENDPOINT
-              value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3Endpoint}>"
+              value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>"
             - name: S3_BUCKET_NAME
-              value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3BucketName}>"
+              value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>"
             - name: S3_ACCESS_KEY
-              value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3AccessKey}>"
+              value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>"
             - name: S3_SECRET_KEY
-              value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3SecretKey}>"
+              value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>"
             - name: S3_PATH_PREFIX
-              value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.gitlab.pathPrefix}>"
+              value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.gitlab.pathPrefix}>"
             - name: RETENTION
-              value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.gitlab.retentionPolicy}>"
+              value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.gitlab.retentionPolicy}>"
             - name: MC_EXTRA_ARGS
-              value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.gitlab.mcExtraArgs}>"
+              value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.gitlab.mcExtraArgs}>"
             args:
             - /bin/sh
             - -c

--- a/roles/gitops/rendering-apps-files/templates/gitlab/templates/backup-s3-secret.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlab/templates/backup-s3-secret.yaml.j2
@@ -3,12 +3,12 @@ apiVersion: v1
 data:
   config: |
     [default]
-    access_key = "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3AccessKey}>"
-    secret_key = "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3SecretKey}>"
-    host_base = "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3Endpoint}>"
-    host_bucket = "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3Endpoint}>"
-    proxy_host = "http://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.hostProxy}>"
-    proxy_port = "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.portProxy}>"
+    access_key = "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>"
+    secret_key = "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>"
+    host_base = "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>"
+    host_bucket = "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>"
+    proxy_host = "http://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.hostProxy}>"
+    proxy_port = "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.portProxy}>"
 kind: Secret
 metadata:
   annotations:

--- a/roles/gitops/rendering-apps-files/templates/gitlab/templates/bundle-cnpg-s3-secret.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlab/templates/bundle-cnpg-s3-secret.yaml.j2
@@ -4,7 +4,7 @@ dsc.global.backup.s3.endpointCA.name is defined and
 dsc.global.backup.s3.endpointCA.key is defined %}
 apiVersion: v1
 data:
-  ca.pem: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#cnpgS3CaPem>
+  ca.pem: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#cnpgS3CaPem>
 kind: Secret
 metadata:
   annotations:

--- a/roles/gitops/rendering-apps-files/templates/gitlab/templates/exposed-ca-secret.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlab/templates/exposed-ca-secret.yaml.j2
@@ -1,7 +1,7 @@
 {% if dsc.exposedCA.type == "configmap" or dsc.exposedCA.type == "secret" %}
 apiVersion: v1
 data:
-  tls.crt: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#exposedCa | base64encode>
+  tls.crt: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#exposedCa | base64encode>
 kind: Secret
 metadata:
   annotations:

--- a/roles/gitops/rendering-apps-files/templates/gitlab/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlab/values/00-main.j2
@@ -2,7 +2,7 @@ gitlab:
   watchCluster: false
   
   image:
-    repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlabOperator}>/cloud-native
+    repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlabOperator}>/cloud-native
     name: gitlab-operator
     tag: {{ dsc.gitlabOperator.chartVersion }}
     # digest:

--- a/roles/gitops/rendering-apps-files/templates/gitlab/values/10-registry.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlab/values/10-registry.j2
@@ -1,8 +1,8 @@
 gitlab:
   image:
-    registry: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>
+    registry: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>
 
   manager:
     kubeRbacProxy:
       image:
-        registry: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>
+        registry: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>

--- a/roles/gitops/rendering-apps-files/templates/gitlab/values/100-cnpg.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlab/values/100-cnpg.j2
@@ -3,7 +3,7 @@ cpn-cnpg:
 {% if dsc.gitlab.cnpg.imageName is defined %}
   imageName: "{{ dsc.gitlab.cnpg.imageName }}"
 {% else %}
-  imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.ghcr}>/cloudnative-pg/postgresql:16.1"
+  imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloudnative-pg/postgresql:16.1"
 {% endif %}
 {% if use_image_pull_secrets %}
   imagePullSecrets:
@@ -68,8 +68,8 @@ cpn-cnpg:
 
 {% if dsc.global.backup.cnpg.enabled or dsc.gitlab.cnpg.mode == "restore" %}
   backup:
-    destinationPath: "s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3BucketName}>/{{ dsc.global.backup.cnpg.pathPrefix | default('') }}"
-    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3Endpoint}>
+    destinationPath: "s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>/{{ dsc.global.backup.cnpg.pathPrefix | default('') }}"
+    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>
 {% if dsc.global.backup.cnpg.enabled and dsc.gitlab.cnpg.mode != "restore" %}
     enabled: true
 {% if dsc.global.backup.s3.endpointCA.key is defined %}
@@ -77,7 +77,7 @@ cpn-cnpg:
       create: true
       name: "bundle-cnpg-s3"
       key: "ca.pem"
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#cnpgS3CaPem>
+      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#cnpgS3CaPem>
 {% endif %}
 {% endif %}
     s3Credentials:
@@ -85,10 +85,10 @@ cpn-cnpg:
       secretName: pg-cluster-backup
       accessKeyId:
         key: {{ dsc.global.backup.s3.credentials.accessKeyId.key | default ('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3AccessKey}>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>
       secretAccessKey:
         key: {{ dsc.global.backup.s3.credentials.secretAccessKey.key | default('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3SecretKey}>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>
 {% if dsc.global.backup.cnpg.compression != 'none' %}
     compression: "{{ dsc.global.backup.cnpg.compression }}"
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/gitlab/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlab/values/200-ansible-job.j2
@@ -3,7 +3,7 @@ cpn-ansible-job:
     name: "gitlab" 
     extraEnv:
       - name: VAULT_INFRA_TOKEN
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#vault_infra_token>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>
   cronJob:
     create: true
     name: "gitlab-ci-catalog"

--- a/roles/gitops/rendering-apps-files/templates/gitlabrunner/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlabrunner/values/00-main.j2
@@ -5,7 +5,7 @@ gitlabrunner:
 ## How many old ReplicaSets for this Deployment you want to retain
   revisionHistoryLimit: 2
   
-  gitlabUrl: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.gitlab}>/
+  gitlabUrl: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.gitlab}>/
   
   runnerToken: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/gitlab/values#runnerToken>
   

--- a/roles/gitops/rendering-apps-files/templates/gitlabrunner/values/10-proxy.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlabrunner/values/10-proxy.j2
@@ -2,9 +2,9 @@
 gitlabrunner:
   envVars:
     - name: HTTP_PROXY
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>
+      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
     - name: HTTPS_PROXY
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>
+      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
     - name: NO_PROXY
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>
+      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/gitlabrunner/values/10-registry.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlabrunner/values/10-registry.j2
@@ -1,3 +1,3 @@
 gitlabrunner:
   image:
-    registry: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.gitlab}>
+    registry: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.gitlab}>

--- a/roles/gitops/rendering-apps-files/templates/gitlabrunner/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlabrunner/values/200-ansible-job.j2
@@ -5,4 +5,4 @@ cpn-ansible-job:
       create: false
     extraEnv:
       - name: VAULT_INFRA_TOKEN
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#vault_infra_token>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>

--- a/roles/gitops/rendering-apps-files/templates/glexporter/templates/exposed-ca.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/glexporter/templates/exposed-ca.yaml.j2
@@ -7,5 +7,5 @@ metadata:
   annotations:
     avp.kubernetes.io/remove-missing: "true"
 data:
-  tls.crt: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#exposedCa | base64encode>
+  tls.crt: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#exposedCa | base64encode>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/glexporter/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/glexporter/values/00-main.j2
@@ -2,7 +2,7 @@ glexporter:
   fullnameOverride: "glexporter"
   config:
     gitlab:
-      url: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.gitlab}>/
+      url: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.gitlab}>/
       token: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/gitlab/values#gitlabToken>
     redis:
       url: "redis://glexporter-redis-master.{{ dsc.gitlab.namespace }}.svc:6379"

--- a/roles/gitops/rendering-apps-files/templates/glexporter/values/10-proxy.j2
+++ b/roles/gitops/rendering-apps-files/templates/glexporter/values/10-proxy.j2
@@ -2,9 +2,9 @@
 glexporter:
   envVariables:
     - name: HTTP_PROXY
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>
+      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
     - name: HTTPS_PROXY
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>
+      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
     - name: NO_PROXY
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>
+      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/glexporter/values/10-registry.j2
+++ b/roles/gitops/rendering-apps-files/templates/glexporter/values/10-registry.j2
@@ -1,3 +1,3 @@
 glexporter:
   image:
-    repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.quay}>/mvisonneau/gitlab-ci-pipelines-exporter
+    repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.quay}>/mvisonneau/gitlab-ci-pipelines-exporter

--- a/roles/gitops/rendering-apps-files/templates/harbor/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/harbor/values/00-main.j2
@@ -4,10 +4,10 @@ harbor:
     imagePullPolicy: IfNotPresent
     type: ingress
     ingress:
-      className: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#ingressClassName>
+      className: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#ingressClassName>
       hosts:
-        core: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.harbor}>
-        notary: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.harborNotary}>
+        core: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.harbor}>
+        notary: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.harborNotary}>
       notary:
         annotations:
 {% for key, val in dsc.ingress.annotations.items() %}
@@ -26,7 +26,7 @@ harbor:
 {% for key, val in dsc.ingress.labels.items() %}
           {{ key }}: {{ val }}
 {% endfor %}
-  externalURL: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.harbor}>
+  externalURL: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.harbor}>
   persistence:
     enabled: true
     resourcePolicy: keep

--- a/roles/gitops/rendering-apps-files/templates/harbor/values/10-proxy.j2
+++ b/roles/gitops/rendering-apps-files/templates/harbor/values/10-proxy.j2
@@ -1,9 +1,9 @@
 {% if dsc.proxy.enabled %}
 harbor:
   proxy:
-    httpProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>
-    httpsProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>
-    noProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>,.local,.internal
+    httpProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
+    httpsProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
+    noProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>,.local,.internal
     components:
       - nginx
       - portal

--- a/roles/gitops/rendering-apps-files/templates/harbor/values/10-registry.j2
+++ b/roles/gitops/rendering-apps-files/templates/harbor/values/10-registry.j2
@@ -1,45 +1,45 @@
 harbor:
   nginx:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/goharbor/nginx-photon"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/goharbor/nginx-photon"
   
   portal:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/goharbor/harbor-portal"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/goharbor/harbor-portal"
   
   core:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/goharbor/harbor-core"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/goharbor/harbor-core"
   
   jobservice:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/goharbor/harbor-jobservice"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/goharbor/harbor-jobservice"
   
   registry:
     registry:
       image:
-        repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/goharbor/registry-photon"
+        repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/goharbor/registry-photon"
     controller:
       image:
-        repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/goharbor/harbor-registryctl"
+        repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/goharbor/harbor-registryctl"
   
   trivy:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/goharbor/trivy-adapter-photon"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/goharbor/trivy-adapter-photon"
   
   database:
     internal:
       image:
-        repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/goharbor/harbor-db"
+        repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/goharbor/harbor-db"
   
   redis:
     internal:
       image:
-        repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/goharbor/redis-photon"
+        repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/goharbor/redis-photon"
   
   exporter:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/goharbor/harbor-exporter"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/goharbor/harbor-exporter"
 
 {% if use_image_pull_secrets %}
   imagePullSecrets:

--- a/roles/gitops/rendering-apps-files/templates/harbor/values/100-cnpg.j2
+++ b/roles/gitops/rendering-apps-files/templates/harbor/values/100-cnpg.j2
@@ -3,7 +3,7 @@ cpn-cnpg:
 {% if dsc.harbor.cnpg.imageName is defined %}
   imageName: "{{ dsc.harbor.cnpg.imageName }}"
 {% else %}
-  imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.ghcr}>/cloudnative-pg/postgresql:16.1"
+  imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloudnative-pg/postgresql:16.1"
 {% endif %}
 {% if use_image_pull_secrets %}
   imagePullSecrets:
@@ -68,8 +68,8 @@ cpn-cnpg:
 
 {% if dsc.global.backup.cnpg.enabled or dsc.harbor.cnpg.mode == "restore" %}
   backup:
-    destinationPath: "s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3BucketName}>/{{ dsc.global.backup.cnpg.pathPrefix | default('') }}"
-    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3Endpoint}>
+    destinationPath: "s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>/{{ dsc.global.backup.cnpg.pathPrefix | default('') }}"
+    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>
 {% if dsc.global.backup.cnpg.enabled and dsc.harbor.cnpg.mode != "restore" %}
     enabled: true
 {% if dsc.global.backup.s3.endpointCA.key is defined %}
@@ -77,7 +77,7 @@ cpn-cnpg:
       create: true
       name: "bundle-cnpg-s3"
       key: "ca.pem"
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#cnpgS3CaPem>
+      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#cnpgS3CaPem>
 {% endif %}
 {% endif %}
     s3Credentials:
@@ -85,10 +85,10 @@ cpn-cnpg:
       secretName: pg-cluster-backup
       accessKeyId:
         key: {{ dsc.global.backup.s3.credentials.accessKeyId.key | default ('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3AccessKey}>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>
       secretAccessKey:
         key: {{ dsc.global.backup.s3.credentials.secretAccessKey.key | default('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3SecretKey}>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>
 {% if dsc.global.backup.cnpg.compression != 'none' %}
     compression: "{{ dsc.global.backup.cnpg.compression }}"
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/harbor/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/harbor/values/200-ansible-job.j2
@@ -3,4 +3,4 @@ cpn-ansible-job:
     name: "harbor" 
     extraEnv:
       - name: VAULT_INFRA_TOKEN
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#vault_infra_token>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>

--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/00-main.j2
@@ -82,10 +82,10 @@ keycloak:
 
   ingress:
     enabled: true
-    ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#ingressClassName>
+    ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#ingressClassName>
     pathType: "Prefix"
     apiVersion: ""
-    hostname: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.keycloak}>
+    hostname: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.keycloak}>
     path: /
     servicePort: "http"
     annotations:
@@ -202,7 +202,7 @@ keycloak:
 
   extraEnvVars:
     - name: DSFR_THEME_HOME_URL
-      value: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.console}>
+      value: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.console}>
     - name: DSFR_THEME_SERVICE_TITLE
       value: Cloud Pi Native
     - name: DSFR_THEME_BRAND_TOP
@@ -211,7 +211,7 @@ keycloak:
       value: cloudpinative-relations@interieur.gouv.fr
   initContainers:
     - name: realm-ext-provider
-      image: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/curlimages/curl:8.12.1"
+      image: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/curlimages/curl:8.12.1"
       imagePullPolicy: IfNotPresent
       command:
         - sh
@@ -224,9 +224,9 @@ keycloak:
 {% if dsc.proxy.enabled %}
       env:
         - name: HTTP_PROXY
-          value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>
+          value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
         - name: HTTPS_PROXY
-          value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>
+          value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
         - name: NO_PROXY
-          value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>
+          value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/10-proxy.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/10-proxy.j2
@@ -2,9 +2,9 @@
 keycloak:
   extraEnvVars:
     - name: HTTP_PROXY
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>
+      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
     - name: HTTPS_PROXY
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>
+      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
     - name: NO_PROXY
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>
+      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/10-registry.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/10-registry.j2
@@ -3,7 +3,7 @@ keycloak:
     security:
       allowInsecureImages: true
   image:
-    registry: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>
+    registry: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>
     pullPolicy: "IfNotPresent"
 
 {% if use_image_pull_secrets %}

--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/10-tls.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/10-tls.j2
@@ -3,6 +3,6 @@ keycloak:
   ingress:
     extraTls:
       - hosts:
-        - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.keycloak}>
+        - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.keycloak}>
         secretName: "{{ dsc.ingress.tls.tlsSecret.name }}"
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/100-cnpg.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/100-cnpg.j2
@@ -3,7 +3,7 @@ cpn-cnpg:
 {% if dsc.keycloak.cnpg.imageName is defined %}
   imageName: "{{ dsc.keycloak.cnpg.imageName }}"
 {% else %}
-  imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.ghcr}>/cloudnative-pg/postgresql:16.1"
+  imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloudnative-pg/postgresql:16.1"
 {% endif %}
 {% if use_image_pull_secrets %}
   imagePullSecrets:
@@ -68,8 +68,8 @@ cpn-cnpg:
 
 {% if dsc.global.backup.cnpg.enabled or dsc.keycloak.cnpg.mode == "restore" %}
   backup:
-    destinationPath: "s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3BucketName}>/{{ dsc.global.backup.cnpg.pathPrefix | default('') }}"
-    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3Endpoint}>
+    destinationPath: "s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>/{{ dsc.global.backup.cnpg.pathPrefix | default('') }}"
+    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>
 {% if dsc.global.backup.cnpg.enabled and dsc.keycloak.cnpg.mode != "restore" %}
     enabled: true
 {% if dsc.global.backup.s3.endpointCA.key is defined %}
@@ -77,7 +77,7 @@ cpn-cnpg:
       create: true
       name: "bundle-cnpg-s3"
       key: "ca.pem"
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#cnpgS3CaPem>
+      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#cnpgS3CaPem>
 {% endif %}
 {% endif %}
     s3Credentials:
@@ -85,10 +85,10 @@ cpn-cnpg:
       secretName: pg-cluster-backup
       accessKeyId:
         key: {{ dsc.global.backup.s3.credentials.accessKeyId.key | default ('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3AccessKey}>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>
       secretAccessKey:
         key: {{ dsc.global.backup.s3.credentials.secretAccessKey.key | default('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3SecretKey}>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>
 {% if dsc.global.backup.cnpg.compression != 'none' %}
     compression: "{{ dsc.global.backup.cnpg.compression }}"
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/200-ansible-job.j2
@@ -3,4 +3,4 @@ cpn-ansible-job:
     name: "keycloak" 
     extraEnv:
     - name: VAULT_INFRA_TOKEN
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#vault_infra_token>
+      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>

--- a/roles/gitops/rendering-apps-files/templates/kyverno/values/10-registry.j2
+++ b/roles/gitops/rendering-apps-files/templates/kyverno/values/10-registry.j2
@@ -1,4 +1,4 @@
 kyverno:
   global:
     image:
-      registry: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.ghcr}>
+      registry: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>

--- a/roles/gitops/rendering-apps-files/templates/nexus/templates/ingress.yml.j2
+++ b/roles/gitops/rendering-apps-files/templates/nexus/templates/ingress.yml.j2
@@ -17,16 +17,16 @@ spec:
 {% if not dsc.ingress.tls.type == 'none' %}
   tls:
   - hosts:
-    - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.nexus}>
+    - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.nexus}>
 {% if dsc.ingress.tls.type == 'tlsSecret' %}
     secretName: {{ dsc.ingress.tls.tlsSecret.name }}
 {% else %}
     secretName: nexus-tls-secret
 {% endif %}
 {% endif %}
-  ingressClassName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#ingressClassName>"
+  ingressClassName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#ingressClassName>"
   rules:
-    - host: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.nexus}>
+    - host: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.nexus}>
       http:
         paths:
           - path: /

--- a/roles/gitops/rendering-apps-files/templates/nexus/templates/ingressproxy.yml.j2
+++ b/roles/gitops/rendering-apps-files/templates/nexus/templates/ingressproxy.yml.j2
@@ -17,16 +17,16 @@ spec:
 {% if not dsc.ingress.tls.type == 'none' %}
   tls:
   - hosts:
-    - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.nexusDockerProxy}>
+    - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.nexusDockerProxy}>
 {% if dsc.ingress.tls.type == 'tlsSecret' %}
     secretName: {{ dsc.ingress.tls.tlsSecret.name }}
 {% else %}
     secretName: nexus-docker-proxy-tls-secret
 {% endif %}
 {% endif %}
-  ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#ingressClassName>
+  ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#ingressClassName>
   rules:
-    - host: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.nexusDockerProxy}>
+    - host: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.nexusDockerProxy}>
       http:
         paths:
           - path: /

--- a/roles/gitops/rendering-apps-files/templates/nexus/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/nexus/values/00-main.j2
@@ -114,7 +114,7 @@ nexus3:
           - new-anon
     job:
       image:
-        repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/alpine/k8s"
+        repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/alpine/k8s"
         tag: 1.31.2
         pullPolicy: IfNotPresent
       ttlSecondsAfterFinished: 600
@@ -152,15 +152,15 @@ nexus3:
         name: dockerproxy
         containerPort: 5000
         hosts:
-          - "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.nexusDockerProxy}>"
+          - "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.nexusDockerProxy}>"
   env:
 {% if dsc.proxy.enabled %}
     - name: http_proxy
-      value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>"
+      value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>"
     - name: https_proxy
-      value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>"
+      value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>"
     - name: no_proxy
-      value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>"
+      value: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>"
 {% endif %}
 
   # Désactivation des métriques Nexus (sans ServiceMonitor interne)

--- a/roles/gitops/rendering-apps-files/templates/observability/templates/gitlab-token.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/observability/templates/gitlab-token.yaml.j2
@@ -8,5 +8,5 @@ metadata:
 type: Opaque
 stringData:
   password: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/gitlab/values#gitlabToken>
-  url: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.gitlab}>/observability/observability.git"
+  url: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.gitlab}>/observability/observability.git"
   username: "root"

--- a/roles/gitops/rendering-apps-files/templates/observability/templates/grafana-app.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/observability/templates/grafana-app.yaml.j2
@@ -21,7 +21,7 @@ spec:
       - ./values.yaml
       - $tenants/helm/values.yaml
   - ref: tenants
-    repoURL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.gitlab}>/observability/observability.git"
+    repoURL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.gitlab}>/observability/observability.git"
     targetRevision: main
   syncPolicy:
     automated:

--- a/roles/gitops/rendering-apps-files/templates/observability/templates/observatorium-app.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/observability/templates/observatorium-app.yaml.j2
@@ -21,7 +21,7 @@ spec:
       - ./values.yaml
       - $tenants/helm/values.yaml
   - ref: tenants
-    repoURL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.gitlab}>/observability/observability.git"
+    repoURL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.gitlab}>/observability/observability.git"
     targetRevision: main
   syncPolicy:
     automated:

--- a/roles/gitops/rendering-apps-files/templates/observability/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/observability/values/00-main.j2
@@ -21,16 +21,16 @@ observatorium:
           url: https://github.com/cloud-pi-native/socle.git
   ingress:
     enabled: true
-    ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#ingressClassName>
+    ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#ingressClassName>
     hosts:
-      - host: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.observatorium}>
+      - host: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.observatorium}>
         paths:
           - path: /
             pathType: ImplementationSpecific
     tls:
       - hosts:
-          - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.observatorium}>
-        secretName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.observatorium}>-tls
+          - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.observatorium}>
+        secretName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.observatorium}>-tls
   api:
     loglevel: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/observatorium/values#api | jsonPath {.loglevel}>
     config:
@@ -40,7 +40,7 @@ observatorium:
       groups: [/admin]
       # Default oidc config
       clientID: "account"
-      issuerURL: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.keycloak}>/realms/dso
+      issuerURL: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.keycloak}>/realms/dso
       usernameClaim: "preferred_username"
       groupClaim: "groups"
   logs:
@@ -70,7 +70,7 @@ grafana:
     name: console
   oauth:
     enabled: true
-    url: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.keycloak}>/realms/dso
+    url: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.keycloak}>/realms/dso
     id: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/keycloak/values#client | jsonPath {.grafana.id}>
     secret: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/keycloak/values#client | jsonPath {.grafana.secret}>
     aud: grafana
@@ -80,10 +80,10 @@ grafana:
     certManager:
       enabled: true
     ingressClassName: nginx
-    url: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.grafana}>
+    url: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.grafana}>
   grafana:
     isOpenShift: {{ dsc.global.platform == "openshift" | ternary(true, false) }}
-    observatorium_url: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.observatorium}>
+    observatorium_url: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.observatorium}>
   global:
     projects:
       console:

--- a/roles/gitops/rendering-apps-files/templates/sonarqube/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/sonarqube/values/00-main.j2
@@ -3,7 +3,7 @@ sonarqube:
   nameOverride: sonar
   image:
     pullPolicy: IfNotPresent
-    repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/sonarqube
+    repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/sonarqube
   
   sonarWebContext: /
   
@@ -11,7 +11,7 @@ sonarqube:
     enabled: true
     # Used to create an Ingress record.
     hosts:
-      - name: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.sonarqube}>
+      - name: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.sonarqube}>
         pathType: Prefix
         path: "/"
     annotations:
@@ -20,7 +20,7 @@ sonarqube:
 {% endfor %}
     # This property allows for reports up to a certain size to be uploaded to SonarQube
       nginx.ingress.kubernetes.io/proxy-body-size: "64m"
-    ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#ingressClassName>
+    ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#ingressClassName>
     labels:
       app: "sonar"
   
@@ -61,8 +61,8 @@ sonarqube:
     sonar.auth.oidc.loginStrategy.customClaim.name: "upn"
     sonar.auth.oidc.clientId.secured: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/keycloak/values#client | jsonPath {.sonar.id}>
     sonar.auth.oidc.clientSecret.secured: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/keycloak/values#client | jsonPath {.sonar.secret}>
-    sonar.auth.oidc.issuerUri: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.keycloak}>/realms/dso"
-    sonar.core.serverBaseURL: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.sonarqube}>
+    sonar.auth.oidc.issuerUri: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.keycloak}>/realms/dso"
+    sonar.core.serverBaseURL: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.sonarqube}>
     sonar.plugins.risk.consent: "ACCEPTED"
   
   ## Override JDBC values
@@ -95,7 +95,7 @@ sonarqube:
       requests:
         cpu: 100m
         memory: 128Mi
-  curlContainerImage: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/curlimages/curl:8.11.0
+  curlContainerImage: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/curlimages/curl:8.11.0
   adminJobAnnotations: {}
   
   terminationGracePeriodSeconds: 60

--- a/roles/gitops/rendering-apps-files/templates/sonarqube/values/10-proxy.j2
+++ b/roles/gitops/rendering-apps-files/templates/sonarqube/values/10-proxy.j2
@@ -1,18 +1,18 @@
 {% if dsc.proxy.enabled %}
 sonarqube:
   prometheusExporter:
-    httpProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>
-    httpsProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>
-    noProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>
+    httpProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
+    httpsProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
+    noProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
   
   plugins:
-    httpProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>
-    httpsProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>
-    noProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>
+    httpProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
+    httpsProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
+    noProxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
   
   sonarProperties:
-    http.proxyHost: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.hostProxy}>
-    http.proxyPort: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.portProxy}>
-    https.proxyHost: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.hostProxy}>
-    https.proxyPort: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.portProxy}>
+    http.proxyHost: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.hostProxy}>
+    http.proxyPort: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.portProxy}>
+    https.proxyHost: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.hostProxy}>
+    https.proxyPort: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.portProxy}>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/sonarqube/values/10-tls.j2
+++ b/roles/gitops/rendering-apps-files/templates/sonarqube/values/10-tls.j2
@@ -3,7 +3,7 @@ sonarqube:
   ingress:
     tls:
       - hosts:
-          - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.sonarqube}>
+          - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.sonarqube}>
 {% if dsc.ingress.tls.type == 'tlsSecret' %}
         secretName: {{ dsc.ingress.tls.tlsSecret.name }}
 {% else %}

--- a/roles/gitops/rendering-apps-files/templates/sonarqube/values/100-cnpg.j2
+++ b/roles/gitops/rendering-apps-files/templates/sonarqube/values/100-cnpg.j2
@@ -3,7 +3,7 @@ cpn-cnpg:
 {% if dsc.sonarqube.cnpg.imageName is defined %}
   imageName: "{{ dsc.sonarqube.cnpg.imageName }}"
 {% else %}
-  imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.ghcr}>/cloudnative-pg/postgresql:16.1"
+  imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloudnative-pg/postgresql:16.1"
 {% endif %}
 {% if use_image_pull_secrets %}
   imagePullSecrets:
@@ -68,8 +68,8 @@ cpn-cnpg:
 
 {% if dsc.global.backup.cnpg.enabled or dsc.sonarqube.cnpg.mode == "restore" %}
   backup:
-    destinationPath: "s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3BucketName}>/{{ dsc.global.backup.cnpg.pathPrefix | default('') }}"
-    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3Endpoint}>
+    destinationPath: "s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>/{{ dsc.global.backup.cnpg.pathPrefix | default('') }}"
+    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>
 {% if dsc.global.backup.cnpg.enabled and dsc.sonarqube.cnpg.mode != "restore" %}
     enabled: true
 {% if dsc.global.backup.s3.endpointCA.key is defined %}
@@ -77,7 +77,7 @@ cpn-cnpg:
       create: true
       name: "bundle-cnpg-s3"
       key: "ca.pem"
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#cnpgS3CaPem>
+      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#cnpgS3CaPem>
 {% endif %}
 {% endif %}
     s3Credentials:
@@ -85,10 +85,10 @@ cpn-cnpg:
       secretName: pg-cluster-backup
       accessKeyId:
         key: {{ dsc.global.backup.s3.credentials.accessKeyId.key | default ('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3AccessKey}>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>
       secretAccessKey:
         key: {{ dsc.global.backup.s3.credentials.secretAccessKey.key | default('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3SecretKey}>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>
 {% if dsc.global.backup.cnpg.compression != 'none' %}
     compression: "{{ dsc.global.backup.cnpg.compression }}"
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/sonarqube/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/sonarqube/values/200-ansible-job.j2
@@ -3,4 +3,4 @@ cpn-ansible-job:
     name: "sonarqube" 
     extraEnv:
       - name: VAULT_INFRA_TOKEN
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#vault_infra_token>
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>

--- a/roles/gitops/rendering-apps-files/templates/vault/templates/exposed-ca.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/vault/templates/exposed-ca.yaml.j2
@@ -7,5 +7,5 @@ metadata:
   annotations:
     avp.kubernetes.io/remove-missing: "true"
 data:
-  tls.crt: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#exposedCa | base64encode>
+  tls.crt: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#exposedCa | base64encode>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/vault/templates/ingress.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/vault/templates/ingress.yaml.j2
@@ -17,16 +17,16 @@ spec:
 {% if not dsc.ingress.tls.type == 'none' %}
   tls:
     - hosts:
-        - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.vault}>
+        - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.vault}>
 {% if dsc.ingress.tls.type == 'tlsSecret' %}
       secretName: {{ dsc.ingress.tls.tlsSecret.name }}
 {% else %}
       secretName: vault-tls-secret
 {% endif %}
 {% endif %}
-  ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#ingressClassName>
+  ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#ingressClassName>
   rules:
-    - host: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.vault}>
+    - host: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.vault}>
       http:
         paths:
           - path: /

--- a/roles/gitops/rendering-apps-files/templates/vault/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/vault/values/00-main.j2
@@ -16,7 +16,7 @@ vault:
     ha:
       enabled: true
       replicas: 3
-      apiAddr: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#domain | jsonPath {.vault}>"
+      apiAddr: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.vault}>"
       raft:
         enabled: true
     standalone:

--- a/roles/gitops/rendering-apps-files/templates/vault/values/10-proxy.j2
+++ b/roles/gitops/rendering-apps-files/templates/vault/values/10-proxy.j2
@@ -2,7 +2,7 @@
 vault:
   server:
     extraEnvironmentVars:
-      HTTP_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpProxy}>
-      HTTPS_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.httpsProxy}>
-      NO_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#proxy | jsonPath {.noProxy}>,.{{ dsc.vault.namespace }}-internal"
+      HTTP_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
+      HTTPS_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
+      NO_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>,.{{ dsc.vault.namespace }}-internal"
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/vault/values/10-registry.j2
+++ b/roles/gitops/rendering-apps-files/templates/vault/values/10-registry.j2
@@ -2,20 +2,20 @@
 vault:
   injector:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/hashicorp/vault-k8s"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/hashicorp/vault-k8s"
     agentImage:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/hashicorp/vault"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/hashicorp/vault"
   
   server:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/hashicorp/vault"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/hashicorp/vault"
   
   csi:
     image:
-      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/hashicorp/vault-csi-provider"
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/hashicorp/vault-csi-provider"
     agent:
       image:
-        repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#image | jsonPath {.repository.docker}>/hashicorp/vault"
+        repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/hashicorp/vault"
 {% endif %}
 
 {% if use_image_pull_secrets %}

--- a/roles/gitops/rendering-apps-files/templates/vault/values/100-cpn-backup-utils.j2
+++ b/roles/gitops/rendering-apps-files/templates/vault/values/100-cpn-backup-utils.j2
@@ -4,13 +4,13 @@ cpn-backup-utils:
   vault:
     enabled: true
     secrets:
-      S3_BUCKET_NAME: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3BucketName}>
-      S3_BUCKET_PREFIX: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3BucketPrefix}>
-      S3_ENDPOINT: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3Endpoint}>
+      S3_BUCKET_NAME: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>
+      S3_BUCKET_PREFIX: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketPrefix}>
+      S3_ENDPOINT: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>
       VAULT_ADDR: "http://{{ dsc.vault.namespace }}-active:8200"
       VAULT_TOKEN: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/vault/values#vaultToken>
-      S3_ACCESS_KEY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3AccessKey}>
-      S3_SECRET_KEY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/common/values#backup | jsonPath {.s3SecretKey}>
+      S3_ACCESS_KEY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>
+      S3_SECRET_KEY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>
     env:
       RETENTION: "{{ dsc.global.backup.vault.retentionPolicy }}"
       MC_EXTRA_ARGS: "{{ dsc.global.backup.vault.mcExtraArgs }}"


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Certaines values générées par le role `gitops/rendering-apps-files` utilisent un chemin obsolète dans le Vault d'infra car le kv `apps/common` a été remplacé par `apps/global`.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous corrigeons le chemin erroné dans tous les templates de rendu concernés.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé sur un cluster de formation.
