### PR TITLE
fix: 🐛 Improve gitops installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,12 @@ Notons que chacune des trois applications d'infrastructure ci-dessus dispose d'u
 
 Si vous souhaitez les installer une première fois, il faut donc positionner lors de cette première installation le paramètre `installEnabled` sur la valeur `true`.
 
+Si vous souhaitez installer **keyclock**, pensez à installer cloudnativepg s'il existe pas dans votre cluster
+
+```shell
+ansible-playbook install-gitops.yaml -t cloudnativepg
+```
+
 Autre point important, le mot de passe admin d'Argo CD (`argocd_admin_password` dans notre exemple ci-dessus) doit être un hash salé que vous pouvez générer à l'aide de la commande suivante :
 
 ```shell

--- a/install-gitops.yaml
+++ b/install-gitops.yaml
@@ -28,6 +28,11 @@
         - prom
       when: dsc.prometheus.crd.type == 'managed'
 
+    - role: cloudnativepg
+      tags:
+        - cloudnativepg
+        - never
+
     - role: infra/keycloak-infra
       tags:
         - keycloak-infra

--- a/roles/cloudnativepg/tasks/main.yml
+++ b/roles/cloudnativepg/tasks/main.yml
@@ -29,7 +29,7 @@
     - name: Add CloudNativePG helm repo
       kubernetes.core.helm_repository:
         name: cnpg
-        repo_url: "{{ dsc.cloudnativepg.helmRepoUrl }}"
+        repo_url: "{{ dsc.cloudnativepg.operator.helmRepoUrl }}"
         force_update: true
 
     - name: Set path fact
@@ -41,14 +41,14 @@
         name: combine
       vars:
         combine_path: "{{ path }}"
-        combine_user_values: "{{ dsc.cloudnativepg['values'] }}"
+        combine_user_values: "{{ dsc.cloudnativepg.operator['values'] }}"
         combine_dest_var: "cnpg_values"
 
     - name: Deploy CloudNativePG helm
       kubernetes.core.helm:
         name: cloudnative-pg
         chart_ref: cnpg/cloudnative-pg
-        chart_version: "{{ dsc.cloudnativepg.chartVersion }}"
+        chart_version: "{{ dsc.cloudnativepg.operator.chartVersion }}"
         release_namespace: "{{ dsc.cloudnativepg.namespace }}"
         values: "{{ cnpg_values }}"
 

--- a/roles/infra/keycloak-infra/tasks/main.yml
+++ b/roles/infra/keycloak-infra/tasks/main.yml
@@ -458,6 +458,20 @@
             state: present
 #        force: true  ## Ne fontionne pas quand user supprimé via la GUI et tâche relancée.
 
+- name: Get a New Keycloak API token
+  ansible.builtin.uri:
+    url: https://{{ keycloakinfra_domain }}/realms/master/protocol/openid-connect/token
+    method: POST
+    status_code: [200, 202]
+    validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
+    return_content: true
+    body: username={{ keycloak_admin }}&password={{ keycloak_admin_password }}&grant_type=password&client_id=admin-cli
+  register: kc_token
+
+- name: Set kc_access_token fact
+  ansible.builtin.set_fact:
+    kc_access_token: "{{ kc_token.json.access_token }}"
+
 - name: Get infra keycloak client scopes from API
   ansible.builtin.uri:
     url: https://{{ keycloakinfra_domain }}/admin/realms/infra/client-scopes


### PR DESCRIPTION
## Issues liées

Issues numéro: [#799](https://github.com/cloud-pi-native/socle/issues/799)

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
l'installation du composant infra-keyclock en mode gitops échoue a cause du crd de cnpg manquante

## Quel est le nouveau comportement ?
le playbook d'installation de gitops applique le role cloudnativepg avant d'installer le keyclock d'infra

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
