### PR TITLE
fix: :bug: Add dscName parameter to post-conf job

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/gitlab/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlab/values/200-ansible-job.j2
@@ -1,6 +1,7 @@
 cpn-ansible-job:
   job:
-    name: "gitlab" 
+    name: "gitlab"
+    dscName: "{{ dsc_name }}"
     extraEnv:
       - name: VAULT_INFRA_TOKEN
         value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>

--- a/roles/gitops/rendering-apps-files/templates/harbor/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/harbor/values/200-ansible-job.j2
@@ -1,6 +1,7 @@
 cpn-ansible-job:
   job:
-    name: "harbor" 
+    name: "harbor"
+    dscName: "{{ dsc_name }}"
     extraEnv:
       - name: VAULT_INFRA_TOKEN
         value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>

--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/200-ansible-job.j2
@@ -1,6 +1,7 @@
 cpn-ansible-job:
   job:
-    name: "keycloak" 
+    name: "keycloak"
+    dscName: "{{ dsc_name }}"
     extraEnv:
     - name: VAULT_INFRA_TOKEN
       value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>

--- a/roles/gitops/rendering-apps-files/templates/sonarqube/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/sonarqube/values/200-ansible-job.j2
@@ -1,6 +1,7 @@
 cpn-ansible-job:
   job:
-    name: "sonarqube" 
+    name: "sonarqube"
+    dscName: "{{ dsc_name }}"
     extraEnv:
       - name: VAULT_INFRA_TOKEN
         value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>

--- a/roles/gitops/rendering-apps-files/templates/vault/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/vault/values/200-ansible-job.j2
@@ -1,6 +1,7 @@
 cpn-ansible-job:
   job:
-    name: "vault" 
+    name: "vault"
+    dscName: "{{ dsc_name }}"
     extraEnv:
       - name: VAULT_INFRA_TOKEN
         value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Le job lancé pour chaque outil nécessitant des actions de post-conf ne tient pas compte de la resource dsc utilisée et se positionne systématiquement sur celle par défaut (conf-dso) ce qui entraîne des erreurs sur toutes les tasks liées à des paramètres récupérés d'une autre dsc (cas d'une installation en parallèle dans un même cluster).

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous introduisons le paramètre dscName dans les values du chart utilisé pour le job de post-conf.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de déploiement.