### PR TITLE
fix: :bug: SonarQube post-install reset admin token

### DIFF
--- a/post-install/sonarqube.yaml
+++ b/post-install/sonarqube.yaml
@@ -15,14 +15,6 @@
       ansible.builtin.import_role:
         name: gitops/post-install/sonarqube
 
-    - name: Get sonarqube secret
-      kubernetes.core.k8s_info:
-        namespace: "{{ dsc.sonarqube.namespace }}"
-        kind: Secret
-        name: sonarqube
-      register: sonarqube_secret
-      ignore_errors: true
-
     - name: Get SonarQube admin password secret
       kubernetes.core.k8s_info:
         namespace: "{{ dsc.sonarqube.namespace }}"
@@ -41,23 +33,8 @@
         status_code: [200]
       register: token_check
 
-    - name: Revoke SonarQube DSO admin token
-      ansible.builtin.uri:
-        validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-        url: "https://{{ sonar_domain }}/api/user_tokens/revoke"
-        user: "admin"
-        password: "{{ sonarqube_pwd.resources[0].data.password | b64decode }}"
-        force_basic_auth: true
-        method: POST
-        body_format: form-urlencoded
-        body:
-          login: "admin"
-          name: "DSO"
-        status_code: [204]
-      when: "'DSO' in (token_check.json.userTokens | map(attribute='name') | list)"
-      ignore_errors: true
-
     - name: Generate new SonarQube DSO admin token
+      when: "'DSO' not in (token_check.json.userTokens | map(attribute='name') | list)"
       ansible.builtin.uri:
         validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
         url: "https://{{ sonar_domain }}/api/user_tokens/generate?name=DSO"
@@ -67,6 +44,13 @@
         method: POST
         status_code: [200, 204]
       register: token_pass
+
+    - name: Keep current token if not changed
+      when: token_pass.json.token is not defined
+      ansible.builtin.set_fact:
+        token_pass:
+          json:
+            token: "{{ retrieved_token_pass }}"
 
     - name: Update vault-secrets sonarApiToken
       block:
@@ -84,7 +68,7 @@
                       auth:
                         sonarApiToken: >-
                           {{
-                            (token_pass.json.token)if token_pass is defined and
+                            (token_pass.json.token)if token_pass.json.token is defined and
                             token_pass.json.token | length > 0
                             else ''
                           }}

--- a/roles/gitops/post-install/sonarqube/tasks/main.yaml
+++ b/roles/gitops/post-install/sonarqube/tasks/main.yaml
@@ -104,8 +104,12 @@
       register: sonar_vault_values
       ignore_errors: true
 
+    - name: Set retrieved_token_pass fact
+      ansible.builtin.set_fact:
+        retrieved_token_pass: "{{ sonar_vault_values.data.data.auth.sonarApiToken }}"
+
 - name: Reset Admin Password procedure
-  when: sonar_vault_values.data.data.auth.sonarApiToken is undefined
+  when: retrieved_token_pass | length == 0
   ansible.builtin.include_tasks:
     file: reset-admin-password.yaml
 


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Le reset de token admin de SonarQube n'est pas fonctionnel.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous réparons la procédure de reset du token admin SonarQube.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.