### PR TITLE
fix: :bug: SonarQube admin password setting

### DIFF
--- a/roles/socle-config/tasks/envs.yaml
+++ b/roles/socle-config/tasks/envs.yaml
@@ -201,7 +201,7 @@
                     (sonarqube_secret.resources[0].data.password | b64decode
                      if (sonarqube_secret.resources[0].data.password is defined and
                          sonarqube_secret.resources[0].data.password | length > 0)
-                     else lookup('ansible.builtin.password', '/dev/null', length=24, chars=['ascii_letters', 'digits']))
+                     else lookup('ansible.builtin.password', '/dev/null', length=24, chars=['ascii_letters', 'digits', 'punctuation']))
                   }}
                 monitoringPassword: "{{ lookup('ansible.builtin.password', '/dev/null', length=24, chars=['ascii_letters', 'digits']) }}"
                 sonarApiToken: >-


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

La définition du mot de passe admin de SonarQube n'inclut pas de caractères spéciaux.
Il s'agit pourtant d'un prérequis si nous changeons manuellement ce mot de passe via la web UI.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Ajoute au moins un caractère spécial au mot de passe de SonarQube qui sera généré par notre role en cas de besoin.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
