### PR TITLE
fix: :bug: Vault ServiceMonitor and telemetry value

### DIFF
--- a/roles/gitops/post-install/vault/tasks/main.yml
+++ b/roles/gitops/post-install/vault/tasks/main.yml
@@ -508,9 +508,25 @@
       ansible.builtin.set_fact:
         service_monitors_names: "{{ service_monitors.resources | map(attribute='metadata.name') }}"
 
+    # bearerTokenSecret is not supported in Vault Helm Chart
+
+    - name: Patch ServiceMonitors endpoints
+      kubernetes.core.k8s_json_patch:
+        api_version: monitoring.coreos.com/v1
+        kind: ServiceMonitor
+        namespace: "{{ dsc.vault.namespace }}"
+        name: "{{ item }}"
+        patch:
+          - op: add
+            path: /spec/endpoints/0/bearerTokenSecret
+            value:
+              key: root_token
+              name: "{{ dsc_name }}-vault-keys"
+      loop: "{{ service_monitors_names }}"
+
     # Label is not supported in Vault Helm Chart
 
-    - name: Patch serviceMonitors
+    - name: Patch serviceMonitors labels
       when: dsc.global.metrics.additionalLabels is defined
       kubernetes.core.k8s:
         kind: ServiceMonitor

--- a/roles/gitops/rendering-apps-files/vars/main.yaml
+++ b/roles/gitops/rendering-apps-files/vars/main.yaml
@@ -223,7 +223,7 @@ values:
           path = "/vault/data"
         }
         telemetry {
-          prometheus_retention_time = "30s"
+          prometheus_retention_time = "12h"
           disable_hostname = true
         }
 


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Le ServiceMonitor de Vault n'est plus fonctionnel car le paramètre de endpoint "bearerTokenSecret" que nous avions retiré est bel est bien nécessaire.
Voir : https://developer.hashicorp.com/vault/docs/configuration/telemetry#prometheus
```
A Vault token is required with capabilities = ["read", "list"] to /v1/sys/metrics.
The Prometheus bearer_token or bearer_token_file options must be added to the scrape job.
```

Par ailleurs, certaines métriques de Vault sont manquantes dans notre environnement de test. 

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous réintroduisons une tâche de post-install pour gérer le paramètre de endpoint "bearerTokenSecret", car après vérification, il s'avère que ceci n'est toujours pas géré dans les values du chart Helm.

La problématique des métriques manquantes est liée au paramètre de telemetry "prometheus_retention_time" qui était fixé à une valeur trop basse. En relevant la valeur, ces métriques remontent. Voir à ce sujet :
* https://discuss.hashicorp.com/t/monitoring-vault-with-prometheus-missing-data/16902

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.
