### PR TITLE
fix: :ambulance: Keycloak default adminUser name

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/00-main.j2
@@ -2,7 +2,7 @@ keycloak:
   fullnameOverride: keycloak 
 
   auth:
-    adminUser: "dsoadmin"
+    adminUser: "admin"
     existingSecret: "keycloak"
     passwordSecretKey: "admin-password"
 


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Nous positionnons par défaut dans les values du chart Keycloak un nom d'admin ("dsoadmin") différent du nom par défaut proposé par le chart ("admin").
Il en résulte un échec des tasks de post install à ce niveau. L'admin défini dans les values du chart est en effet un admin temporaire qu'il vaut mieux éviter de changer, sinon il ne fonctionne tout simplement pas.
Au lieu de cela, un admin définitif doit être créé en parallèle puis l'admin temporaire initial doit être détruit. C'est tout le propos des tasks de post-install qui traitent précisément ce point.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous rétablissons la value "admin" au niveau du paramètre `auth.adminUser` du chart Keycloak.
L'accès à l'admin du realm master de Keycloak est à nouveau fonctionnel.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non, au contraire.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.