### PR TITLE
feat: :sparkles: migration to official cnpg cluster chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1542,7 +1542,6 @@ harbor:
     regionendpoint: <regionendpoint>
     secretkey: <secretkey>
 ```
-Conserver `dsc.harbor.cnpg.initPassword` à `false`.  
 Puis lancer le playbook d'insertion des secrets dans le Vault d'infrastructure. 
 ```shell
 ansible-playbook install-gitops.yaml -t vault-secrets

--- a/post-install/harbor.yaml
+++ b/post-install/harbor.yaml
@@ -12,7 +12,6 @@
         name: socle-config
 
     - name: Get pg-cluster-harbor-app secret
-      when: not dsc.harbor.cnpg.initPassword
       kubernetes.core.k8s_info:
         namespace: "{{ dsc.harbor.namespace }}"
         kind: Secret

--- a/roles/gitops/rendering-apps-files/tasks/template.yml
+++ b/roles/gitops/rendering-apps-files/tasks/template.yml
@@ -57,6 +57,8 @@
       {%- set app_name = item.1.argocd_app -%}
       {%- if app_name == 'gitlab' -%}
       {{ {} | combine({app_name: dsc.gitlabOperator['values']}) }}
+      {%- elif app_name == 'cloudnativepg' -%}
+      {{ {} | combine({app_name: dsc[app_name]['operator']['values']}) }}
       {%- else -%}
       {{ {} | combine({app_name: dsc[app_name]['values']}) }}
       {%- endif -%}

--- a/roles/gitops/rendering-apps-files/templates/cloudnativepg/Chart.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/cloudnativepg/Chart.yaml.j2
@@ -2,10 +2,10 @@
 apiVersion: v2
 name: cloudnative-pg
 type: application
-version: {{ dsc.cloudnativepg.chartVersion }}
+version: {{ dsc.cloudnativepg.operator.chartVersion }}
 description: Cloudnative-pg operator installer
 dependencies: 
   - name: cloudnative-pg
     alias: cloudnativepg
-    version: {{ dsc.cloudnativepg.chartVersion }}
-    repository: {{ dsc.cloudnativepg.helmRepoUrl }}
+    version: {{ dsc.cloudnativepg.operator.chartVersion }}
+    repository: {{ dsc.cloudnativepg.operator.helmRepoUrl }}

--- a/roles/gitops/rendering-apps-files/templates/console/Chart.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/console/Chart.yaml.j2
@@ -3,10 +3,10 @@ type: application
 name: console
 version: 1.0.0
 dependencies:
-- name: cpn-cnpg
-  alias: cpn-cnpg
-  version: {{ dsc.cpnCnpg.chartVersion | quote }}
-  repository: {{ dsc.cpnCnpg.helmRepoUrl }}
+- name: cluster
+  alias: cluster
+  version: {{ dsc.cloudnativepg.cluster.chartVersion }}
+  repository: {{ dsc.cloudnativepg.cluster.helmRepoUrl }}
 - alias: console
   name: cpn-console
   repository: {{ dsc.console.helmRepoUrl }}

--- a/roles/gitops/rendering-apps-files/templates/console/values/100-cnpg.j2
+++ b/roles/gitops/rendering-apps-files/templates/console/values/100-cnpg.j2
@@ -1,86 +1,60 @@
-cpn-cnpg:
+cluster:
   nameOverride: "pg-cluster-console"
-{% if dsc.console.cnpg.imageName is defined %}
-  imageName: "{{ dsc.console.cnpg.imageName }}"
-{% else %}
-  imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloudnative-pg/postgresql:16.1"
-{% endif %}
+  fullnameOverride: "pg-cluster-console"
+  cluster:
+    primaryUpdateMethod: restart
+    enablePDB: false
+    imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/{{ dsc.console.cnpg.imageName }}"
 {% if use_image_pull_secrets %}
-  imagePullSecrets:
-  - name: dso-config-pull-secret
+    imagePullSecrets:
+    - name: dso-config-pull-secret
 {% endif %}
-  username: "dso"
-  dbName: "dso-console-db"
-  pvcSize:
-    data: {{ dsc.console.postgresPvcSize }}
+    initdb:
+      owner: "dso"
+      database: "dso-console-db"
+  
+    # Require 1Gi of space per instance using default storage class
+    storage:
+      size: {{ dsc.console.postgresPvcSize }}
 {% if dsc.console.postgresWalPvcSize is defined %}
-    wal: {{ dsc.console.postgresWalPvcSize }}
+    walStorage:
+      enabled: true
+      size: {{ dsc.console.postgresWalPvcSize }}
 {% endif %}
-  parameters:
-    max_worker_processes: "60"
+  
+    postgresql:
+      parameters:
+        max_worker_processes: "60"
 {% if dsc.console.postgresWalMaxSlotKeepSize is defined %}
-    max_slot_wal_keep_size: {{ dsc.console.postgresWalMaxSlotKeepSize }}
+        max_slot_wal_keep_size: {{ dsc.console.postgresWalMaxSlotKeepSize }}
 {% endif %}
+      pg_hba:
+        - host dso-console-db dso all md5
+        - host dso-console-db streaming_replica all md5
+
 {% if dsc.global.backup.velero.enabled %}
-  annotations:
-    pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d console > /var/lib/postgresql/data/app.dump-${index}"]'
-    pre.hook.backup.velero.io/container: postgres
-    pre.hook.backup.velero.io/on-error: Fail
-    pre.hook.backup.velero.io/timeout: 90s
+    annotations:
+      pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d dso-console-db > /var/lib/postgresql/data/app.dump-${index}"]'
+      pre.hook.backup.velero.io/container: postgres
+      pre.hook.backup.velero.io/on-error: Fail
+      pre.hook.backup.velero.io/timeout: 90s
 {% endif %}
-{% if dsc.console.cnpg.exposed %}
-  exposed: true
-  nodePort: {{ dsc.console.cnpg.nodePort }}
-{% endif %}
-{% if dsc.console.cnpg.initPassword %}
-  initSecret:
-    enabled: true 
-    username: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/console/values#cnpg | jsonPath  
-      {.username} | base64encode>
-    password: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/console/values#cnpg | jsonPath
-      {.password} | base64encode>
-{% endif %}
-{% if dsc.console.cnpg.mode == "replica" %}
-{%- filter indent(width=4) %}
-{{ dsc.console.cnpg.connectionParameters }}
-{%- endfilter %}
-{% endif %}
-{% if dsc.console.cnpg.mode == "replica" %}
-  mode: "replica"
-{% endif %}
-  monitoring:
-    enabled: {{ dsc.global.metrics.enabled }}
-{% if dsc.global.metrics.additionalLabels is defined %}
-    podMonitorAdditionalLabels:
-{% for key, value in dsc.global.metrics.additionalLabels.items() %}
-      {{ key }}: {{ value }}
-{% endfor %}
-{% endif %}
-{% if dsc.global.backup.cnpg.enabled or dsc.console.cnpg.mode == "restore" %}
-  backup:
-    destinationPath: "s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>/{{ dsc.global.backup.cnpg.pathPrefix | default('') }}"
-    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>
-{% if dsc.global.backup.cnpg.enabled and dsc.console.cnpg.mode != "restore" %}
+
+    monitoring:
+      enabled: {{ dsc.global.metrics.enabled }}
+
+{% if dsc.global.backup.cnpg.enabled %}
+  backups:       
+    destinationPath: s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>/cnpg
     enabled: true
