### PR TITLE
fix: :lock: Add no_log parameter to sensitive task

### DIFF
--- a/roles/gitops/post-install/gitlab/tasks/main.yaml
+++ b/roles/gitops/post-install/gitlab/tasks/main.yaml
@@ -158,6 +158,7 @@
     extra_kaniko_args: "{{ extra_kaniko_args | default('') }} --registry-mirror {{ harbor_domain | regex_replace('^https?://', '') }}/{{ item.name }}"
   loop: "{{ dsc.harbor.proxyCache }}"
   when: dsc.harbor.proxyCache is defined
+  no_log: true
 
 - name: Set or update insecure args variables
   community.general.gitlab_group_variable:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

La task de post-install GitLab "Append registry mirror arguments to extra_kaniko_args" affiche des credentials dans les logs de sortie.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous ajoutons le paramètre no_log à la task en question pour éviter ce comportement.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.
