### PR TITLE
fix: argocd-infra initContainers

### DIFF
--- a/roles/infra/argocd-infra/templates/values/00-main.j2
+++ b/roles/infra/argocd-infra/templates/values/00-main.j2
@@ -172,8 +172,8 @@ repoServer:
     runAsNonRoot: true
     runAsUser: 999
 {% endif %}
-{% if dsc.global.dockerAccount.enabled %}
   initContainers:
+{% if dsc.global.dockerAccount.enabled %}
   - name: helm-login
     image: quay.io/argoproj/argocd:{{ argo_app_version }}
     command: ["sh", "-c"]


### PR DESCRIPTION
## Issues liées

Issues numéro: [801](https://github.com/cloud-pi-native/socle/issues/801)

---------

## Quel est le comportement actuel ?
Lors du lancement du playbook "ansible-playbook install-gitops.yaml -t argocd-infra", il y a une erreur sur le fichier "00-main.j2" qui indique :

`An exception occurred during task execution. To see the full traceback, use -vvv. The error was:   in "<unicode string>", line 331, column 3`


## Quel est le nouveau comportement ?
L'erreur n'est plus présente.

## Cette PR introduit-elle un breaking change ?
Non.

## Autres informations
Non.