-{% if dsc.global.backup.s3.endpointCA.key is defined %}
-    endpointCA:
-      create: true
-      name: "bundle-cnpg-s3"
-      key: "ca.pem"
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#cnpgS3CaPem>
-{% endif %}
-{% endif %}
-    s3Credentials:
-      create: true
-      secretName: pg-cluster-backup
-      accessKeyId:
-        key: {{ dsc.global.backup.s3.credentials.accessKeyId.key | default ('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>
-      secretAccessKey:
-        key: {{ dsc.global.backup.s3.credentials.secretAccessKey.key | default('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>
-{% if dsc.global.backup.cnpg.compression != 'none' %}
-    compression: "{{ dsc.global.backup.cnpg.compression }}"
-{% endif %}
-    retentionPolicy: "{{ dsc.global.backup.cnpg.retentionPolicy }}"
+    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>
+    retentionPolicy: 14d
+    s3:          
+      accessKey: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>
+      secretKey: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>
+    scheduledBackups:
+    - name: pg-cluster-console
+      schedule: 0 0 */6 * * *                                                              
+      backupOwnerReference: self
+      method: barmanObjectStore
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/gitlab/Chart.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlab/Chart.yaml.j2
@@ -4,10 +4,10 @@ name: gitlab
 type: application
 version: {{ dsc.gitlabOperator.chartVersion }}
 dependencies:
-- name: cpn-cnpg
-  alias: cpn-cnpg
-  version: {{ dsc.cpnCnpg.chartVersion | quote }}
-  repository: {{ dsc.cpnCnpg.helmRepoUrl }}
+- name: cluster
+  alias: cluster
+  version: {{ dsc.cloudnativepg.cluster.chartVersion }}
+  repository: {{ dsc.cloudnativepg.cluster.helmRepoUrl }}
 - name: gitlab-operator
   alias: gitlab
   version: {{ dsc.gitlabOperator.chartVersion }}

--- a/roles/gitops/rendering-apps-files/templates/gitlab/values/100-cnpg.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlab/values/100-cnpg.j2
@@ -1,96 +1,60 @@
-cpn-cnpg:
+cluster:
   nameOverride: "pg-cluster-gitlab"
-{% if dsc.gitlab.cnpg.imageName is defined %}
-  imageName: "{{ dsc.gitlab.cnpg.imageName }}"
-{% else %}
-  imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloudnative-pg/postgresql:16.1"
-{% endif %}
+  fullnameOverride: "pg-cluster-gitlab"
+  cluster:
+    primaryUpdateMethod: restart
+    enablePDB: false
+    imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/{{ dsc.gitlab.cnpg.imageName }}"
 {% if use_image_pull_secrets %}
-  imagePullSecrets:
-  - name: dso-config-pull-secret
+    imagePullSecrets:
+    - name: dso-config-pull-secret
 {% endif %}
-  username: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/gitlab/values#cnpg | jsonPath {.username}>"
-  dbName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/gitlab/values#cnpg | jsonPath {.database}>"
-
-  # Require 1Gi of space per instance using default storage class
-  pvcSize:
-    data: {{ dsc.gitlab.postgresPvcSize }}
+    initdb:
+      owner: "gitlab"
+      database: "gitlabhq_production"
+  
+    # Require 1Gi of space per instance using default storage class
+    storage:
+      size: {{ dsc.gitlab.postgresPvcSize }}
 {% if dsc.gitlab.postgresWalPvcSize is defined %}
-    wal: {{ dsc.gitlab.postgresWalPvcSize }}
+    walStorage:
+      enabled: true
+      size: {{ dsc.gitlab.postgresWalPvcSize }}
 {% endif %}
-
-  parameters:
-    max_worker_processes: "60"
+  
+    postgresql:
+      parameters:
+        max_worker_processes: "60"
 {% if dsc.gitlab.postgresWalMaxSlotKeepSize is defined %}
-    max_slot_wal_keep_size: {{ dsc.gitlab.postgresWalMaxSlotKeepSize }}
+        max_slot_wal_keep_size: {{ dsc.gitlab.postgresWalMaxSlotKeepSize }}
 {% endif %}
+      pg_hba:
+        - host gitlabhq_production gitlab all md5
+        - host gitlabhq_production streaming_replica all md5
 
 {% if dsc.global.backup.velero.enabled %}
-  annotations:
-    pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d gitlabhq_production > /var/lib/postgresql/data/app.dump-${index}"]'
-    pre.hook.backup.velero.io/container: postgres
-    pre.hook.backup.velero.io/on-error: Fail
-    pre.hook.backup.velero.io/timeout: 90s
+    annotations:
+      pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d gitlabhq_production > /var/lib/postgresql/data/app.dump-${index}"]'
+      pre.hook.backup.velero.io/container: postgres
+      pre.hook.backup.velero.io/on-error: Fail
+      pre.hook.backup.velero.io/timeout: 90s
 {% endif %}
 
-{% if dsc.gitlab.cnpg.exposed %}
-  exposed: true
-  nodePort: {{ dsc.gitlab.cnpg.nodePort }}
-{% endif %}
+    monitoring:
+      enabled: {{ dsc.global.metrics.enabled }}
 
-{% if dsc.gitlab.cnpg.initPassword %}
-  initSecret:
-    enabled: true 
-    username: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/gitlab/values#cnpg | jsonPath  
-      {.username} | base64encode>
-    password: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/gitlab/values#cnpg | jsonPath
-      {.password} | base64encode>
-{% endif %}
-
-{% if dsc.gitlab.cnpg.mode == "replica" %}
-{%- filter indent(width=4) %}
-{{ dsc.gitlab.cnpg.connectionParameters }}
-{%- endfilter %}
-{% endif %}
-
-{% if dsc.gitlab.cnpg.mode == "replica" %}
-  mode: "replica"
-{% endif %}
-
-  monitoring:
-    enabled: {{ dsc.global.metrics.enabled }}
-{% if dsc.global.metrics.additionalLabels is defined %}
-    podMonitorAdditionalLabels:
-{% for key, value in dsc.global.metrics.additionalLabels.items() %}
-      {{ key }}: {{ value }}
-{% endfor %}
-{% endif %}
-
-{% if dsc.global.backup.cnpg.enabled or dsc.gitlab.cnpg.mode == "restore" %}
-  backup:
-    destinationPath: "s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>/{{ dsc.global.backup.cnpg.pathPrefix | default('') }}"
-    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>
-{% if dsc.global.backup.cnpg.enabled and dsc.gitlab.cnpg.mode != "restore" %}
+{% if dsc.global.backup.cnpg.enabled %}
+  backups:       
+    destinationPath: s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>/cnpg
     enabled: true
-{% if dsc.global.backup.s3.endpointCA.key is defined %}
-    endpointCA:
-      create: true
-      name: "bundle-cnpg-s3"
-      key: "ca.pem"
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#cnpgS3CaPem>
-{% endif %}
-{% endif %}
-    s3Credentials:
-      create: true
-      secretName: pg-cluster-backup
-      accessKeyId:
-        key: {{ dsc.global.backup.s3.credentials.accessKeyId.key | default ('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>
-      secretAccessKey:
-        key: {{ dsc.global.backup.s3.credentials.secretAccessKey.key | default('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>
-{% if dsc.global.backup.cnpg.compression != 'none' %}
-    compression: "{{ dsc.global.backup.cnpg.compression }}"
-{% endif %}
-    retentionPolicy: "{{ dsc.global.backup.cnpg.retentionPolicy }}"
+    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>
+    retentionPolicy: 14d
+    s3:          
+      accessKey: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>
+      secretKey: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>
+    scheduledBackups:
+    - name: pg-cluster-gitlab
+      schedule: 0 0 */6 * * *                                                              
+      backupOwnerReference: self
+      method: barmanObjectStore
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/harbor/Chart.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/harbor/Chart.yaml.j2
@@ -4,10 +4,10 @@ name: harbor
 type: application
 version: {{ dsc.harbor.chartVersion }}
 dependencies:
-- name: cpn-cnpg
-  alias: cpn-cnpg
-  version: {{ dsc.cpnCnpg.chartVersion | quote }}
-  repository: {{ dsc.cpnCnpg.helmRepoUrl }}
+- name: cluster
+  alias: cluster
+  version: {{ dsc.cloudnativepg.cluster.chartVersion }}
+  repository: {{ dsc.cloudnativepg.cluster.helmRepoUrl }}
 - name: harbor
   alias: harbor
   version: {{ dsc.harbor.chartVersion }}

--- a/roles/gitops/rendering-apps-files/templates/harbor/values/100-cnpg.j2
+++ b/roles/gitops/rendering-apps-files/templates/harbor/values/100-cnpg.j2
@@ -1,96 +1,60 @@
-cpn-cnpg:
+cluster:
   nameOverride: "pg-cluster-harbor"
-{% if dsc.harbor.cnpg.imageName is defined %}
-  imageName: "{{ dsc.harbor.cnpg.imageName }}"
-{% else %}
-  imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloudnative-pg/postgresql:16.1"
-{% endif %}
+  fullnameOverride: "pg-cluster-harbor"
+  cluster:
+    primaryUpdateMethod: restart
+    enablePDB: false
+    imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/{{ dsc.harbor.cnpg.imageName }}"
 {% if use_image_pull_secrets %}
-  imagePullSecrets:
-  - name: dso-config-pull-secret
+    imagePullSecrets:
+    - name: dso-config-pull-secret
 {% endif %}
-  username: "harbor"
-  dbName: "registry"
-
-  # Require 1Gi of space per instance using default storage class
-  pvcSize:
-    data: {{ dsc.harbor.postgresPvcSize }}
+    initdb:
+      owner: "harbor"
+      database: "registry"
+  
+    # Require 1Gi of space per instance using default storage class
+    storage:
+      size: {{ dsc.harbor.postgresPvcSize }}
 {% if dsc.harbor.postgresWalPvcSize is defined %}
-    wal: {{ dsc.harbor.postgresWalPvcSize }}
+    walStorage:
+      enabled: true
+      size: {{ dsc.harbor.postgresWalPvcSize }}
 {% endif %}
-
-  parameters:
-    max_worker_processes: "60"
+  
+    postgresql:
+      parameters:
+        max_worker_processes: "60"
 {% if dsc.harbor.postgresWalMaxSlotKeepSize is defined %}
-    max_slot_wal_keep_size: {{ dsc.harbor.postgresWalMaxSlotKeepSize }}
+        max_slot_wal_keep_size: {{ dsc.harbor.postgresWalMaxSlotKeepSize }}
 {% endif %}
+      pg_hba:
+        - host registry harbor all md5
+        - host registry streaming_replica all md5
 
 {% if dsc.global.backup.velero.enabled %}
-  annotations:
-    pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d harbor > /var/lib/postgresql/data/app.dump-${index}"]'
-    pre.hook.backup.velero.io/container: postgres
-    pre.hook.backup.velero.io/on-error: Fail
-    pre.hook.backup.velero.io/timeout: 90s
+    annotations:
+      pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d registry > /var/lib/postgresql/data/app.dump-${index}"]'
+      pre.hook.backup.velero.io/container: postgres
+      pre.hook.backup.velero.io/on-error: Fail
+      pre.hook.backup.velero.io/timeout: 90s
 {% endif %}
 
-{% if dsc.harbor.cnpg.exposed %}
-  exposed: true
-  nodePort: {{ dsc.harbor.cnpg.nodePort }}
-{% endif %}
+    monitoring:
+      enabled: {{ dsc.global.metrics.enabled }}
 
-{% if dsc.harbor.cnpg.initPassword %}
-  initSecret:
-    enabled: true 
-    username: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/harbor/values#cnpg | jsonPath  
-      {.username} | base64encode>
-    password: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/harbor/values#cnpg | jsonPath
-      {.password} | base64encode>
-{% endif %}
-
-{% if dsc.harbor.cnpg.mode == "replica" %}
-{%- filter indent(width=4) %}
-{{ dsc.harbor.cnpg.connectionParameters }}
-{%- endfilter %}
-{% endif %}
-
-{% if dsc.harbor.cnpg.mode == "replica" %}
-  mode: "replica"
-{% endif %}
-
-  monitoring:
-    enabled: {{ dsc.global.metrics.enabled }}
-{% if dsc.global.metrics.additionalLabels is defined %}
-    podMonitorAdditionalLabels:
-{% for key, value in dsc.global.metrics.additionalLabels.items() %}
-      {{ key }}: {{ value }}
-{% endfor %}
-{% endif %}
-
-{% if dsc.global.backup.cnpg.enabled or dsc.harbor.cnpg.mode == "restore" %}
-  backup:
-    destinationPath: "s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>/{{ dsc.global.backup.cnpg.pathPrefix | default('') }}"
-    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>
-{% if dsc.global.backup.cnpg.enabled and dsc.harbor.cnpg.mode != "restore" %}
+{% if dsc.global.backup.cnpg.enabled %}
+  backups:       
+    destinationPath: s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>/cnpg
     enabled: true
-{% if dsc.global.backup.s3.endpointCA.key is defined %}
-    endpointCA:
-      create: true
-      name: "bundle-cnpg-s3"
-      key: "ca.pem"
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#cnpgS3CaPem>
-{% endif %}
-{% endif %}
-    s3Credentials:
-      create: true
-      secretName: pg-cluster-backup
-      accessKeyId:
-        key: {{ dsc.global.backup.s3.credentials.accessKeyId.key | default ('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>
-      secretAccessKey:
-        key: {{ dsc.global.backup.s3.credentials.secretAccessKey.key | default('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>
-{% if dsc.global.backup.cnpg.compression != 'none' %}
-    compression: "{{ dsc.global.backup.cnpg.compression }}"
-{% endif %}
-    retentionPolicy: "{{ dsc.global.backup.cnpg.retentionPolicy }}"
+    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>
+    retentionPolicy: 14d
+    s3:          
+      accessKey: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>
+      secretKey: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>
+    scheduledBackups:
+    - name: pg-cluster-harbor
+      schedule: 0 0 */6 * * *                                                              
+      backupOwnerReference: self
+      method: barmanObjectStore
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/keycloak/Chart.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/Chart.yaml.j2
@@ -4,10 +4,10 @@ name: keycloak
 type: application
 version: {{ dsc.keycloak.chartVersion }}
 dependencies:
-- name: cpn-cnpg
-  alias: cpn-cnpg
-  version: {{ dsc.cpnCnpg.chartVersion | quote }}
-  repository: {{ dsc.cpnCnpg.helmRepoUrl }}
+- name: cluster
+  alias: cluster
+  version: {{ dsc.cloudnativepg.cluster.chartVersion }}
+  repository: {{ dsc.cloudnativepg.cluster.helmRepoUrl }}
 - name: keycloak
   alias: keycloak
   version: {{ dsc.keycloak.chartVersion }}

--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/100-cnpg.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/100-cnpg.j2
@@ -1,96 +1,60 @@
-cpn-cnpg:
+cluster:
   nameOverride: "pg-cluster-keycloak"
-{% if dsc.keycloak.cnpg.imageName is defined %}
-  imageName: "{{ dsc.keycloak.cnpg.imageName }}"
-{% else %}
-  imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloudnative-pg/postgresql:16.1"
-{% endif %}
+  fullnameOverride: "pg-cluster-keycloak"
+  cluster:
+    primaryUpdateMethod: restart
+    enablePDB: false
+    imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/{{ dsc.keycloak.cnpg.imageName }}"
 {% if use_image_pull_secrets %}
-  imagePullSecrets:
-  - name: dso-config-pull-secret
+    imagePullSecrets:
+    - name: dso-config-pull-secret
 {% endif %}
-  username: "keycloak"
-  dbName: "keycloak"
-
-  # Require 1Gi of space per instance using default storage class
-  pvcSize:
-    data: {{ dsc.keycloak.postgresPvcSize }}
+    initdb:
+      owner: "keycloak"
+      database: "keycloak"
+  
+    # Require 1Gi of space per instance using default storage class
+    storage:
+      size: {{ dsc.keycloak.postgresPvcSize }}
 {% if dsc.keycloak.postgresWalPvcSize is defined %}
-    wal: {{ dsc.keycloak.postgresWalPvcSize }}
+    walStorage:
+      enabled: true
+      size: {{ dsc.keycloak.postgresWalPvcSize }}
 {% endif %}
-
-  parameters:
-    max_worker_processes: "60"
+  
+    postgresql:
+      parameters:
+        max_worker_processes: "60"
 {% if dsc.keycloak.postgresWalMaxSlotKeepSize is defined %}
-    max_slot_wal_keep_size: {{ dsc.keycloak.postgresWalMaxSlotKeepSize }}
+        max_slot_wal_keep_size: {{ dsc.keycloak.postgresWalMaxSlotKeepSize }}
 {% endif %}
+      pg_hba:
+        - host keycloak keycloak all md5
+        - host keycloak streaming_replica all md5
 
 {% if dsc.global.backup.velero.enabled %}
-  annotations:
-    pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d keycloak > /var/lib/postgresql/data/app.dump-${index}"]'
-    pre.hook.backup.velero.io/container: postgres
-    pre.hook.backup.velero.io/on-error: Fail
-    pre.hook.backup.velero.io/timeout: 90s
+    annotations:
+      pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d keycloak > /var/lib/postgresql/data/app.dump-${index}"]'
+      pre.hook.backup.velero.io/container: postgres
+      pre.hook.backup.velero.io/on-error: Fail
+      pre.hook.backup.velero.io/timeout: 90s
 {% endif %}
 
-{% if dsc.keycloak.cnpg.exposed %}
-  exposed: true
-  nodePort: {{ dsc.keycloak.cnpg.nodePort }}
-{% endif %}
+    monitoring:
+      enabled: {{ dsc.global.metrics.enabled }}
 
-{% if dsc.keycloak.cnpg.initPassword %}
-  initSecret:
-    enabled: true 
-    username: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/keycloak/values#cnpg | jsonPath  
-      {.username} | base64encode>
-    password: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/keycloak/values#cnpg | jsonPath
-      {.password} | base64encode>
-{% endif %}
-
-{% if dsc.keycloak.cnpg.mode == "replica" %}
-{%- filter indent(width=4) %}
-{{ dsc.keycloak.cnpg.connectionParameters }}
-{%- endfilter %}
-{% endif %}
-
-{% if dsc.keycloak.cnpg.mode == "replica" %}
-  mode: "replica"
-{% endif %}
-
-  monitoring:
-    enabled: {{ dsc.global.metrics.enabled }}
-{% if dsc.global.metrics.additionalLabels is defined %}
-    podMonitorAdditionalLabels:
-{% for key, value in dsc.global.metrics.additionalLabels.items() %}
-      {{ key }}: {{ value }}
-{% endfor %}
-{% endif %}
-
-{% if dsc.global.backup.cnpg.enabled or dsc.keycloak.cnpg.mode == "restore" %}
-  backup:
-    destinationPath: "s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>/{{ dsc.global.backup.cnpg.pathPrefix | default('') }}"
-    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>
-{% if dsc.global.backup.cnpg.enabled and dsc.keycloak.cnpg.mode != "restore" %}
+{% if dsc.global.backup.cnpg.enabled %}
+  backups:       
+    destinationPath: s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>/cnpg
     enabled: true
-{% if dsc.global.backup.s3.endpointCA.key is defined %}
-    endpointCA:
-      create: true
-      name: "bundle-cnpg-s3"
-      key: "ca.pem"
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#cnpgS3CaPem>
-{% endif %}
-{% endif %}
-    s3Credentials:
-      create: true
-      secretName: pg-cluster-backup
-      accessKeyId:
-        key: {{ dsc.global.backup.s3.credentials.accessKeyId.key | default ('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>
-      secretAccessKey:
-        key: {{ dsc.global.backup.s3.credentials.secretAccessKey.key | default('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>
-{% if dsc.global.backup.cnpg.compression != 'none' %}
-    compression: "{{ dsc.global.backup.cnpg.compression }}"
-{% endif %}
-    retentionPolicy: "{{ dsc.global.backup.cnpg.retentionPolicy }}"
+    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>
+    retentionPolicy: 14d
+    s3:          
+      accessKey: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>
+      secretKey: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>
+    scheduledBackups:
+    - name: pg-cluster-keycloak
+      schedule: 0 0 */6 * * *                                                              
+      backupOwnerReference: self
+      method: barmanObjectStore
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/sonarqube/Chart.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/sonarqube/Chart.yaml.j2
@@ -4,10 +4,10 @@ name: sonarqube
 type: application
 version: {{ dsc.sonarqube.chartVersion }}
 dependencies:
-- name: cpn-cnpg
-  alias: cpn-cnpg
-  version: {{ dsc.cpnCnpg.chartVersion | quote }}
-  repository: {{ dsc.cpnCnpg.helmRepoUrl }}
+- name: cluster
+  alias: cluster
+  version: {{ dsc.cloudnativepg.cluster.chartVersion }}
+  repository: {{ dsc.cloudnativepg.cluster.helmRepoUrl }}
 - name: sonarqube
   alias: sonarqube
   version: {{ dsc.sonarqube.chartVersion }}

--- a/roles/gitops/rendering-apps-files/templates/sonarqube/values/100-cnpg.j2
+++ b/roles/gitops/rendering-apps-files/templates/sonarqube/values/100-cnpg.j2
@@ -1,96 +1,60 @@
-cpn-cnpg:
+cluster:
   nameOverride: "pg-cluster-sonar"
-{% if dsc.sonarqube.cnpg.imageName is defined %}
-  imageName: "{{ dsc.sonarqube.cnpg.imageName }}"
-{% else %}
-  imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloudnative-pg/postgresql:16.1"
-{% endif %}
+  fullnameOverride: "pg-cluster-sonar"
+  cluster:
+    primaryUpdateMethod: restart
+    enablePDB: false
+    imageName: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/{{ dsc.sonarqube.cnpg.imageName }}"
 {% if use_image_pull_secrets %}
-  imagePullSecrets:
-  - name: dso-config-pull-secret
+    imagePullSecrets:
+    - name: dso-config-pull-secret
 {% endif %}
-  username: "dso_admin"
-  dbName: "sonardb"
-
-  # Require 1Gi of space per instance using default storage class
-  pvcSize:
-    data: {{ dsc.sonarqube.postgresPvcSize }}
+    initdb:
+      owner: "dso_admin"
+      database: "sonardb"
+  
+    # Require 1Gi of space per instance using default storage class
+    storage:
+      size: {{ dsc.sonarqube.postgresPvcSize }}
 {% if dsc.sonarqube.postgresWalPvcSize is defined %}
-    wal: {{ dsc.sonarqube.postgresWalPvcSize }}
+    walStorage:
+      enabled: true
+      size: {{ dsc.sonarqube.postgresWalPvcSize }}
 {% endif %}
-
-  parameters:
-    max_worker_processes: "60"
+  
+    postgresql:
+      parameters:
+        max_worker_processes: "60"
 {% if dsc.sonarqube.postgresWalMaxSlotKeepSize is defined %}
-    max_slot_wal_keep_size: {{ dsc.sonarqube.postgresWalMaxSlotKeepSize }}
+        max_slot_wal_keep_size: {{ dsc.sonarqube.postgresWalMaxSlotKeepSize }}
 {% endif %}
+      pg_hba:
+        - host sonardb dso_admin all md5
+        - host sonardb streaming_replica all md5
 
 {% if dsc.global.backup.velero.enabled %}
-  annotations:
-    pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d sonarqube > /var/lib/postgresql/data/app.dump-${index}"]'
-    pre.hook.backup.velero.io/container: postgres
-    pre.hook.backup.velero.io/on-error: Fail
-    pre.hook.backup.velero.io/timeout: 90s
+    annotations:
+      pre.hook.backup.velero.io/command: '["/bin/bash", "-c", "(( $(date +%d) %2 == 0 )) && index=0 || index=1; pg_dump -U postgres -Fc -d sonardb > /var/lib/postgresql/data/app.dump-${index}"]'
+      pre.hook.backup.velero.io/container: postgres
+      pre.hook.backup.velero.io/on-error: Fail
+      pre.hook.backup.velero.io/timeout: 90s
 {% endif %}
 
-{% if dsc.sonarqube.cnpg.exposed %}
-  exposed: true
-  nodePort: {{ dsc.sonarqube.cnpg.nodePort }}
-{% endif %}
+    monitoring:
+      enabled: {{ dsc.global.metrics.enabled }}
 
-{% if dsc.sonarqube.cnpg.initPassword %}
-  initSecret:
-    enabled: true 
-    username: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/sonarqube/values#cnpg | jsonPath  
-      {.username} | base64encode>
-    password: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/sonarqube/values#cnpg | jsonPath
-      {.password} | base64encode>
-{% endif %}
-
-{% if dsc.sonarqube.cnpg.mode == "replica" %}
-{%- filter indent(width=4) %}
-{{ dsc.sonarqube.cnpg.connectionParameters }}
-{%- endfilter %}
-{% endif %}
-
-{% if dsc.sonarqube.cnpg.mode == "replica" %}
-  mode: "replica"
-{% endif %}
-
-  monitoring:
-    enabled: {{ dsc.global.metrics.enabled }}
-{% if dsc.global.metrics.additionalLabels is defined %}
-    podMonitorAdditionalLabels:
-{% for key, value in dsc.global.metrics.additionalLabels.items() %}
-      {{ key }}: {{ value }}
-{% endfor %}
-{% endif %}
-
-{% if dsc.global.backup.cnpg.enabled or dsc.sonarqube.cnpg.mode == "restore" %}
-  backup:
-    destinationPath: "s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>/{{ dsc.global.backup.cnpg.pathPrefix | default('') }}"
-    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>
-{% if dsc.global.backup.cnpg.enabled and dsc.sonarqube.cnpg.mode != "restore" %}
+{% if dsc.global.backup.cnpg.enabled %}
+  backups:       
+    destinationPath: s3://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3BucketName}>/cnpg
     enabled: true
-{% if dsc.global.backup.s3.endpointCA.key is defined %}
-    endpointCA:
-      create: true
-      name: "bundle-cnpg-s3"
-      key: "ca.pem"
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#cnpgS3CaPem>
-{% endif %}
-{% endif %}
-    s3Credentials:
-      create: true
-      secretName: pg-cluster-backup
-      accessKeyId:
-        key: {{ dsc.global.backup.s3.credentials.accessKeyId.key | default ('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>
-      secretAccessKey:
-        key: {{ dsc.global.backup.s3.credentials.secretAccessKey.key | default('') }}
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>
-{% if dsc.global.backup.cnpg.compression != 'none' %}
-    compression: "{{ dsc.global.backup.cnpg.compression }}"
-{% endif %}
-    retentionPolicy: "{{ dsc.global.backup.cnpg.retentionPolicy }}"
+    endpointURL: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3Endpoint}>
+    retentionPolicy: 14d
+    s3:          
+      accessKey: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3AccessKey}>
+      secretKey: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#backup | jsonPath {.s3SecretKey}>
+    scheduledBackups:
+    - name: pg-cluster-sonar
+      schedule: 0 0 */6 * * *                                                              
+      backupOwnerReference: self
+      method: barmanObjectStore
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/vault/Chart.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/vault/Chart.yaml.j2
@@ -12,7 +12,7 @@ dependencies:
 - name: cpn-backup-utils
   alias: cpn-backup-utils
   version: {{ dsc.global.backup.vault.chartVersion }}
-  repository: {{ dsc.cpnCnpg.helmRepoUrl }}
+  repository: {{ dsc.cpnAnsibleJob.helmRepoUrl }}
 {% endif %}
 - name: cpn-ansible-job
   alias: cpn-ansible-job

--- a/roles/gitops/vault-secrets/tasks/main.yaml
+++ b/roles/gitops/vault-secrets/tasks/main.yaml
@@ -85,7 +85,6 @@
       register: vault_keys
 
     - name: Get pg-cluster-harbor-app secret
-      when: not dsc.harbor.cnpg.initPassword
       kubernetes.core.k8s_info:
         namespace: "{{ dsc.harbor.namespace }}"
         kind: Secret
@@ -107,7 +106,6 @@
       register: kubernetes_service_clusterip
 
     - name: Get pg-cluster-gitlab-app secret
-      when: not dsc.gitlab.cnpg.initPassword
       kubernetes.core.k8s_info:
         namespace: "{{ dsc.gitlab.namespace }}"
         kind: Secret

--- a/roles/socle-config/files/config.yaml
+++ b/roles/socle-config/files/config.yaml
@@ -26,23 +26,22 @@ spec:
   cloudnativepg:
     installEnabled: true
     namespace: dso-cloudnativepg
-    helmRepoUrl: https://cloudnative-pg.github.io/charts
-    forcedInstall: false
-    values: {}
+    cluster:
+      helmRepoUrl: https://cloudnative-pg.io/charts
+      values: {}
+    operator:
+      helmRepoUrl: https://cloudnative-pg.io/charts
+      forcedInstall: false
+      values: {}
   console:
     installEnabled: true
     namespace: dso-console
     subDomain: console
     helmRepoUrl: https://cloud-pi-native.github.io/helm-charts
     cnpg:
-      mode: primary
-      exposed: false
-      initPassword: false
+      imageName: cloudnative-pg/postgresql:16.2
     values: {}
   cpnAnsibleJob:
-    helmRepoUrl: https://cloud-pi-native.github.io/helm-charts
-    values: {}
-  cpnCnpg:
     helmRepoUrl: https://cloud-pi-native.github.io/helm-charts
     values: {}
   gitlab:
@@ -52,9 +51,7 @@ spec:
     insecureCI: false
     pvcGitalySize: 50Gi
     cnpg:
-      mode: primary
-      exposed: false
-      initPassword: false
+      imageName: cloudnative-pg/postgresql:16.2
     values: {}
   gitlabCatalog:
     catalogRepoUrl: https://github.com/cloud-pi-native/gitlab-ci-catalog.git
@@ -120,9 +117,7 @@ spec:
     s3ImageChartStorage:
       enabled: false
     cnpg:
-      mode: primary
-      exposed: false
-      initPassword: false # switch to true when only GitOps deployment remain
+      imageName: cloudnative-pg/postgresql:16.2
     values: {}
   keycloak:
     installEnabled: true
@@ -132,9 +127,7 @@ spec:
     postgresPvcSize: 1Gi
     pluginDownloadUrl: https://github.com/codegouvfr/keycloak-theme-dsfr/releases/download/v2.1.4/keycloak-theme-for-kc-26-and-above.jar
     cnpg:
-      mode: primary
-      exposed: false
-      initPassword: false
+      imageName: cloudnative-pg/postgresql:16.2
     values: {}
   keycloakInfra:
     installEnabled: false
@@ -144,8 +137,7 @@ spec:
     postgresPvcSize: 1Gi
     pluginDownloadUrl: https://github.com/codegouvfr/keycloak-theme-dsfr/releases/download/v2.1.4/keycloak-theme-for-kc-26-and-above.jar
     cnpg:
-      mode: primary
-      exposed: false
+      imageName: cloudnative-pg/postgresql:16.2
     values: {}
   kyverno:
     installEnabled: false
@@ -184,9 +176,7 @@ spec:
     helmRepoUrl: https://sonarsource.github.io/helm-chart-sonarqube
     postgresPvcSize: 5Gi
     cnpg:
-      mode: primary
-      exposed: false
-      initPassword: false
+      imageName: cloudnative-pg/postgresql:16.2
     values: {}
   vault:
     installEnabled: true

--- a/roles/socle-config/files/cr-conf-dso-default.yaml
+++ b/roles/socle-config/files/cr-conf-dso-default.yaml
@@ -59,12 +59,8 @@ spec:
   #    password: WeAreThePasswords
   certmanager: {}
   cloudnativepg: {}
-  console:
-    cnpg:
-      mode: primary
-  gitlab:
-    cnpg:
-      mode: primary
+  console: {}
+  gitlab: {}
   glexporter: {}
   gitlabOperator: {}
   gitlabrunner: {}
@@ -80,8 +76,6 @@ spec:
   grafanaDatasource: {}
   grafanaOperator: {}
   harbor:
-    cnpg:
-      mode: primary
     adminPassword: anotherGreatPassword
     pvcRegistrySize: 50Gi
   ingress:
@@ -89,12 +83,8 @@ spec:
       route.openshift.io/termination: edge
     tls:
       type: none
-  keycloak:
-    cnpg:
-      mode: primary
-  keycloakInfra:
-    cnpg:
-      mode: primary
+  keycloak: {}
+  keycloakInfra: {}
   kyverno: {}
   nexus: {}
   observatorium:
@@ -109,8 +99,6 @@ spec:
   #  https_proxy: http://192.168.xx.xx:3128/
   #  no_proxy: .cluster.local,.svc,10.0.0.0/8,127.0.0.1,192.168.0.0/16,api.example.com,api-int.example.com,canary-openshift-ingress-canary.apps.example.com,console-openshift-console.apps.example.com,localhost,oauth-openshift.apps.example.com,svc.cluster.local,localdomain
   #  port: "3128"
-  sonarqube:
-    cnpg:
-      mode: primary
+  sonarqube: {}
   vault: {}
   vaultInfra: {}

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -237,19 +237,16 @@ spec:
                   type: object
                 cloudnativepg:
                   description: Configuration for CloudNativePG.
+                  type: object
+                  required:
+                    - installEnabled
                   properties:
                     installEnabled:
                       default: true
-                      description: Specifies whether we should install CloudNativePG instance.
+                      description: Specifies whether we should install CloudNativePG Operator instance.
                       type: boolean
                     namespace:
-                      description: The namespace for CloudNativePG.
-                      type: string
-                    helmRepoUrl:
-                      description: CloudNativePG helm repository url.
-                      type: string
-                    chartVersion:
-                      description: CloudNativePG helm chart version (e.g., "0.18.2").
+                      description: The namespace for CloudNativePG Operator.
                       type: string
                     forcedInstall:
                       description: |
@@ -258,16 +255,33 @@ spec:
                         The default value is false, which means no forced installation will occur.
                       default: false
                       type: boolean
-                    values:
-                      description: |
-                        You can add custom values for CloudNativePG, they will be merged with roles/cloudnativepg/templates/values/
-                        https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg
-                        https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/values.yaml
+                    cluster:
+                      description: Configuration for the cluster.
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                  required:
-                    - installEnabled
-                  type: object
+                      properties:
+                        helmRepoUrl:
+                          description: CloudNativePG helm repository url.
+                          type: string
+                        chartVersion:
+                          description: CloudNativePG helm chart version (e.g., "0.3.1").
+                          type: string
+                    operator:
+                      description: Configuration for the operator.
+                      type: object
+                      properties:
+                        helmRepoUrl:
+                          description: CloudNativePG helm repository url.
+                          type: string
+                        chartVersion:
+                          description: CloudNativePG helm chart version (e.g., "0.25.0").
+                          type: string
+                        values:
+                          description: |
+                            You can add custom values for CloudNativePG, they will be merged with roles/gitops/rendering-apps-files/
+                            https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg
+                            https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/values.yaml
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                 console:
                   description: Configuration for the console.
                   properties:
@@ -311,24 +325,8 @@ spec:
                       description: Configuration for cnpg clusters.
                       type: object
                       properties:
-                        mode:
-                          description: Determines whether cnpg clusters should be deployed as a primary cluster
-                            (initdb from scratch) or replica cluster (initdb from external source).
-                          default: primary
-                          type: string
-                          enum:
-                            - primary
-                            - replica
-                            - restore
                         imageName:
                           description: Name of the container image, supporting both tags (`<image>:<tag>`) and digests for deterministic and repeatable deployments (`<image>:<tag>@sha256:<digestValue>`). See. https://cloudnative-pg.io/documentation/1.24/operator_capability_levels/#override-of-operand-images-through-the-crd
-                          type: string
-                        exposed:
-                          description: Whether or not the cnpg cluster should be exposed via NodePort.
-                          type: boolean
-                          default: false
-                        nodePort:
-                          description: NodePort used to expose the cnpg cluster instance.
                           type: string
                         connectionParameters:
                           description: |
@@ -336,10 +334,6 @@ spec:
                             'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
                             https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
-                        initPassword:
-                          description: Whether or not the cnpg cluster db password should be initialized with a secret.
-                          type: boolean
-                          default: false
                   required:
                     - installEnabled
                   type: object
@@ -357,23 +351,6 @@ spec:
                         You can add custom values for cpn-ansible-job, they will be merged with roles/gitops/rendering-apps-files/
                         https://github.com/cloud-pi-native/helm-charts/blob/main/charts/dso-ansible-job
                         https://github.com/cloud-pi-native/helm-charts/blob/main/charts/dso-ansible-job/values.yaml
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                  type: object
-                cpnCnpg:
-                  description: Configuration for cpn-cnpg.
-                  properties:
-                    helmRepoUrl:
-                      description: CloudNativePG helm repository url.
-                      type: string
-                    chartVersion:
-                      description: CloudNativePG helm chart version (e.g., "0.18.2").
-                      type: string
-                    values:
-                      description: |
-                        You can add custom values for CloudNativePG, they will be merged with roles/gitops/rendering-apps-files/
-                        https://github.com/cloud-pi-native/helm-charts/blob/main/charts/dso-cnpg
-                        https://github.com/cloud-pi-native/helm-charts/blob/main/charts/dso-cnpg/values.yaml
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
                   type: object
@@ -453,24 +430,8 @@ spec:
                       description: Configuration for cnpg clusters.
                       type: object
                       properties:
-                        mode:
-                          description: Determines whether cnpg clusters should be deployed as a primary cluster
-                            (initdb from scratch) or replica cluster (initdb from external source).
-                          default: primary
-                          type: string
-                          enum:
-                            - primary
-                            - replica
-                            - restore
                         imageName:
                           description: Name of the container image, supporting both tags (`<image>:<tag>`) and digests for deterministic and repeatable deployments (`<image>:<tag>@sha256:<digestValue>`). See. https://cloudnative-pg.io/documentation/1.24/operator_capability_levels/#override-of-operand-images-through-the-crd
-                          type: string
-                        exposed:
-                          description: Whether or not the cnpg cluster should be exposed via NodePort.
-                          type: boolean
-                          default: false
-                        nodePort:
-                          description: NodePort used to expose the cnpg cluster instance.
                           type: string
                         connectionParameters:
                           description: |
@@ -478,10 +439,6 @@ spec:
                             'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
                             https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
-                        initPassword:
-                          description: Whether or not the cnpg cluster db password should be initialized with a secret.
-                          type: boolean
-                          default: false
                   required:
                     - installEnabled
                   type: object
@@ -1148,24 +1105,8 @@ spec:
                       description: Configuration for cnpg clusters.
                       type: object
                       properties:
-                        mode:
-                          description: Determines whether cnpg clusters should be deployed as a primary cluster
-                            (initdb from scratch) or replica cluster (initdb from external source).
-                          default: primary
-                          type: string
-                          enum:
-                            - primary
-                            - replica
-                            - restore
                         imageName:
                           description: Name of the container image, supporting both tags (`<image>:<tag>`) and digests for deterministic and repeatable deployments (`<image>:<tag>@sha256:<digestValue>`). See. https://cloudnative-pg.io/documentation/1.24/operator_capability_levels/#override-of-operand-images-through-the-crd
-                          type: string
-                        exposed:
-                          description: Whether or not the cnpg cluster should be exposed via NodePort.
-                          type: boolean
-                          default: false
-                        nodePort:
-                          description: NodePort used to expose the cnpg cluster instance.
                           type: string
                         connectionParameters:
                           description: |
@@ -1173,10 +1114,6 @@ spec:
                             'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
                             https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
-                        initPassword:
-                          description: Whether or not the cnpg cluster db password should be initialized with a secret.
-                          type: boolean
-                          default: false
                   required:
                     - pvcRegistrySize
                     - installEnabled
@@ -1319,24 +1256,8 @@ spec:
                       description: Configuration for cnpg clusters.
                       type: object
                       properties:
-                        mode:
-                          description: Determines whether cnpg clusters should be deployed as a primary cluster
-                            (initdb from scratch) or replica cluster (initdb from external source).
-                          default: primary
-                          type: string
-                          enum:
-                            - primary
-                            - replica
-                            - restore
                         imageName:
                           description: Name of the container image, supporting both tags (`<image>:<tag>`) and digests for deterministic and repeatable deployments (`<image>:<tag>@sha256:<digestValue>`). See. https://cloudnative-pg.io/documentation/1.24/operator_capability_levels/#override-of-operand-images-through-the-crd
-                          type: string
-                        exposed:
-                          description: Whether or not the cnpg cluster should be exposed via NodePort.
-                          type: boolean
-                          default: false
-                        nodePort:
-                          description: NodePort used to expose the cnpg cluster instance.
                           type: string
                         connectionParameters:
                           description: |
@@ -1344,10 +1265,6 @@ spec:
                             'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
                             https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
-                        initPassword:
-                          description: Whether or not the cnpg cluster db password should be initialized with a secret.
-                          type: boolean
-                          default: false
                   required:
                     - installEnabled
                   type: object
@@ -1400,32 +1317,12 @@ spec:
                       description: Configuration for cnpg clusters.
                       type: object
                       properties:
-                        mode:
-                          description: Determines whether cnpg clusters should be deployed as a primary cluster
-                            (initdb from scratch) or replica cluster (initdb from external source).
-                          default: primary
-                          type: string
-                          enum:
-                            - primary
-                            - replica
-                            - restore
-                        exposed:
-                          description: Whether or not the cnpg cluster should be exposed via NodePort.
-                          type: boolean
-                          default: false
-                        nodePort:
-                          description: NodePort used to expose the cnpg cluster instance.
-                          type: string
                         connectionParameters:
                           description: |
                             Connection parameters used for replication, it should contain
                             'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
                             https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
-                        initPassword:
-                          description: Whether or not the cnpg cluster db password should be initialized with a secret.
-                          type: boolean
-                          default: false
                   required:
                     - installEnabled
                   type: object
@@ -1640,24 +1537,8 @@ spec:
                       description: Configuration for cnpg clusters.
                       type: object
                       properties:
-                        mode:
-                          description: Determines whether cnpg clusters should be deployed as a primary cluster
-                            (initdb from scratch) or replica cluster (initdb from external source).
-                          default: primary
-                          type: string
-                          enum:
-                            - primary
-                            - replica
-                            - restore
                         imageName:
                           description: Name of the container image, supporting both tags (`<image>:<tag>`) and digests for deterministic and repeatable deployments (`<image>:<tag>@sha256:<digestValue>`). See. https://cloudnative-pg.io/documentation/1.24/operator_capability_levels/#override-of-operand-images-through-the-crd
-                          type: string
-                        exposed:
-                          description: Whether or not the cnpg cluster should be exposed via NodePort.
-                          type: boolean
-                          default: false
-                        nodePort:
-                          description: NodePort used to expose the cnpg cluster instance.
                           type: string
                         connectionParameters:
                           description: |
@@ -1665,10 +1546,6 @@ spec:
                             'connectionParameters', 'sslKey', 'sslCert', 'sslRootCert'
                             https://cloudnative-pg.io/documentation/1.18/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
                           type: string
-                        initPassword:
-                          description: Whether or not the cnpg cluster db password should be initialized with a secret.
-                          type: boolean
-                          default: false
                   required:
                     - installEnabled
                   type: object

--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -14,17 +14,18 @@ spec:
     # https://github.com/cert-manager/cert-manager/releases
     chartVersion: v1.14.3
   cloudnativepg:
-    # https://artifacthub.io/packages/helm/cloudnative-pg/cloudnative-pg
-    chartVersion: 0.20.1
+    cluster:
+      # https://artifacthub.io/packages/helm/cloudnative-pg/cluster
+      chartVersion: 0.3.1
+    operator:
+      # https://artifacthub.io/packages/helm/cloudnative-pg/cloudnative-pg
+      chartVersion: "0.25.0"
   console:
     # https://github.com/cloud-pi-native/console/releases
     chartVersion: 2.1.10
   cpnAnsibleJob:
     # https://github.com/cloud-pi-native/helm-charts/releases
     chartVersion: ">=1.0.0 <2.0.0"
-  cpnCnpg:
-    # https://github.com/cloud-pi-native/helm-charts/releases
-    chartVersion: ">=2.0.0 <3.0.0"
   gitlab:
     # https://artifacthub.io/packages/helm/gitlab/gitlab
     chartVersion: "9.1.2"

--- a/roles/socle-config/tasks/envs.yaml
+++ b/roles/socle-config/tasks/envs.yaml
@@ -101,31 +101,6 @@
             customNamespacePrefix: ""
             syncWave: 30
             vault_values:
-              cnpg:
-                username: >-
-                  {{
-                    (pg_gitlab_db_secret.resources[0].data.username | b64decode)
-                    if not dsc.gitlab.cnpg.initPassword
-                    and pg_gitlab_db_secret is defined
-                    and pg_gitlab_db_secret.resources | length > 0
-                    else 'gitlab'
-                  }}
-                password: >-
-                  {{
-                    (pg_gitlab_db_secret.resources[0].data.password | b64decode)
-                    if not dsc.gitlab.cnpg.initPassword
-                    and pg_gitlab_db_secret is defined
-                    and pg_gitlab_db_secret.resources | length > 0
-                    else lookup('ansible.builtin.password', '/dev/null', length=24, chars=['ascii_letters', 'digits'])
-                  }}
-                database: >-
-                  {{
-                    (pg_gitlab_db_secret.resources[0].data.dbname | b64decode)
-                    if not dsc.gitlab.cnpg.initPassword
-                    and pg_gitlab_db_secret is defined
-                    and pg_gitlab_db_secret.resources | length > 0
-                    else 'gitlabhq_production'
-                  }}
               gitlab:
                 toolbox:
                   backups:

--- a/versions.md
+++ b/versions.md
@@ -2,10 +2,10 @@
 | ------------------------- | ---------------- | ------------- | -------------------------------------------------------------------------------------------------------------------- |
 | argocd                    | 2.14.1           | 7.9.0         | [argocd](https://artifacthub.io/packages/helm/argo/argo-cd)                                                          |
 | certmanager               | 1.14.3           | 1.14.3        | [certmanager](https://github.com/cert-manager/cert-manager/releases)                                                 |
-| cloudnativepg             | 1.22.1           | 0.20.1        | [cloudnativepg](https://artifacthub.io/packages/helm/cloudnative-pg/cloudnative-pg)                                  |
+| cloudnativepg.cluster     | N/A              | 0.3.1         | [cluster](https://artifacthub.io/packages/helm/cloudnative-pg/cluster)                                               |
+| cloudnativepg.operator    | 1.26.1           | 0.25.0        | [cloudnative-pg](https://artifacthub.io/packages/helm/cloudnative-pg/cloudnative-pg)                                 |
 | console                   | 9.\*.\*          | 2.\*.\*       | [console](https://github.com/cloud-pi-native/helm-charts)                                                            |
 | cpn-ansible-job           | 1.\*.\*            | 1.\*.\*         | [cpn-ansible-job](https://github.com/cloud-pi-native/helm-charts)                                                    |
-| cpn-cnpg                  | 2.\*.\*         | 2.\*.\*        | [cpn-cnpg](https://github.com/cloud-pi-native/helm-charts)                                                           |
 | gitlab                    | 18.1.2          | 9.1.2        | [gitlab](https://artifacthub.io/packages/helm/gitlab/gitlab)                                                         |
 | glexporter | 0.5.10           | 0.3.5         | [glexporter](https://github.com/mvisonneau/helm-charts/tree/main/charts/gitlab-ci-pipelines-exporter) |
 | gitlabOperator            | 2.1.2           | 2.1.2        | [gitlabOperator](https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/tags)                                  |


### PR DESCRIPTION
## Issues liées

Issues numéro: https://github.com/cloud-pi-native/helm-charts/issues/159

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
We were using and maintaining our own cnpg cluster chart (https://github.com/cloud-pi-native/helm-charts/releases/tag/cpn-cnpg-2.3.3) because when the project started, there were no official cnpg cluster chart.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Use the official cnpg cluster chart so we can stop maintaining ours.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Yes:
- Some CRDs structure changes.
- No more support for `initPassword` in the code.
- No more support for mode other than primary in the code (restore mode is yet to release in the official chart).
- No more support for NodePort exposition in the code.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Fixed some parts (mostly the db name in the pg_dump command) of the code regarding https://github.com/cloud-pi-native/socle/issues/721.