### PR TITLE
fix: :ambulance: Secrets and templates generation

### DIFF
--- a/roles/gitops/rendering-apps-files/tasks/main.yml
+++ b/roles/gitops/rendering-apps-files/tasks/main.yml
@@ -8,16 +8,6 @@
   ansible.builtin.include_tasks: ./generate_dsc_json.yml
 
 - name: Loop over services to render templates
-  when: >
-    (
-      item.1.argocd_app == "observability"
-      and dsc.observatorium.installEnabled
-    )
-    or
-    (
-      item.1.argocd_app != "observability"
-      and dsc[item.1.argocd_app].installEnabled
-    )
   ansible.builtin.include_tasks: ./template.yml
   loop: "{{ envs | subelements('apps') }}"
   loop_control:

--- a/roles/gitops/rendering-apps-files/tasks/template.yml
+++ b/roles/gitops/rendering-apps-files/tasks/template.yml
@@ -1,4 +1,17 @@
 ---
+- name: Message
+  ansible.builtin.debug:
+    msg: "Traitement du templating de l'app {{ item.1.argocd_app }}"
+
+- name: Set install_enabled fact when not observability
+  when: (dsc[item.1.argocd_app].installEnabled is defined) and (item.1.argocd_app != "observability")
+  ansible.builtin.set_fact:
+    install_enabled: "{{ dsc[item.1.argocd_app].installEnabled }}"
+
+- name: Set install_enabled fact when observability
+  when: (dsc[item.1.argocd_app].installEnabled is defined) and (item.1.argocd_app == "observability")
+  ansible.builtin.set_fact:
+    install_enabled: "{{ dsc.observatorium.installEnabled }}"
 
 - name: Create chart and values destination dir
   ansible.builtin.file:
@@ -8,103 +21,115 @@
 
 # Files copy
 
-- name: Check if files path exists
-  ansible.builtin.stat:
-    path: "{{ role_path + '/templates/' + item.1.argocd_app + '/files' }}"
-  register: argocd_app_files_stat
+- name: Files copy
+  when: install_enabled
+  block:
+    - name: Check if files path exists
+      ansible.builtin.stat:
+        path: "{{ role_path + '/templates/' + item.1.argocd_app + '/files' }}"
+      register: argocd_app_files_stat
 
-- name: Copy files if exists
-  when: argocd_app_files_stat.stat.exists
-  ansible.builtin.copy:
-    src: "{{ role_path + '/templates/' + item.1.argocd_app + '/files' }}"
-    dest: "{{ gitops_local_repo }}/{{ dsc.global.gitOps.repo.path }}/envs/{{ item.0.name }}/apps/{{ item.1.argocd_app }}/"
-    mode: "0644"
+    - name: Copy files if exists
+      when: argocd_app_files_stat.stat.exists
+      ansible.builtin.copy:
+        src: "{{ role_path + '/templates/' + item.1.argocd_app + '/files' }}"
+        dest: "{{ gitops_local_repo }}/{{ dsc.global.gitOps.repo.path }}/envs/{{ item.0.name }}/apps/{{ item.1.argocd_app }}/"
+        mode: "0644"
 
 # Chart file rendering
 
