### PR TITLE
fix :bug: with `global.backup` options not defined

### DIFF
--- a/roles/gitlab/templates/values/00-main.j2
+++ b/roles/gitlab/templates/values/00-main.j2
@@ -62,9 +62,9 @@ gitlab:
     backups:
       cron:
         enabled: {{ dsc.global.backup.gitlab.enabled }}
+{% if dsc.global.backup.gitlab.enabled %}
         schedule: {{ dsc.global.backup.gitlab.cron }}
         extraArgs: {{ dsc.global.backup.gitlab.extraArgs }}
-{% if dsc.global.backup.gitlab.enabled %}
       objectStorage:
         config:
           secret: gitlab-backup
@@ -124,8 +124,10 @@ global:
       autoLinkUser: ["openid_connect"]
       providers:
         - secret: openid-connect
+{% if dsc.global.backup.s3.enabled %}
     backups:
       bucket: "{{ dsc.global.backup.s3.bucketName }}"
+{% endif %}
 
   extraEnv:
     GITLAB_ROOT_EMAIL: "admin@example.com"

--- a/roles/gitops/rendering-apps-files/gitlab/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/gitlab/values/00-main.j2
@@ -91,9 +91,9 @@ gitlab:
     backups:
       cron:
         enabled: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/gitlab/values#gitlab | jsonPath {.toolbox.backups.cron.enabled}>
+{% if dsc.global.backup.gitlab.enabled %}
         schedule: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/gitlab/values#gitlab | jsonPath {.toolbox.backups.cron.schedule}>
         extraArgs: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/gitlab/values#gitlab | jsonPath {.toolbox.backups.cron.extraArgs}>
-{% if dsc.global.backup.gitlab.enabled %}
       objectStorage:
         config:
           secret: gitlab-backup
@@ -153,8 +153,10 @@ global:
       autoLinkUser: ["openid_connect"]
       providers:
         - secret: openid-connect
+{% if dsc.global.backup.s3.enabled %}
     backups:
       bucket: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>
+{% endif %}
 
   extraEnv:
     GITLAB_ROOT_EMAIL: "admin@example.com"

--- a/roles/socle-config/files/config.yaml
+++ b/roles/socle-config/files/config.yaml
@@ -77,6 +77,8 @@ spec:
     namespace: dso-global
     values: {}
     backup:
+      s3:
+        enabled: false
       velero:
         enabled: false
       cnpg:
@@ -84,6 +86,8 @@ spec:
       vault:
         enabled: false
       vaultInfra:
+        enabled: false
+      gitlab:
         enabled: false
     metrics:
       enabled: false


### PR DESCRIPTION
## Issues liées

---------

## Quel est le comportement actuel ?
Lorsque `global.backup.gitlab.enabled` et/ou `global.backup.s3.enabled` sont définis à `false`, ce qui devrait être fait dans `config.yaml`, le rôle GitLab échoue à plusieurs endroits. En effet, `global.backup.gitlab.cron`, `global.backup.gitlab.extraArgs` et `global.backup.s3.bucketName` ne sont pas définis et n'ont pas besoin de l'être.

Voici un exemple d'erreur, lors de l'execution de la tâche : `combine : Template and merge all files`
```
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable.
The error was: 'dict object' has no attribute 'bucketName'
The error appears to be in '/home/benjamin.bordes/GIT/forge-socle/roles/combine/tasks/main.yaml':
line 11, column 3, but may be elsewhere in the file depending on the exact syntax problem.
The offending line appears to be:
- name: Template and merge all files
  ^ here"}
```

## Quel est le nouveau comportement ?
Le rôle GitLab ne plante plus en raison de l'absence des options mentionnées ci-dessus lorsque `global.backup.gitlab.enabled` et/ou `global.backup.s3.enabled` sont définis à `false`. Ces deux options ont maintenant une valeur par défaut, comme c'est le cas pour `cnpg`, `vault` et `vaultInfra`.

## Cette PR introduit-elle un breaking change ?
Non

## Autres informations
