### PR TITLE
fix: :ambulance: Argo CD infra plugin config

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/argocd/values/10-metrics.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/values/10-metrics.j2
@@ -1,11 +1,12 @@
 {% if dsc.global.metrics.enabled %}
 argocd:
-  global:
-    addPrometheusAnnotations: true
   redis-ha:
     exporter:
       enabled: true
       image: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/oliver006/redis_exporter
+      serviceMonitor:
+        enabled: true
+        namespace: "{{ dsc.argocd.namespace }}"
 {% if dsc.global.metrics.additionalLabels is defined %}
         labels: {{ dsc.global.metrics.additionalLabels }}
 {% endif %}
@@ -14,36 +15,53 @@ argocd:
         repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/library/haproxy
       metrics:
         enabled: true
+        serviceMonitor:
+          enabled: true
+          namespace: "{{ dsc.argocd.namespace }}"
 {% if dsc.global.metrics.additionalLabels is defined %}
           labels: {{ dsc.global.metrics.additionalLabels }}
 {% endif %}
   redis:
     metrics:
       enabled: false
+      serviceMonitor:
+        enabled: false
 {% if dsc.global.metrics.additionalLabels is defined %}
         labels: {{ dsc.global.metrics.additionalLabels }}
 {% endif %}
   server:
     metrics:
       enabled: true
+      serviceMonitor:
+        enabled: true
+        namespace: "{{ dsc.argocd.namespace }}"
 {% if dsc.global.metrics.additionalLabels is defined %}
         labels: {{ dsc.global.metrics.additionalLabels }}
 {% endif %}
   repoServer:
     metrics:
       enabled: true
+      serviceMonitor:
+        enabled: true
+        namespace: "{{ dsc.argocd.namespace }}"
 {% if dsc.global.metrics.additionalLabels is defined %}
         labels: {{ dsc.global.metrics.additionalLabels }}
 {% endif %}
   applicationSet:
     metrics:
       enabled: true
+      serviceMonitor:
+        enabled: true
+        namespace: "{{ dsc.argocd.namespace }}"
 {% if dsc.global.metrics.additionalLabels is defined %}
         labels: {{ dsc.global.metrics.additionalLabels }}
 {% endif %}
   notifications:
     metrics:
       enabled: true
+      serviceMonitor:
+        enabled: true
+        namespace: "{{ dsc.argocd.namespace }}"
 {% if dsc.global.metrics.additionalLabels is defined %}
         labels: {{ dsc.global.metrics.additionalLabels }}
 {% endif %}

--- a/roles/infra/argocd-infra/templates/vault-plugin-cm.yml.j2
+++ b/roles/infra/argocd-infra/templates/vault-plugin-cm.yml.j2
@@ -49,8 +49,13 @@ data:
           - bash
           - "-c"
           - |
+{% if dsc.global.metrics.enabled %}
+            helm template $ARGOCD_APP_NAME --api-versions "monitoring.coreos.com/v1" --include-crds -n $ARGOCD_APP_NAMESPACE ${ARGOCD_ENV_HELM_ARGS} -f <(echo "$ARGOCD_ENV_HELM_VALUES") . |
+            argocd-vault-plugin generate --verbose-sensitive-output -
+{% else %}
             helm template $ARGOCD_APP_NAME --include-crds -n $ARGOCD_APP_NAMESPACE ${ARGOCD_ENV_HELM_ARGS} -f <(echo "$ARGOCD_ENV_HELM_VALUES") . |
             argocd-vault-plugin generate --verbose-sensitive-output -
+{% endif %}
       lockRepo: false
   avp-kustomize.yaml: |
     ---


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Pour déployer ses ServiceMonitors, le chart Helm d'Argo CD vérifie la présence de l'apiVersion "monitoring.coreos.com/v1" (issue de Prometheus), comme nous pouvons le voir par exemple ici :
https://github.com/argoproj/argo-helm/commit/c2f813ec6241b016a6907238c87eadf8a9feb505#diff-f49744c40f601cfc1a7f1af0eed50f7a73d9f82908851da8d3a2181a1e989de7

En mode de déploiement GitOps, nous paramétrons notre Argo CD d'infra pour utiliser le Config Management Plugin Vault et c'est lui qui génère nos templates à l'aide de la commande `helm template`.

Or la commande `helm template` ne s'appuie pas sur les apiVersions fournies par l'api du cluster, mais sur celles fournies par une version compilée de kubectl. C'est la raison pour laquelle il faut lui préciser explicitement les apiVersions "exotiques" qui existeraient dans notre cluster, à l'aide de l'option `--api-versions`.

Donc, dans le cas d'un chart Helm utilisant une apiVersion qui n'est pas connue par la version compilée de kubectl, ce qui est le cas ici avec Argo CD et sa vérification de "monitoring.coreos.com/v1"  pour déployer les ServiceMonitors, nous devons adapter la configmap cmp-plugin de notre Argo CD d'infra et corriger la commande `helm template` du ConfigManagementPlugin argocd-vault-plugin-helm en lui ajoutant l'option `--api-versions "monitoring.coreos.com/v1"` lorsque les métriques sont activées dans la dsc.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous adaptons la configmap cmp-plugin de notre Argo CD d'infra, afin que le plugin Vault utilise bien l'option `--api-versions "monitoring.coreos.com/v1"` lorsque les métriques sont activée dans la dsc, ce qui permet notamment au chart Helm d'Argo CD déployé en GitOps, via cet ArgoCD d'infra, de déployer également ses ServiceMonitors.

Nous réintroduisons donc la gestion des ServiceMonitors par les values du chart Argo CD et nous abandonnons l'utilisation du paramètre `global.addPrometheusAnnotations` qui avait été introduit dans une précédente PR et qui se révèle non fonctionnel dans notre contexte.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.