### PR TITLE
fix: :bug: retrieved_token_pass fact

### DIFF
--- a/roles/gitops/post-install/sonarqube/tasks/main.yaml
+++ b/roles/gitops/post-install/sonarqube/tasks/main.yaml
@@ -106,7 +106,12 @@
 
     - name: Set retrieved_token_pass fact
       ansible.builtin.set_fact:
-        retrieved_token_pass: "{{ sonar_vault_values.data.data.auth.sonarApiToken }}"
+        retrieved_token_pass: >-
+          {{
+            (sonar_vault_values.data.data.auth.sonarApiToken)if sonar_vault_values.data.data.auth.sonarApiToken is defined and
+            sonar_vault_values.data.data.auth.sonarApiToken | length > 0
+            else ''
+          }}
 
 - name: Reset Admin Password procedure
   when: retrieved_token_pass | length == 0


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

La task de post-install SonarQube "Set retrieved_token_pass fact" échoue si le secret n'existe pas dans le Vault d'infra.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous réparons le fonctionnement de cette task, en lui ajoutant des conditions de vérification et l'initialisons à vide s'il s'avère que le secret n'existe pas dans le Vault d'infra.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.