### PR TITLE
fix: :bug: Missing Vault serviceMonitor

### DIFF
--- a/roles/gitops/rendering-apps-files/vars/main.yaml
+++ b/roles/gitops/rendering-apps-files/vars/main.yaml
@@ -229,6 +229,8 @@ values:
 
     serverTelemetry: |
       serverTelemetry:
+        serviceMonitor:
+          enabled: {{ (dsc.global.metrics.enabled or dsc.global.alerting.enabled) | lower }}
         prometheusRules:
           enabled: {{ (dsc.global.metrics.enabled or dsc.global.alerting.enabled) | lower }}
           rules:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Lors du rendu des values du chart Vault en mode de déploiement GitOps, le serviceMonitor n'est pas activé quand les métriques le sont dans dsc.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Active le serviceMonitor pour Vault quand les métriques sont activées dans la dsc.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.