### PR TITLE
fix: :ambulance: ClusterRoleBindings names for dual install

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/global/templates/cluster-role-binding.yml.j2
+++ b/roles/gitops/rendering-apps-files/templates/global/templates/cluster-role-binding.yml.j2
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: dsc-access-binding
+  name: {{dsc_name}}-dsc-access-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -31,7 +31,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: pgdump-role-binding
+  name: {{dsc_name}}-pgdump-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/roles/gitops/rendering-apps-files/templates/vault/templates/post-conf-job.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/vault/templates/post-conf-job.yaml.j2
@@ -75,7 +75,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: vault-secret-access-cluster-role-binding
+  name: {{ dsc_name }}-vault-secret-access-cluster-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Certains ClusterRoleBindings ont un nom unique qui n'est pas fonction de celui de la dsc.
Cela peut poser un problème de conflit entre applications du Socle dans le cas d'une dual install de la chaîne DSO sur un même cluster, car ces CRB ont pour sujets des ressources « namespacées ».

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous préfixons le nom des CRB concernés par le nom de la resource dsc utilisée pour leur déploiement.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.
