### PR TITLE
fix: :bug: Argo CD metrics scraping

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/argocd/values/10-metrics.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/values/10-metrics.j2
@@ -1,12 +1,11 @@
 {% if dsc.global.metrics.enabled %}
 argocd:
+  global:
+    addPrometheusAnnotations: true
   redis-ha:
     exporter:
       enabled: true
       image: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/oliver006/redis_exporter
-      serviceMonitor:
-        enabled: true
-        namespace: "{{ dsc.argocd.namespace }}"
 {% if dsc.global.metrics.additionalLabels is defined %}
         labels: {{ dsc.global.metrics.additionalLabels }}
 {% endif %}
@@ -15,53 +14,36 @@ argocd:
         repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/library/haproxy
       metrics:
         enabled: true
-        serviceMonitor:
-          enabled: true
-          namespace: "{{ dsc.argocd.namespace }}"
 {% if dsc.global.metrics.additionalLabels is defined %}
           labels: {{ dsc.global.metrics.additionalLabels }}
 {% endif %}
   redis:
     metrics:
       enabled: false
-      serviceMonitor:
-        enabled: false
 {% if dsc.global.metrics.additionalLabels is defined %}
         labels: {{ dsc.global.metrics.additionalLabels }}
 {% endif %}
   server:
     metrics:
       enabled: true
-      serviceMonitor:
-        enabled: true
-        namespace: "{{ dsc.argocd.namespace }}"
 {% if dsc.global.metrics.additionalLabels is defined %}
         labels: {{ dsc.global.metrics.additionalLabels }}
 {% endif %}
   repoServer:
     metrics:
       enabled: true
-      serviceMonitor:
-        enabled: true
-        namespace: "{{ dsc.argocd.namespace }}"
 {% if dsc.global.metrics.additionalLabels is defined %}
         labels: {{ dsc.global.metrics.additionalLabels }}
 {% endif %}
   applicationSet:
     metrics:
       enabled: true
-      serviceMonitor:
-        enabled: true
-        namespace: "{{ dsc.argocd.namespace }}"
 {% if dsc.global.metrics.additionalLabels is defined %}
         labels: {{ dsc.global.metrics.additionalLabels }}
 {% endif %}
   notifications:
     metrics:
       enabled: true
-      serviceMonitor:
-        enabled: true
-        namespace: "{{ dsc.argocd.namespace }}"
 {% if dsc.global.metrics.additionalLabels is defined %}
         labels: {{ dsc.global.metrics.additionalLabels }}
 {% endif %}


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Le déploiement en GitOps d'Argo CD ne déploie pas les ressources de type ServiceMonitor qui servent au scraping des métriques par Prometheus.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous désactivons tous les ServiceMonitors dans les values d'Argo CD et nous utilisons à la place le paramètre `global.addPrometheusAnnotations` qui est justement une alternative aux ServiceMonitors proposée par le chart.

Cela ajoute une annotation aux services de métriques, ce qui permet à Prometheus de les extraire directement, sans avoir à déployer de ServiceMonitors.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement, où nous constatons que les métriques remontent et deviennent accessibles au dashboard associé.