### PR TITLE
chore: :arrow_up: upgrade nexus chart

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/nexus/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/nexus/values/00-main.j2
@@ -1,5 +1,6 @@
 nexus3:
   fullnameOverride: nexus
+  chownDataDir: false
   config:
     enabled: true
     cleanup:

--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -67,7 +67,7 @@ spec:
     chartVersion: 3.1.4
   nexus:
     # https://hub.docker.com/r/sonatype/nexus3/
-    chartVersion: 5.13.1
+    chartVersion: 5.13.2
   observatorium:
     # https://github.com/cloud-pi-native/helm-charts/tags
     chartVersion: 0.5.2

--- a/versions.md
+++ b/versions.md
@@ -17,6 +17,6 @@
 | keycloak                  | 26.3.3           | 25.2.0        | [keycloak](https://artifacthub.io/packages/helm/bitnami/keycloak)                                                    |
 | kyverno                   | v1.11.4          | 3.1.4         | [kyverno](https://artifacthub.io/packages/helm/kyverno/kyverno)                                                      |
 | observatorium             | main-2025-02-10-1bcf722 | 0.5.2  | [observatorium](https://github.com/cloud-pi-native/helm-charts/tree/main/charts/observatorium)                                                                   |
-| nexus                     | 3.83.1           | 5.13.1        | [nexus](https://artifacthub.io/packages/helm/stevehipwell/nexus3)                                                    |
+| nexus                     | 3.83.2           | 5.13.2        | [nexus](https://artifacthub.io/packages/helm/stevehipwell/nexus3)                                                    |
 | sonarqube                 | 10.8.1-community | 10.8.1        | [sonarqube](https://artifacthub.io/packages/helm/sonarqube/sonarqube)                                                |
 | vault                     | 1.18.1           | 0.29.1        | [vault](https://artifacthub.io/packages/helm/hashicorp/vault)                                                        |


### PR DESCRIPTION
## Issues liées

Issues numéro: #719 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Nexus Chart did not allow to disable `chown-data-dir` initContainers for Openshift compatibility.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Upgrade chart to version `5.13.2`.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
No.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
No.