-- name: Set path fact to chart file location
-  ansible.builtin.set_fact:
-    path: "{{ role_path + '/templates/' + item.1.argocd_app + '/Chart.yaml.j2' }}"
-
-- name: Render "{{ item.1.argocd_app }}" chart template and write to destination
-  ansible.builtin.copy:
-    content: "{{ lookup('ansible.builtin.template', path) | from_yaml | to_nice_yaml(indent=2) }}"
-    dest: "{{ gitops_local_repo }}/{{ dsc.global.gitOps.repo.path }}/envs/{{ item.0.name }}/apps/{{ item.1.argocd_app }}/{{ path | basename | regex_replace('\\.j2', '') }}"
-    mode: "0644"
-
-# Templates rendering
-
-- name: Set path fact to templates location
-  ansible.builtin.set_fact:
-    path: "{{ role_path + '/templates/' + item.1.argocd_app + '/templates' }}"
-
-- name: Create templates destination dir
-  ansible.builtin.file:
-    path: "{{ gitops_local_repo }}/{{ dsc.global.gitOps.repo.path }}/envs/{{ item.0.name }}/apps/{{ item.1.argocd_app }}/templates"
-    state: directory
-    mode: 0775
-
-- name: Check if keycloak/templates/users.yaml exists
-  ansible.builtin.stat:
-    path: "{{ gitops_local_repo }}/{{ dsc.global.gitOps.repo.path }}/envs/{{ dsc_name }}/apps/keycloak/templates/users.yaml"
-  register: keycloak_users_file_stat
-
-- name: Render "{{ item.1.argocd_app }}" templates and write yaml files to destination
-  vars:
-    rendered_content: "{{ lookup('ansible.builtin.template', my_template) }}"
-  when:
-    - rendered_content | trim != ''
-    - not (my_template | basename == 'users.yaml.j2' and keycloak_users_file_stat.stat.exists)
-  ansible.builtin.copy:
-    content: "{{ rendered_content }}"
-    dest: "{{ gitops_local_repo }}/{{ dsc.global.gitOps.repo.path }}/envs/{{ item.0.name }}/apps/{{ item.1.argocd_app }}/templates/{{ my_template | basename | regex_replace('\\.j2', '') }}"
-    mode: "0644"
-  with_fileglob: "{{ path }}/*"
-  loop_control:
-    loop_var: my_template
-
-# Values rendering
-
-- name: Set path fact to values location
-  ansible.builtin.set_fact:
-    path: "{{ role_path + '/templates/' + item.1.argocd_app + '/values' }}"
-
-- name: Compute "{{ item.1.argocd_app }}" Helm values
-  when: item.1.argocd_app != "dashboard"
-  ansible.builtin.include_role:
-    name: combine
-  vars:
-    combine_path: "{{ path }}"
-    combine_user_values: >-
-      {%- set app_name = item.1.argocd_app -%}
-      {%- if app_name == 'gitlab' -%}
-      {{ {} | combine({app_name: dsc.gitlabOperator['values']}) }}
-      {%- elif app_name == 'cloudnativepg' -%}
-      {{ {} | combine({app_name: dsc[app_name]['operator']['values']}) }}
-      {%- else -%}
-      {{ {} | combine({app_name: dsc[app_name]['values']}) }}
-      {%- endif -%}
-    combine_dest_var: "{{ item.1.argocd_app }}_values"
-
-- name: Render "{{ item.1.argocd_app }}" values and write values.yaml to destination
-  when: item.1.argocd_app != "dashboard"
-  ansible.builtin.copy:
-    content: "{{ lookup('vars', item.1.argocd_app ~ '_values') | to_nice_yaml(indent=2) }}"
-    dest: "{{ gitops_local_repo }}/{{ dsc.global.gitOps.repo.path }}/envs/{{ item.0.name }}/apps/{{ item.1.argocd_app }}/values.yaml"
-    mode: "0644"
-
-- name: Render "{{ item.1.argocd_app }}" values and write values.yaml to destination
-  when: item.1.argocd_app == "dashboard"
+- name: Chart file rendering
+  when: install_enabled
   block:
-    - name: Set path fact to values file location
+    - name: Set path fact to chart file location
       ansible.builtin.set_fact:
-        path: "{{ role_path + '/templates/' + item.1.argocd_app + '/values.yaml.j2' }}"
+        path: "{{ role_path + '/templates/' + item.1.argocd_app + '/Chart.yaml.j2' }}"
 
-    - name: Render "{{ item.1.argocd_app }}" values template and write to destination
+    - name: Render "{{ item.1.argocd_app }}" chart template and write to destination
       ansible.builtin.copy:
         content: "{{ lookup('ansible.builtin.template', path) | from_yaml | to_nice_yaml(indent=2) }}"
         dest: "{{ gitops_local_repo }}/{{ dsc.global.gitOps.repo.path }}/envs/{{ item.0.name }}/apps/{{ item.1.argocd_app }}/{{ path | basename | regex_replace('\\.j2', '') }}"
         mode: "0644"
 
