### PR TITLE
Requirements update ansible modules

### DIFF
--- a/admin-tools/install-requirements.yaml
+++ b/admin-tools/install-requirements.yaml
@@ -19,10 +19,12 @@
       - helm
       - k9s
       - kubectl
-      - yq
+      - yq # Go version, i.e. https://github.com/mikefarah/yq
+    ansible_modules:
+      - kubernetes.core # ansible 2.19+ requires kubernetes.core >= 5.3
+      - community.hashi_vault
 
   tasks:
-
     - name: "Install some required packages"
       become: true
       ansible.builtin.package:
@@ -36,15 +38,12 @@
         state: present
       loop: "{{ python_modules }}"
 
-    - name: "Install collection kubernetes.core"
+    - name: "Install ansible modules"
       community.general.ansible_galaxy_install:
         type: collection
-        name: kubernetes.core
-
-    - name: "Install collection community.hashi_vault"
-      community.general.ansible_galaxy_install:
-        type: collection
-        name: community.hashi_vault
+        name: "{{ item }}"
+        force: true # allow updates (to install latest version)
+      loop: "{{ ansible_modules }}"
 
     - name: "Check if Homebrew is already installed"
       ansible.builtin.stat:
@@ -57,7 +56,7 @@
         executable: /bin/bash
         cmd: NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-    - name: Get Homebrew shellenv
+    - name: "Get Homebrew shellenv"
       ansible.builtin.shell:
         cmd: "/home/linuxbrew/.linuxbrew/bin/brew shellenv"
       register: homebrew_shellenv


### PR DESCRIPTION
## Quel est le comportement actuel ?
Le playbook Ansible `install-requirements.yaml` ne met pas à jours les modules Ansible déjà installés. Avec `ansible-core` v2.19+, le module `kubernetes.core` doit au minimum être en version 5.3 sans quoi le templating Jinja ne fonctionne pas correctement avec la syntaxe suivante :
```yaml
  kubernetes.core.k8s:
    template: "{{ item }}"
```
L'erreur obtenu est donc :
```
[ERROR]: Task failed: Module failed: Failed to load resource definition: while scanning for the next token
found character '%' that cannot start any token  in "<unicode string>", line 7, column 2:
    {% if dsc.global.backup.velero.en ...
      ^
```
Des "deprication warnings" apparaissent au début de l’exécution du playbook d'installation de la forge, ce qui suggère que cette nouvelle version d'Ansible a eu des changements dans la logique de templating :
[WARNING]: Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.
[DEPRECATION WARNING]: Direct access to the `environment` attribute is deprecated. This feature will be removed from ansible-core version 2.23. Consider using `copy_with_new_env` or passing `overrides` to `template`.
[DEPRECATION WARNING]: The `do_template` method on `Templar` is deprecated. This feature will be removed from ansible-core version 2.23. Use the `template` method on `Templar` instead.

## Quel est le nouveau comportement ?
Le playbook `install-requirements.yaml` installe la dernière version des modules Ansible (grâce à `force: true`) ce qui, une fois exécuté met à jour les modules ansible.

## Cette PR introduit-elle un breaking change ?
Non

## Autres informations
J'ai mis en commentaire cette dépendance de version de `kubernetes.core` >= 5.3 avec `ansible-core` v2.19+

Par ailleurs, étant sur Arch (btw) je ne lance pas directement ce playbook de requirements car les modules python ne s'installent pas avec pip (sauf dans un venv) et que je ne souhaite pas installer Homebrew. Or, il existe deux versions de `yq` dont la syntaxe n'est pas exactement la même. Or, celle par défaut sur Homebrew, n'est pas la même que sur nix et pacman ( `go-yg` par opposition à `py-yq`) cf. [Naming collision in package yq](https://github.com/Homebrew/homebrew-core/issues/29529). J'ai donc ajouté un commentaire pour préciser qu'il s'agit de la version Go (qui n'est pas tout à fait iso-compatible avec `jq`).