### PR TITLE
fix: :art: Argo CD logs RBAC

### DIFF
--- a/roles/gitops/rendering-apps-files/vars/main.yaml
+++ b/roles/gitops/rendering-apps-files/vars/main.yaml
@@ -9,7 +9,7 @@ values:
           p, role:admin, *, *, */*, allow
           p, role:nada, applicationsets, *, */*, deny
           p, role:nada, applications, *, */*, deny
-          p, role:nada, logs, *, */*, deny
+          p, role:nada, logs, get, */*, allow
           p, role:nada, exec, *, */*, deny
           p, role:nada, certificates, *, *, deny
           p, role:nada, accounts, *, *, deny


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Suite à la [PR#854](https://github.com/cloud-pi-native/socle/pull/854) qui upgrade Argo CD en version 3.1.7, nous constatons que l'accès aux logs des containers via l'UI d'Argo CD n'est plus disponible pour nos utilisateurs.
Elle n'est accessible qu'aux personnes disposant des droits d'admin sur l'instance d'Argo CD concernée.

Ce breaking change est documenté ici :
* https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/2.14-3.0/#logs-rbac-enforcement-as-a-first-class-rbac-citizen

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous appliquons la "quick remediation" recommandée par la documentation, en adaptant la partie RBAC concernant les logs, au niveau de la policy par défaut pour notre custom role.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé sur plusieurs clusters.