### PR TITLE
fix: :bug: Vault post-install serviceMonitors patching

### DIFF
--- a/roles/gitops/post-install/vault/tasks/main.yml
+++ b/roles/gitops/post-install/vault/tasks/main.yml
@@ -508,23 +508,6 @@
       ansible.builtin.set_fact:
         service_monitors_names: "{{ service_monitors.resources | map(attribute='metadata.name') }}"
 
-    # bearerTokenSecret is not supported in Vault Helm Chart
-
-    - name: Patch ServiceMonitor
-      kubernetes.core.k8s:
-        api_version: monitoring.coreos.com/v1
-        kind: ServiceMonitor
-        namespace: "{{ dsc.vault.namespace }}"
-        name: "{{ item }}"
-        state: patched
-        definition:
-          spec:
-            endpoints:
-              - bearerTokenSecret:
-                  key: root_token
-                  name: "{{ dsc_name }}-vault-keys"
-      loop: "{{ service_monitors_names }}"
-
     # Label is not supported in Vault Helm Chart
 
     - name: Patch serviceMonitors


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

La patch que nous appliquons en post-install sur la section endpoints du ServiceMonitor de Vault n'est plus nécessaire.
Il vient par ailleurs casser le ServiceMonitor déployé par le chart Helm, ce qui se traduit par une application Vault désynchronisée côté Argo CD.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous supprimons la task de post-install ansible associée.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de déploiement.