### PR TITLE
fix: :bug: Add missing namespacePrefix parameter to dsc CRD

### DIFF
--- a/roles/gitops/dso-app/templates/dso-appset.yaml.j2
+++ b/roles/gitops/dso-app/templates/dso-appset.yaml.j2
@@ -30,7 +30,7 @@ spec:
 {% endraw %}
   template:
     metadata:
-      name: "{{ dsc.global.gitOps.envName }}-{{"{{"}}.prefix{{"}}"}}{{"{{"}}.app{{"}}"}}"
+      name: "{{ dsc.global.gitOps.envName }}-{{"{{"}}.namespacePrefix{{"}}"}}{{"{{"}}.app{{"}}"}}"
 {%- raw %}
       annotations:
         argocd.argoproj.io/compare-options: ServerSideDiff=true
@@ -61,7 +61,7 @@ spec:
                 destinationClusterName: {{.destination.clusterName}}
       destination:
         name: "{{ default .destination.clusterName .clusterName }}"
-        namespace: "{{ default .prefix .customPrefix }}{{.namespace}}"
+        namespace: "{{ default .namespacePrefix .customNamespacePrefix }}{{.namespace}}"
       syncPolicy:
         automated:
           prune: true

--- a/roles/gitops/rendering-apps-files/config/dsc.json.j2
+++ b/roles/gitops/rendering-apps-files/config/dsc.json.j2
@@ -5,7 +5,7 @@
   "enabled": (dsc.observatorium.installEnabled if app.argocd_app == "observability" else dsc[app.argocd_app].installEnabled) | default(false),
   "clusterName": app.clusterName | default(""),
   "namespace": app.nameSpace,
-  "customPrefix": app.customPrefix | default(""),
+  "customNamespacePrefix": app.customNamespacePrefix | default(""),
   "syncWave": app.syncWave | default(10) | int
 }) %}
 {% endfor %}
@@ -13,7 +13,7 @@
   "env": envs[0].name,
   "provider": "self-hosted",
   "region": "fr-par",
-  "prefix": prefix | default("dso-"),
+  "namespacePrefix": dsc.global.gitOps.namespacePrefix,
   "destination": {
     "clusterName": dsc.global.gitOps.envName | default("")
   },

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -937,6 +937,11 @@ spec:
                         envName:
                           type: string
                           description: Name of the current environment where resides this DSC instance.
+                        namespacePrefix:
+                          type: string
+                          description: Prefix for all namespaces in the current environment.
+                      required:
+                        - namespacePrefix
                       type: object
                     dockerAccount:
                       properties:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Le template JSON de configuration des dépots GitOps utilise une variable prefix inexistante et positionne systématiquement la valeur de préfixe par défaut "dso-" sur les namespaces déployés.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous corrigeons le point en ajoutant le paramètre `spec.global.gitOps.namespacePrefix` à la dsc et en le rendant obligatoire.
Nous renommons également dans la conf le paramètre `prefix` en `namespacePrefix` de même que le paramètre `customPrefix` en `customNamespacePrefix`.
Nous adaptons l'ApplicationSet en conséquence.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de déploiement.