-- name: Special parsing for pipe after colon
-  ansible.builtin.include_tasks: ./parsing.yml
+# Templates rendering
+
+- name: Templates rendering
+  when: install_enabled
+  block:
+    - name: Set path fact to templates location
+      ansible.builtin.set_fact:
+        path: "{{ role_path + '/templates/' + item.1.argocd_app + '/templates' }}"
+
+    - name: Create templates destination dir
+      ansible.builtin.file:
+        path: "{{ gitops_local_repo }}/{{ dsc.global.gitOps.repo.path }}/envs/{{ item.0.name }}/apps/{{ item.1.argocd_app }}/templates"
+        state: directory
+        mode: 0775
+
+    - name: Check if keycloak/templates/users.yaml exists
+      ansible.builtin.stat:
+        path: "{{ gitops_local_repo }}/{{ dsc.global.gitOps.repo.path }}/envs/{{ dsc_name }}/apps/keycloak/templates/users.yaml"
+      register: keycloak_users_file_stat
+
+    - name: Render "{{ item.1.argocd_app }}" templates and write yaml files to destination
+      vars:
+        rendered_content: "{{ lookup('ansible.builtin.template', my_template) }}"
+      when:
+        - rendered_content | trim != ''
+        - not (my_template | basename == 'users.yaml.j2' and keycloak_users_file_stat.stat.exists)
+      ansible.builtin.copy:
+        content: "{{ rendered_content }}"
+        dest: "{{ gitops_local_repo }}/{{ dsc.global.gitOps.repo.path }}/envs/{{ item.0.name }}/apps/{{ item.1.argocd_app }}/templates/{{ my_template | basename | regex_replace('\\.j2', '') }}"
+        mode: "0644"
+      with_fileglob: "{{ path }}/*"
+      loop_control:
+        loop_var: my_template
+
+# Values rendering
+
+- name: Values rendering
+  when: install_enabled
+  block:
+    - name: Set path fact to values location
+      ansible.builtin.set_fact:
+        path: "{{ role_path + '/templates/' + item.1.argocd_app + '/values' }}"
+
+    - name: Compute "{{ item.1.argocd_app }}" Helm values
+      when: item.1.argocd_app != "dashboard"
+      ansible.builtin.include_role:
+        name: combine
+      vars:
+        combine_path: "{{ path }}"
+        combine_user_values: >-
+          {%- set app_name = item.1.argocd_app -%}
+          {%- if app_name == 'gitlab' -%}
+          {{ {} | combine({app_name: dsc.gitlabOperator['values']}) }}
+          {%- elif app_name == 'cloudnativepg' -%}
+          {{ {} | combine({app_name: dsc[app_name]['operator']['values']}) }}
+          {%- else -%}
+          {{ {} | combine({app_name: dsc[app_name]['values']}) }}
+          {%- endif -%}
+        combine_dest_var: "{{ item.1.argocd_app }}_values"
+
+    - name: Render "{{ item.1.argocd_app }}" values and write values.yaml to destination
+      when: item.1.argocd_app != "dashboard"
+      ansible.builtin.copy:
+        content: "{{ lookup('vars', item.1.argocd_app ~ '_values') | to_nice_yaml(indent=2) }}"
+        dest: "{{ gitops_local_repo }}/{{ dsc.global.gitOps.repo.path }}/envs/{{ item.0.name }}/apps/{{ item.1.argocd_app }}/values.yaml"
+        mode: "0644"
+
+    - name: Render "{{ item.1.argocd_app }}" values and write values.yaml to destination
+      when: item.1.argocd_app == "dashboard"
+      block:
+        - name: Set path fact to values file location
+          ansible.builtin.set_fact:
+            path: "{{ role_path + '/templates/' + item.1.argocd_app + '/values.yaml.j2' }}"
+
+        - name: Render "{{ item.1.argocd_app }}" values template and write to destination
+          ansible.builtin.copy:
+            content: "{{ lookup('ansible.builtin.template', path) | from_yaml | to_nice_yaml(indent=2) }}"
+            dest: "{{ gitops_local_repo }}/{{ dsc.global.gitOps.repo.path }}/envs/{{ item.0.name }}/apps/{{ item.1.argocd_app }}/{{ path | basename | regex_replace('\\.j2', '') }}"
+            mode: "0644"
+
+    - name: Special parsing for pipe after colon
+      ansible.builtin.include_tasks: ./parsing.yml

--- a/roles/gitops/vault-secrets/tasks/main.yaml
+++ b/roles/gitops/vault-secrets/tasks/main.yaml
@@ -112,16 +112,6 @@
 # Write Vault Infra secrets
 
 - name: Write secrets
-  when: >
-    (
-      item.1.argocd_app == "observability"
-      and dsc.observatorium.installEnabled
-    )
-    or
-    (
-      item.1.argocd_app != "observability"
-      and dsc[item.1.argocd_app].installEnabled
-    )
   ansible.builtin.include_tasks: write.yml
   loop: "{{ envs | subelements('apps') }}"
   loop_control:

