### PR TITLE
Fix/post conf rbac

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/keycloak/templates/post-conf-job.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/templates/post-conf-job.yaml.j2
@@ -5,13 +5,18 @@ metadata:
   name: keycloak-secret-access-role
   namespace: {{ dsc.keycloak.namespace }}
 rules:
+  # The "create" verb cannot apply to resourceNames, hence this first rule.
+  # See:  https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]
     resourceNames: ["keycloak"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list", "create", "update", "patch"]
+    verbs: ["get", "list", "update", "patch"]
     resourceNames: ["dso-admin-user-secret", "keycloak-client-secret-argo-client", "keycloak-client-secret-console-backend", "keycloak-client-secret-console-frontend", "keycloak-client-secret-gitlab-client", "keycloak-client-secret-grafana-projects", "keycloak-client-secret-harbor-client", "keycloak-client-secret-portail-client", "keycloak-client-secret-sonar-client", "keycloak-client-secret-vault-client"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/roles/gitops/rendering-apps-files/templates/vault/templates/post-conf-job.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/vault/templates/post-conf-job.yaml.j2
@@ -5,9 +5,14 @@ metadata:
   name: vault-secret-access-role
   namespace: {{ dsc.vault.namespace }}
 rules:
+  # The "create" verb cannot apply to resourceNames, hence this first rule.
+  # See:  https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list", "create"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
     resourceNames: ["{{ dsc_name }}-vault-keys"]
   - apiGroups: [""]
     resources: ["pods"]


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Les jobs de post-conf échouent pour Keycloak et Vault, car l'API Kubernetes considère que le serviceAccount `cpn-ansible-job` n'a pas les droits pour créer le secret indiqué.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

L'erreur est liée au fait que dans une ressource de type `Role` pour la définition des RBAC, le verb `create` ne peut pas s'appliquer sur des resourceNames, comme indiqué dans la documentation officielle :
https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources

Nous corrigeons donc ce point en autorisant la création ("create") du type de ressource souhaité via une règle dédiée, tout en maintenant la restriction aux resourceNames indiqués pour les autres verbs. 

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.