### PR TITLE
fix: :bug: GitLab and GitLab Operator user values

### DIFF
--- a/roles/gitops/rendering-apps-files/tasks/template.yml
+++ b/roles/gitops/rendering-apps-files/tasks/template.yml
@@ -53,7 +53,13 @@
     name: combine
   vars:
     combine_path: "{{ path }}"
-    combine_user_values: "{{ {} | combine({item.1.argocd_app: dsc[item.1.argocd_app]['values']}) }}"
+    combine_user_values: >-
+      {%- set app_name = item.1.argocd_app -%}
+      {%- if app_name == 'gitlab' -%}
+      {{ {} | combine({app_name: dsc.gitlabOperator['values']}) }}
+      {%- else -%}
+      {{ {} | combine({app_name: dsc[app_name]['values']}) }}
+      {%- endif -%}
     combine_dest_var: "{{ item.1.argocd_app }}_values"
 
 - name: Render "{{ item.1.argocd_app }}" values and write values.yaml to destination


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Lorsque nous spécifions des values personnalisées dans la dsc au niveau de `spec.gitlab.values`, celles-ci sont prises en compte et concaténées par le role `gitops/rendering-apps-files` à la fois pour l'instance GitLab (ce qui est correct) mais aussi pour le chart GitLab Operator, ce qui est problématique car ce ne sont pas des values appropriées pour cette dernière ressource.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous faisons en sorte qu'en mode de déploiement GitOps les values dsc de `spec.gitlab.values` soient concaténées uniquement dans la resource de kind GitLab et que les values dsc de `spec.gitlabOperator.values` le soient pour le chart qui, dans ce mode de déploiement, correspond à l'app `gitlab`.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé lors de la génération de values dans un repo GitOps privé.