--- a/roles/gitops/vault-secrets/tasks/write.yml
+++ b/roles/gitops/vault-secrets/tasks/write.yml
@@ -1,65 +1,82 @@
 ---
-- name: Reset current vault values
+- name: Message
+  ansible.builtin.debug:
+    msg: "Traitement des Vault secrets de l'app {{ item.1.argocd_app }}"
+
+- name: Set install_enabled fact when not observability
+  when: (dsc[item.1.argocd_app].installEnabled is defined) and (item.1.argocd_app != "observability")
   ansible.builtin.set_fact:
-    current_vault_values:
+    install_enabled: "{{ dsc[item.1.argocd_app].installEnabled }}"
 
-- name: Retrieve current vault secret
-  community.hashi_vault.vault_kv2_get:
-    url: "https://{{ vaultinfra_domain }}"
-    auth_method: token
-    token: "{{ vault_infra_token }}"
-    namespace: "{{ dsc.vaultInfra.namespace }}"
-    engine_mount_point: "{{ vaultinfra_kv_name }}"
-    path: "env/{{ item.0.name }}/apps/{{ item.1.argocd_app }}/values"
-    validate_certs: "{{ vaultinfra_cert_valid }}"
-  register: current_vault_values
-  ignore_errors: true
-
-- name: Get current non null values
-  when: not vault_secrets_post_install
-  ansible.builtin.shell:
-    cmd: |
-      echo '{
-        "old": {{ current_vault_values.secret | default({}) | to_json }},
-        "new": {{ item.1.vault_values | default({}) | to_json }}
-      }' | yq -p=json -o=json -I=0 '.old *n .new'
-  register: current_vault_values_combined_pre
-  changed_when: false
-
-- name: Get current and post install non null values
-  when: vault_secrets_post_install
-  ansible.builtin.shell:
-    cmd: |
-      echo '{
-        "old": {{ current_vault_values.secret | default({}) | to_json }},
-        "new": {{ item.1.vault_values | default({}) | to_json }}
-      }' | yq -p=json -o=json -I=0 '(.new |= with_entries(select(.value != null))) | .old * .new'
-  register: current_vault_values_combined_post
-
-- name: Set unified current_vault_values_combined
-  set_fact:
-    current_vault_values_combined: "{{ current_vault_values_combined_pre if not vault_secrets_post_install else current_vault_values_combined_post }}"
-
-- name: Compare vault values
-  ansible.utils.fact_diff:
-    before: "{{ current_vault_values.secret | default({}) | to_nice_json }}"
-    after: "{{ current_vault_values_combined.stdout | from_json | to_nice_json }}"
-  register: json_comparison_result
-
-- name: Update vault secret
-  when:
-    - json_comparison_result.changed
-    - post_conf_job is not defined or post_vault_update is defined
-  community.hashi_vault.vault_kv2_write:
-    url: "https://{{ vaultinfra_domain }}"
-    auth_method: token
-    token: "{{ vault_infra_token }}"
-    namespace: "{{ dsc.vaultInfra.namespace }}"
-    engine_mount_point: "{{ vaultinfra_kv_name }}"
-    path: "env/{{ item.0.name }}/apps/{{ item.1.argocd_app }}/values"
-    data: "{{ current_vault_values_combined.stdout | from_json }}"
-    validate_certs: "{{ vaultinfra_cert_valid }}"
-
-- name: Set {{ item.1.argocd_app }}_current_vault_values
+- name: Set install_enabled fact when observability
+  when: (dsc[item.1.argocd_app].installEnabled is defined) and (item.1.argocd_app == "observability")
   ansible.builtin.set_fact:
