### PR TITLE
fix: :ambulance: Argo CD ServiceMonitors

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/argocd/templates/servicemonitors.yml.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/templates/servicemonitors.yml.j2
@@ -1,0 +1,124 @@
+{% if dsc.global.metrics.enabled %}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ dsc_name }}-argocd-application-controller
+  namespace: {{ dsc.argocd.namespace }}
+spec:
+  endpoints:
+  - honorLabels: false
+    interval: 30s
+    path: /metrics
+    port: http-metrics
+  namespaceSelector:
+    matchNames:
+    - {{ dsc.argocd.namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: application-controller
+      app.kubernetes.io/instance: {{ dsc.global.gitOps.envName }}-{{ dsc.argocd.namespace }}
+      app.kubernetes.io/name: argocd-metrics
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ dsc_name }}-argocd-applicationset-controller
+  namespace: {{ dsc.argocd.namespace }}
+spec:
+  endpoints:
+  - honorLabels: false
+    interval: 30s
+    path: /metrics
+    port: http-metrics
+  namespaceSelector:
+    matchNames:
+    - {{ dsc.argocd.namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: applicationset-controller
+      app.kubernetes.io/instance: {{ dsc.global.gitOps.envName }}-{{ dsc.argocd.namespace }}
+      app.kubernetes.io/name: argocd-metrics
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ dsc_name }}-argocd-repo-server
+  namespace: {{ dsc.argocd.namespace }}
+spec:
+  endpoints:
+  - honorLabels: false
+    interval: 30s
+    path: /metrics
+    port: http-metrics
+  namespaceSelector:
+    matchNames:
+    - {{ dsc.argocd.namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: repo-server
+      app.kubernetes.io/instance: {{ dsc.global.gitOps.envName }}-{{ dsc.argocd.namespace }}
+      app.kubernetes.io/name: argocd-repo-server-metrics
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ dsc_name }}-argocd-server
+  namespace: {{ dsc.argocd.namespace }}
+spec:
+  endpoints:
+  - honorLabels: false
+    interval: 30s
+    path: /metrics
+    port: http-metrics
+  namespaceSelector:
+    matchNames:
+    - {{ dsc.argocd.namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: server
+      app.kubernetes.io/instance: {{ dsc.global.gitOps.envName }}-{{ dsc.argocd.namespace }}
+      app.kubernetes.io/name: argocd-server-metrics
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ dsc_name }}-redis-ha
+  namespace: {{ dsc.argocd.namespace }}
+spec:
+  endpoints:
+  - targetPort: 9121
+  jobLabel: conf-cedric-argo-infra-redis-ha
+  namespaceSelector:
+    matchNames:
+    - {{ dsc.argocd.namespace }}
+  selector:
+    matchLabels:
+      app: redis-ha
+      exporter: enabled
+      release: {{ dsc.global.gitOps.envName }}-{{ dsc.argocd.namespace }}
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ dsc_name }}-redis-ha-haproxy
+  namespace: {{ dsc.argocd.namespace }}
+spec:
+  endpoints:
+  - targetPort: 9101
+  jobLabel: conf-cedric-argo-infra-redis-ha-haproxy
+  namespaceSelector:
+    matchNames:
+    - {{ dsc.argocd.namespace }}
+  selector:
+    matchLabels:
+      app: redis-ha
+      component: {{ dsc_name }}-redis-ha-haproxy
+      release: {{ dsc.global.gitOps.envName }}-{{ dsc.argocd.namespace }}
+
+{% endif %}

--- a/roles/gitops/rendering-apps-files/templates/argocd/values/10-metrics.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/values/10-metrics.j2
@@ -1,7 +1,5 @@
 {% if dsc.global.metrics.enabled %}
 argocd:
-  global:
-    addPrometheusAnnotations: true
   redis-ha:
     exporter:
       enabled: true

--- a/roles/gitops/rendering-apps-files/vars/main.yaml
+++ b/roles/gitops/rendering-apps-files/vars/main.yaml
@@ -70,9 +70,6 @@ values:
     controller_metrics: |
       metrics:
         enabled: {{ dsc.global.metrics.enabled | lower }}
-        serviceMonitor:
-          enabled: {{ dsc.global.metrics.enabled | lower }}
-          namespace: {{ dsc.argocd.namespace }}
 
     controller_metrics_labels: |
       labels: {{ dsc.global.metrics.additionalLabels | default('') }}


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Le déploiement en GitOps d'Argo CD ne déploie pas les ressources de type ServiceMonitor qui servent au scraping des métriques par Prometheus.

Le paramètre `global.addPrometheusAnnotations` activé lors d'une précédente PR pour contourner le problème n'est en réalité pas davantage fonctionnel dans notre contexte (une seconde instance d'Argo CD dépoyée dans le même cluster nous a induit en erreur sur la remontée des métriques).

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous désactivons complètement les ServiceMonitors au niveau du chart, ainsi que le paramètre `global.addPrometheusAnnotations` et nous proposons un template pour générer nous-mêmes les ServiceMonitors requis.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement. Les ServiceMonitors sont maintenant bien créés et les métriques correctement scrappées par Prometheus. Le dashboard Argo CD se révèle pleinement fonctionnel.