### PR TITLE
fix: :bug: nexus openshift compatibility

### DIFF
--- a/post-install/gitlab.yaml
+++ b/post-install/gitlab.yaml
@@ -11,10 +11,6 @@
       ansible.builtin.import_role:
         name: socle-config
 
-    - name: Import ca role
-      ansible.builtin.import_role:
-        name: ca
-
     - name: Get gitlab_current_vault_values
       block:
         - name: Reset envs vars

--- a/post-install/vault.yaml
+++ b/post-install/vault.yaml
@@ -12,10 +12,6 @@
       ansible.builtin.import_role:
         name: socle-config
 
-    - name: Import ca role
-      ansible.builtin.import_role:
-        name: ca
-
     - name: Get vault_values
       ansible.builtin.include_role:
         name: gitops/rendering-apps-files

--- a/roles/gitops/rendering-apps-files/templates/nexus/values/10-platform.j2
+++ b/roles/gitops/rendering-apps-files/templates/nexus/values/10-platform.j2
@@ -9,7 +9,12 @@ nexus3:
     runAsGroup: 200
     runAsUser: 200
 {% elif dsc.global.platform == "openshift" %}
+  initNonRootSecurityContext: false
+  initRootSecurityContext: false
   podSecurityContext: false
-
   securityContext: false
+  config:
+    job:
+      podSecurityContext: false
+      securityContext: false
 {% endif %}

--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -67,7 +67,7 @@ spec:
     chartVersion: 3.1.4
   nexus:
     # https://hub.docker.com/r/sonatype/nexus3/
-    chartVersion: 5.13.2
+    chartVersion: 5.14.0
   observatorium:
     # https://github.com/cloud-pi-native/helm-charts/tags
     chartVersion: 0.5.2

--- a/versions.md
+++ b/versions.md
@@ -17,6 +17,6 @@
 | keycloak                  | 26.3.3           | 25.2.0        | [keycloak](https://artifacthub.io/packages/helm/bitnami/keycloak)                                                    |
 | kyverno                   | v1.11.4          | 3.1.4         | [kyverno](https://artifacthub.io/packages/helm/kyverno/kyverno)                                                      |
 | observatorium             | main-2025-02-10-1bcf722 | 0.5.2  | [observatorium](https://github.com/cloud-pi-native/helm-charts/tree/main/charts/observatorium)                                                                   |
-| nexus                     | 3.83.2           | 5.13.2        | [nexus](https://artifacthub.io/packages/helm/stevehipwell/nexus3)                                                    |
+| nexus                     | 3.84.0           | 5.14.0        | [nexus](https://artifacthub.io/packages/helm/stevehipwell/nexus3)                                                    |
 | sonarqube                 | 10.8.1-community | 10.8.1        | [sonarqube](https://artifacthub.io/packages/helm/sonarqube/sonarqube)                                                |
 | vault                     | 1.18.1           | 0.29.1        | [vault](https://artifacthub.io/packages/helm/hashicorp/vault)                                                        |


### PR DESCRIPTION
## Issues liées

Issues numéro:  #719 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Nexus Chart did not unset security context for Openshift compatibility.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Upgrade chart to version 5.14.0 which support the above.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
No.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
No probes regression with the image upgrade:
<img width="1577" height="498" alt="image" src="https://github.com/user-attachments/assets/e984cd4b-4892-4fc3-98c3-8136e583037d" />