-    "{{ item.1.argocd_app }}_current_vault_values": "{{ current_vault_values }}"
+    install_enabled: "{{ dsc.observatorium.installEnabled }}"
+
+- name: Write Vault secrets
+  when: install_enabled
+  block:
+    - name: Reset current vault values
+      ansible.builtin.set_fact:
+        current_vault_values:
+
+    - name: Retrieve current vault secret
+      community.hashi_vault.vault_kv2_get:
+        url: "https://{{ vaultinfra_domain }}"
+        auth_method: token
+        token: "{{ vault_infra_token }}"
+        namespace: "{{ dsc.vaultInfra.namespace }}"
+        engine_mount_point: "{{ vaultinfra_kv_name }}"
+        path: "env/{{ item.0.name }}/apps/{{ item.1.argocd_app }}/values"
+        validate_certs: "{{ vaultinfra_cert_valid }}"
+      register: current_vault_values
+      ignore_errors: true
+
+    - name: Get current non null values
+      when: not vault_secrets_post_install
+      ansible.builtin.shell:
+        cmd: |
+          echo '{
+            "old": {{ current_vault_values.secret | default({}) | to_json }},
+            "new": {{ item.1.vault_values | default({}) | to_json }}
+          }' | yq -p=json -o=json -I=0 '.old *n .new'
+      register: current_vault_values_combined_pre
+      changed_when: false
+
+    - name: Get current and post install non null values
+      when: vault_secrets_post_install
+      ansible.builtin.shell:
+        cmd: |
+          echo '{
+            "old": {{ current_vault_values.secret | default({}) | to_json }},
+            "new": {{ item.1.vault_values | default({}) | to_json }}
+          }' | yq -p=json -o=json -I=0 '(.new |= with_entries(select(.value != null))) | .old * .new'
+      register: current_vault_values_combined_post
+
+    - name: Set unified current_vault_values_combined
+      ansible.builtin.set_fact:
+        current_vault_values_combined: "{{ current_vault_values_combined_pre if not vault_secrets_post_install else current_vault_values_combined_post }}"
+
+    - name: Compare vault values
+      ansible.utils.fact_diff:
+        before: "{{ current_vault_values.secret | default({}) | to_nice_json }}"
+        after: "{{ current_vault_values_combined.stdout | from_json | to_nice_json }}"
+      register: json_comparison_result
+
+    - name: Update vault secret
+      when:
+        - json_comparison_result.changed
+        - post_conf_job is not defined or post_vault_update is defined
+      community.hashi_vault.vault_kv2_write:
+        url: "https://{{ vaultinfra_domain }}"
+        auth_method: token
+        token: "{{ vault_infra_token }}"
+        namespace: "{{ dsc.vaultInfra.namespace }}"
+        engine_mount_point: "{{ vaultinfra_kv_name }}"
+        path: "env/{{ item.0.name }}/apps/{{ item.1.argocd_app }}/values"
+        data: "{{ current_vault_values_combined.stdout | from_json }}"
+        validate_certs: "{{ vaultinfra_cert_valid }}"
+
+    - name: Set {{ item.1.argocd_app }}_current_vault_values
+      ansible.builtin.set_fact:
+        "{{ item.1.argocd_app }}_current_vault_values": "{{ current_vault_values }}"


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

La génération des secrets Vault échoue lorsque la boucle se positionne sur l'app observability.
Le rendu des templates échoue lorsque la boucle se positionne sur l'app observability.

Ceci est dû aux conditions `when` suivantes qui avaient été introduites pour traiter la particularité de l'app observability :

```
  when: >
    (
      item.1.argocd_app == "observability"
      and dsc.observatorium.installEnabled
    )
    or
    (
      item.1.argocd_app != "observability"
      and dsc[item.1.argocd_app].installEnabled
    )
```

Le problème étant que lorsque la boucle parvient à l'application observability, la partie située après le `or` de la condition `when` cherche à évaluer en même temps que le reste un paramètre  `dsc.observability.installEnabled` qui n'existe pas (puisque dans la dsc il s'agit d'observatorium). Ceci malgré la première condition (`item.1.argocd_app != "observability"`) qui est évaluée au même moment et n'est alors pas suspensive de la seconde. La tâche échoue donc avec un message "undefined".

Nous pourrions être tentés de considérer qu'ajouter la condition `and dsc[item.1.argocd_app] is defined` serait suffisant mais ce n'est pas le cas. Pour pouvoir gérer le point, il faudrait pouvoir réorganiser la task sous forme de "block" avec plusieurs "when" imbriqués, mais ce n'est pas possible non plus car "loop" n'est pas compatible avec les blocs.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous réorganisons les tâches de génération des secrets Vault et de templating, en introduisant un fact `install_enabled` dans les fichiers de tasks concernés (appelés par la task de "loop" associée). Nous faisons dépendre l'exécution des tâches subséquentes de la valeur de ce fact (qui doit être à true) et réorganisons les tâches en question dans des blocs.

Nous en profitons pour ajouter un message de debug dans les fichiers de tâches associées à chaque boucle, ce qui permet de se repérer plus aisément dans la sortie du playbook.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.
