### PR TITLE
refactor: :recycle: use kubernetes dns for pod to pod communication

### DIFF
--- a/post-install/sonarqube.yaml
+++ b/post-install/sonarqube.yaml
@@ -15,43 +15,6 @@
       ansible.builtin.import_role:
         name: gitops/post-install/sonarqube
 
-    - name: Get SonarQube admin password secret
-      kubernetes.core.k8s_info:
-        namespace: "{{ dsc.sonarqube.namespace }}"
-        kind: Secret
-        name: "sonarqube"
-      register: sonarqube_pwd
-
-    - name: Check existence of SonarQube DSO admin token
-      ansible.builtin.uri:
-        validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-        url: "https://{{ sonar_domain }}/api/user_tokens/search?login=admin"
-        user: "admin"
-        password: "{{ sonarqube_pwd.resources[0].data.password | b64decode }}"
-        force_basic_auth: true
-        method: GET
-        status_code: [200]
-      register: token_check
-
-    - name: Generate new SonarQube DSO admin token
-      when: "'DSO' not in (token_check.json.userTokens | map(attribute='name') | list)"
-      ansible.builtin.uri:
-        validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-        url: "https://{{ sonar_domain }}/api/user_tokens/generate?name=DSO"
-        user: "admin"
-        password: "{{ sonarqube_pwd.resources[0].data.password | b64decode }}"
-        force_basic_auth: true
-        method: POST
-        status_code: [200, 204]
-      register: token_pass
-
-    - name: Keep current token if not changed
-      when: token_pass.json.token is not defined
-      ansible.builtin.set_fact:
-        token_pass:
-          json:
-            token: "{{ retrieved_token_pass }}"
-
     - name: Update vault-secrets sonarApiToken
       block:
         - name: Reset envs vars
@@ -68,8 +31,8 @@
                       auth:
                         sonarApiToken: >-
                           {{
-                            (token_pass.json.token)if token_pass.json.token is defined and
-                            token_pass.json.token | length > 0
+                            (retrieved_token_pass.json.token)if retrieved_token_pass.json.token is defined and
+                            retrieved_token_pass.json.token | length > 0
                             else ''
                           }}
 

--- a/roles/gitops/post-install/gitlab-catalog/tasks/main.yaml
+++ b/roles/gitops/post-install/gitlab-catalog/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Update Catalog visibility and path
   community.general.gitlab_project:
-    api_url: https://{{ gitlab_domain }}
+    api_url: "{{ gitlab_auth_url }}"
     api_token: "{{ gitlab_token }}"
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     import_url: "{{ dsc.gitlabCatalog.catalogRepoUrl }}"
@@ -20,7 +20,7 @@
 
 - name: Remove branch protection
   community.general.gitlab_protected_branch:
-    api_url: https://{{ gitlab_domain }}
+    api_url: "{{ gitlab_auth_url }}"
     api_token: "{{ gitlab_token }}"
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     project: "{{ dsc.global.projectsRootDir | join('/') }}/catalog"
@@ -32,13 +32,13 @@
   ansible.builtin.shell: |
     set -e
     git config --add http.sslVerify false
-    git push --mirror "https://admin:{{ gitlab_token }}@{{ gitlab_domain }}/{{ dsc.global.projectsRootDir | join('/') }}/catalog"
+    git push --mirror "http://admin:{{ gitlab_token }}@{{ gitlab_auth_url | replace('http://', '') }}/{{ dsc.global.projectsRootDir | join('/') }}/catalog"
   args:
     chdir: /tmp/test
 
 - name: Apply branch protection
   community.general.gitlab_protected_branch:
-    api_url: https://{{ gitlab_domain }}
+    api_url: "{{ gitlab_auth_url }}"
     api_token: "{{ gitlab_token }}"
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     project: "{{ dsc.global.projectsRootDir | join('/') }}/catalog"

--- a/roles/gitops/post-install/gitlab-catalog/vars/main.yaml
+++ b/roles/gitops/post-install/gitlab-catalog/vars/main.yaml
@@ -1,0 +1,2 @@
+---
+gitlab_auth_url: "http://{{ dsc.gitlab.subDomain }}-webservice-default.{{ dsc.gitlab.namespace }}.svc.cluster.local:8181"

--- a/roles/gitops/post-install/gitlab/tasks/create-group.yaml
+++ b/roles/gitops/post-install/gitlab/tasks/create-group.yaml
@@ -5,7 +5,7 @@
 
 - name: Create group {{ group_name }}
   community.general.gitlab_group:
-    api_url: https://{{ gitlab_domain }}
+    api_url: "{{ gitlab_auth_url }}"
     api_token: "{{ gitlab_token }}"
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     name: "{{ group_name }}"

--- a/roles/gitops/post-install/gitlab/tasks/main.yaml
+++ b/roles/gitops/post-install/gitlab/tasks/main.yaml
@@ -9,7 +9,7 @@
   when: set_token_inv.skipped is not defined
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ gitlab_domain }}/api/v4/admin/ci/variables
+    url: "{{ gitlab_auth_url }}/api/v4/admin/ci/variables"
     headers:
       PRIVATE-TOKEN: "{{ gitlab_token }}"
   register: test_token
@@ -48,7 +48,7 @@
 - name: Get settings
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ gitlab_domain }}/api/v4/application/settings
+    url: "{{ gitlab_auth_url }}/api/v4/application/settings"
     headers:
       PRIVATE-TOKEN: "{{ gitlab_token }}"
   register: get_settings
@@ -57,7 +57,7 @@
 - name: Set some parameters
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ gitlab_domain }}/api/v4/application/settings
+    url: "{{ gitlab_auth_url }}/api/v4/application/settings"
     method: PUT
     headers:
       PRIVATE-TOKEN: "{{ gitlab_token }}"
@@ -81,7 +81,7 @@
 
 - name: Set or update some CI/CD variables
   community.general.gitlab_group_variable:
-    api_url: https://{{ gitlab_domain }}
+    api_url: "{{ gitlab_auth_url }}"
     api_token: "{{ gitlab_token }}"
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     group: "{{ dsc.global.projectsRootDir | join('/') }}"
@@ -96,17 +96,17 @@
       - name: PROJECTS_ROOT_DIR
         value: "{{ dsc.global.projectsRootDir | join('/') }}"
       - name: NEXUS_HOST_URL
-        value: https://{{ nexus_domain }}
+        value: "http://{{ dsc.nexus.subDomain }}.{{ dsc.nexus.namespace }}.svc.cluster.local:8081"
       - name: NEXUS_HOSTNAME
         value: "{{ nexus_domain }}"
       - name: SONAR_HOST_URL
-        value: https://{{ sonar_domain }}
+        value: "http://{{ dsc.sonarqube.subDomain }}-sonarqube.{{ dsc.sonarqube.namespace }}.svc.cluster.local:9000"
       - name: VAULT_AUTH_PATH
         value: "{{ vault_auth_path }}"
       - name: VAULT_AUTH_ROLE
         value: "{{ vault_auth_role }}"
       - name: VAULT_SERVER_URL
-        value: https://{{ vault_domain }}
+        value: "http://{{ dsc_name }}-{{ dsc.vault.subDomain }}-active.{{ dsc.vault.namespace }}.svc.cluster.local:8200"
       - name: MVN_CONFIG_FILE
         variable_type: file
         value: "{{ mvn_config_file }}"
@@ -116,7 +116,7 @@
 
 - name: Set or update proxy CI/CD variables
   community.general.gitlab_group_variable:
-    api_url: https://{{ gitlab_domain }}
+    api_url: "{{ gitlab_auth_url }}"
     api_token: "{{ gitlab_token }}"
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     group: "{{ dsc.global.projectsRootDir | join('/') }}"
@@ -142,7 +142,7 @@
 
 - name: Set or update CA_BUNDLE variable
   community.general.gitlab_group_variable:
-    api_url: https://{{ gitlab_domain }}
+    api_url: "{{ gitlab_auth_url }}"
     api_token: "{{ gitlab_token }}"
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     group: "{{ dsc.global.projectsRootDir | join('/') }}"
@@ -162,7 +162,7 @@
 
 - name: Set or update insecure args variables
   community.general.gitlab_group_variable:
-    api_url: https://{{ gitlab_domain }}
+    api_url: "{{ gitlab_auth_url }}"
     api_token: "{{ gitlab_token }}"
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     group: "{{ dsc.global.projectsRootDir | join('/') }}"
@@ -178,7 +178,7 @@
 
 - name: Set or update additional CI/CD variables
   community.general.gitlab_group_variable:
-    api_url: https://{{ gitlab_domain }}
+    api_url: "{{ gitlab_auth_url }}"
     api_token: "{{ gitlab_token }}"
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     group: "{{ dsc.global.projectsRootDir | join('/') }}"
@@ -273,7 +273,7 @@
 - name: Get GitLab online admin runners
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ gitlab_domain }}/api/v4/runners/all?status=online
+    url: "{{ gitlab_auth_url }}/api/v4/runners/all?status=online"
     method: GET
     headers:
       PRIVATE-TOKEN: "{{ gitlab_token }}"
@@ -293,7 +293,7 @@
     (not grunner_installed)
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ gitlab_domain }}/api/v4/user/runners
+    url: "{{ gitlab_auth_url }}/api/v4/user/runners"
     method: POST
     headers:
       PRIVATE-TOKEN: "{{ gitlab_token }}"
@@ -315,7 +315,7 @@
     - name: Get all GitLab admin runners
       ansible.builtin.uri:
         validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-        url: https://{{ gitlab_domain }}/api/v4/runners/all
+        url: "{{ gitlab_auth_url }}/api/v4/runners/all"
         method: GET
         headers:
           PRIVATE-TOKEN: "{{ gitlab_token }}"
@@ -331,7 +331,7 @@
       when: old_admin_runners | length > 0
       ansible.builtin.uri:
         validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-        url: "https://{{ gitlab_domain }}/api/v4/runners/{{ item }}"
+        url: "{{ gitlab_auth_url }}/api/v4/runners/{{ item }}"
         method: DELETE
         headers:
           PRIVATE-TOKEN: "{{ gitlab_token }}"
@@ -345,7 +345,7 @@
     dso_runner is defined
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: "https://{{ gitlab_domain }}/api/v4/runners/{{ dso_runner.id }}"
+    url: "{{ gitlab_auth_url }}/api/v4/runners/{{ dso_runner.id }}"
     method: DELETE
     headers:
       PRIVATE-TOKEN: "{{ gitlab_token }}"

--- a/roles/gitops/post-install/gitlab/vars/main.yaml
+++ b/roles/gitops/post-install/gitlab/vars/main.yaml
@@ -1,0 +1,2 @@
+---
+gitlab_auth_url: "http://{{ dsc.gitlab.subDomain }}-webservice-default.{{ dsc.gitlab.namespace }}.svc.cluster.local:8181"

--- a/roles/gitops/post-install/harbor/tasks/create_proxy_cache.yaml
+++ b/roles/gitops/post-install/harbor/tasks/create_proxy_cache.yaml
@@ -7,7 +7,7 @@
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     method: GET
-    url: https://{{ harbor_domain }}/api/v2.0/registries?q=name={{ proxy_cache.name }}
+    url: "{{ harbor_auth_url }}/api/v2.0/registries?q=name={{ proxy_cache.name }}"
     password: "{{ harbor_current_vault_values.data.data.global.harborAdminPassword }}"
     user: admin
     force_basic_auth: true
@@ -43,7 +43,7 @@
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     method: "{{ method }}"
-    url: https://{{ harbor_domain }}/api/v2.0/registries/{{ url_id_param }}
+    url: "{{ harbor_auth_url }}/api/v2.0/registries/{{ url_id_param }}"
     password: "{{ harbor_current_vault_values.data.data.global.harborAdminPassword }}"
     user: admin
     force_basic_auth: true
@@ -55,7 +55,7 @@
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     method: GET
-    url: https://{{ harbor_domain }}/api/v2.0/registries?q=name={{ proxy_cache.name }}
+    url: "{{ harbor_auth_url }}/api/v2.0/registries?q=name={{ proxy_cache.name }}"
     password: "{{ harbor_current_vault_values.data.data.global.harborAdminPassword }}"
     user: admin
     force_basic_auth: true
@@ -67,7 +67,7 @@
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     method: GET
-    url: https://{{ harbor_domain }}/api/v2.0/projects?q=name={{ proxy_cache.name }}
+    url: "{{ harbor_auth_url }}/api/v2.0/projects?q=name={{ proxy_cache.name }}"
     password: "{{ harbor_current_vault_values.data.data.global.harborAdminPassword }}"
     user: admin
     force_basic_auth: true
@@ -84,7 +84,7 @@
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     method: "{{ method }}"
-    url: https://{{ harbor_domain }}/api/v2.0/projects/{{ url_id_param }}
+    url: "{{ harbor_auth_url }}/api/v2.0/projects/{{ url_id_param }}"
     password: "{{ harbor_current_vault_values.data.data.global.harborAdminPassword }}"
     user: admin
     force_basic_auth: true

--- a/roles/gitops/post-install/harbor/tasks/main.yaml
+++ b/roles/gitops/post-install/harbor/tasks/main.yaml
@@ -2,7 +2,7 @@
 - name: Get harbor config
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ harbor_domain }}/api/v2.0/configurations
+    url: "{{ harbor_auth_url }}/api/v2.0/configurations"
     password: "{{ harbor_current_vault_values.data.data.global.harborAdminPassword }}"
     user: admin
     force_basic_auth: true
@@ -57,7 +57,7 @@
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     method: PUT
-    url: https://{{ harbor_domain }}/api/v2.0/configurations
+    url: "{{ harbor_auth_url }}/api/v2.0/configurations"
     password: "{{ harbor_current_vault_values.data.data.global.harborAdminPassword }}"
     user: admin
     force_basic_auth: true
@@ -69,7 +69,7 @@
 - name: Get trivy schedule scan config
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ harbor_domain }}/api/v2.0/system/scanAll/schedule
+    url: "{{ harbor_auth_url }}/api/v2.0/system/scanAll/schedule"
     password: "{{ harbor_current_vault_values.data.data.global.harborAdminPassword }}"
     user: admin
     force_basic_auth: true
@@ -82,7 +82,7 @@
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     method: POST
-    url: https://{{ harbor_domain }}/api/v2.0/system/scanAll/schedule
+    url: "{{ harbor_auth_url }}/api/v2.0/system/scanAll/schedule"
     password: "{{ harbor_current_vault_values.data.data.global.harborAdminPassword }}"
     user: admin
     force_basic_auth: true

--- a/roles/gitops/post-install/harbor/vars/main.yaml
+++ b/roles/gitops/post-install/harbor/vars/main.yaml
@@ -1,0 +1,2 @@
+---
+harbor_auth_url: "http://harbor-core.{{ dsc.harbor.namespace }}.svc.cluster.local"

--- a/roles/gitops/post-install/sonarqube/tasks/main.yaml
+++ b/roles/gitops/post-install/sonarqube/tasks/main.yaml
@@ -9,7 +9,7 @@
 - name: Get SonarQube migration status
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ sonar_domain }}/api/v2/system/migrations-status
+    url: "{{ sonar_auth_url }}/api/v2/system/migrations-status"
     user: "admin"
     password: "{{ sonarqube_pwd.resources[0].data.password | b64decode }}"
     force_basic_auth: true
@@ -22,7 +22,7 @@
   when: "'Database migration is required' in sonar_migration_status.json.message"
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ sonar_domain }}/api/system/migrate_db
+    url: "{{ sonar_auth_url }}/api/system/migrate_db"
     user: "admin"
     password: "{{ sonarqube_pwd.resources[0].data.password | b64decode }}"
     force_basic_auth: true
@@ -32,7 +32,7 @@
 - name: Wait SonarQube status to be UP
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ sonar_domain }}/api/system/status
+    url: "{{ sonar_auth_url }}/api/system/status"
     user: "admin"
     password: "{{ sonarqube_pwd.resources[0].data.password | b64decode }}"
     force_basic_auth: true
@@ -114,22 +114,15 @@
             else ''
           }}
 
-- name: Reset Admin Password procedure
+- name: Reset Admin Token procedure
   when: retrieved_token_pass | length == 0
   ansible.builtin.include_tasks:
-    file: reset-admin-password.yaml
-
-- name: Get Sonarqube admin password secret
-  kubernetes.core.k8s_info:
-    namespace: "{{ dsc.sonarqube.namespace }}"
-    kind: Secret
-    name: "sonarqube"
-  register: sonarqube_pwd
+    file: reset-admin-token.yaml
 
 - name: Remove permissions for sonar-users
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ sonar_domain }}/api/permissions/remove_group?groupName=sonar-users&permission={{ item }}
+    url: "{{ sonar_auth_url }}/api/permissions/remove_group?groupName=sonar-users&permission={{ item }}"
     user: "admin"
     password: "{{ sonarqube_pwd.resources[0].data.password | b64decode }}"
     force_basic_auth: true

--- a/roles/gitops/post-install/sonarqube/tasks/reset-admin-token.yaml
+++ b/roles/gitops/post-install/sonarqube/tasks/reset-admin-token.yaml
@@ -3,20 +3,24 @@
   ansible.builtin.debug:
     msg: Impossible de retrouver le TOKEN du compte admin, initialisation en cours …
 
-- name: Get Sonarqube admin password secret
-  kubernetes.core.k8s_info:
-    namespace: "{{ dsc.sonarqube.namespace }}"
-    kind: Secret
-    name: "sonarqube"
-  register: sonarqube_pwd
-
 - name: Remove old admin token
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ sonar_domain }}/api/user_tokens/revoke?name=DSO
+    url: "{{ sonar_auth_url }}/api/user_tokens/revoke?name=DSO"
     user: "admin"
     password: "{{ sonarqube_pwd.resources[0].data.password | b64decode }}"
     force_basic_auth: true
     method: post
     status_code: [200, 204, 404]
   register: current_tokens
+
+- name: Generate new SonarQube DSO admin token
+  ansible.builtin.uri:
+    validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
+    url: "{{ sonar_auth_url }}/api/user_tokens/generate?name=DSO"
+    user: "admin"
+    password: "{{ sonarqube_pwd.resources[0].data.password | b64decode }}"
+    force_basic_auth: true
+    method: POST
+    status_code: [200, 204]
+  register: retrieved_token_pass

--- a/roles/gitops/post-install/sonarqube/vars/main.yaml
+++ b/roles/gitops/post-install/sonarqube/vars/main.yaml
@@ -1,0 +1,2 @@
+---
+sonar_auth_url: "http://{{ dsc.sonarqube.subDomain }}-sonarqube.{{ dsc.sonarqube.namespace }}.svc.cluster.local:9000"

--- a/roles/gitops/post-install/vault/tasks/main.yml
+++ b/roles/gitops/post-install/vault/tasks/main.yml
@@ -195,7 +195,7 @@
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
     method: GET
-    url: "https://{{ vault_domain }}/v1/sys/mounts/forge-dso"
+    url: "{{ vault_auth_url }}/v1/sys/mounts/forge-dso"
     status_code: [200, 400]
     headers:
       "X-Vault-Token": "{{ vault_token }}"
@@ -205,7 +205,7 @@
   when: get_engines.status == 400
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: "https://{{ vault_domain }}/v1/sys/mounts/forge-dso"
+    url: "{{ vault_auth_url }}/v1/sys/mounts/forge-dso"
     method: POST
     status_code: [204]
     headers:
@@ -220,7 +220,7 @@
 - name: Config - get auth method"
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ vault_domain }}/v1/sys/auth/jwt
+    url: "{{ vault_auth_url }}/v1/sys/auth/jwt"
     status_code: [200, 400]
     headers:
       X-Vault-Token: "{{ vault_token }}"
@@ -231,7 +231,7 @@
   when: jwt_state.status == 400
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ vault_domain }}/v1/sys/auth/jwt
+    url: "{{ vault_auth_url }}/v1/sys/auth/jwt"
     method: POST
     status_code: [204]
     headers:
@@ -244,7 +244,7 @@
 - name: Config - add role default-ci
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ vault_domain }}/v1/auth/jwt/role/default-ci
+    url: "{{ vault_auth_url }}/v1/auth/jwt/role/default-ci"
     method: POST
     status_code: [204]
     headers:
@@ -258,7 +258,7 @@
       bound_claims_type: glob
       user_claim: user_email
       bound_audiences:
-        - https://{{ vault_domain }}
+        - "{{ vault_auth_url }}"
       bound_claims:
         iss:
           - "https://{{ gitlab_domain }}"
@@ -273,7 +273,7 @@
 - name: Config - set jwt config
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ vault_domain }}/v1/auth/jwt/config
+    url: "{{ vault_auth_url }}/v1/auth/jwt/config"
     method: POST
     status_code: [204]
     headers:
@@ -289,7 +289,7 @@
 - name: Config - get accessor jwt config
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ vault_domain }}/v1/sys/auth/jwt
+    url: "{{ vault_auth_url }}/v1/sys/auth/jwt"
     status_code: [200]
     headers:
       X-Vault-Token: "{{ vault_token }}"
@@ -298,7 +298,7 @@
 - name: Config - create policy
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: https://{{ vault_domain }}/v1/sys/policy/default-ci
+    url: "{{ vault_auth_url }}/v1/sys/policy/default-ci"
     method: POST
     status_code: [204]
     headers:
@@ -324,7 +324,7 @@
 - name: Get auth methods
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: "https://{{ vault_domain }}/v1/sys/auth/oidc"
+    url: "{{ vault_auth_url }}/v1/sys/auth/oidc"
     method: GET
     status_code: [200, 400]
     headers:
@@ -335,7 +335,7 @@
   when: get_auth_method.status == 400
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: "https://{{ vault_domain }}/v1/sys/auth/oidc"
+    url: "{{ vault_auth_url }}/v1/sys/auth/oidc"
     method: POST
     status_code: [200, 204]
     headers:
@@ -355,7 +355,7 @@
 - name: Configure oidc auth method
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: "https://{{ vault_domain }}/v1/auth/oidc/config"
+    url: "{{ vault_auth_url }}/v1/auth/oidc/config"
     method: POST
     status_code: [200, 204]
     headers:
@@ -375,7 +375,7 @@
 - name: Create oidc role
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: "https://{{ vault_domain }}/v1/auth/oidc/role/default"
+    url: "{{ vault_auth_url }}/v1/auth/oidc/role/default"
     method: POST
     status_code: [200, 204]
     headers:
@@ -401,7 +401,7 @@
 - name: Create admin access policy
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: "https://{{ vault_domain }}/v1/sys/policies/acl/admin"
+    url: "{{ vault_auth_url }}/v1/sys/policies/acl/admin"
     method: POST
     status_code: [200, 204]
     headers:
@@ -412,7 +412,7 @@
 - name: Create admin group
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: "https://{{ vault_domain }}/v1/identity/group"
+    url: "{{ vault_auth_url }}/v1/identity/group"
     method: POST
     status_code: [200, 204]
     headers:
@@ -427,7 +427,7 @@
 - name: Get oidc accessor
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: "https://{{ vault_domain }}/v1/sys/auth"
+    url: "{{ vault_auth_url }}/v1/sys/auth"
     method: GET
     status_code: [200, 204]
     headers:
@@ -437,7 +437,7 @@
 - name: Get admin group id
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: "https://{{ vault_domain }}/v1/identity/group/name/admin"
+    url: "{{ vault_auth_url }}/v1/identity/group/name/admin"
     method: GET
     status_code: [200, 204]
     headers:
@@ -447,7 +447,7 @@
 - name: Create admin group alias
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: "https://{{ vault_domain }}/v1/identity/group-alias"
+    url: "{{ vault_auth_url }}/v1/identity/group-alias"
     method: POST
     status_code: [200, 400]
     headers:
@@ -461,7 +461,7 @@
 - name: Set oidc method as default
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: "https://{{ vault_domain }}/v1/sys/auth/oidc/tune"
+    url: "{{ vault_auth_url }}/v1/sys/auth/oidc/tune"
     method: POST
     status_code: [204]
     headers:
@@ -474,7 +474,7 @@
 - name: Get auth methods
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: "https://{{ vault_domain }}/v1/sys/auth/approle"
+    url: "{{ vault_auth_url }}/v1/sys/auth/approle"
     method: GET
     status_code: [200, 400]
     headers:
@@ -485,7 +485,7 @@
   when: get_auth_method.status == 400
   ansible.builtin.uri:
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
-    url: "https://{{ vault_domain }}/v1/sys/auth/approle"
+    url: "{{ vault_auth_url }}/v1/sys/auth/approle"
     method: POST
     status_code: [200, 204]
     headers:

--- a/roles/gitops/post-install/vault/vars/main.yaml
+++ b/roles/gitops/post-install/vault/vars/main.yaml
@@ -1,0 +1,2 @@
+---
+vault_auth_url: "http://{{ dsc_name }}-{{ dsc.vault.subDomain }}-active.{{ dsc.vault.namespace }}.svc.cluster.local:8200"

--- a/roles/gitops/rendering-apps-files/templates/console/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/console/values/00-main.j2
@@ -10,19 +10,24 @@ console:
       ARGOCD_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.argocd}>/"
       GITLAB_TOKEN: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/gitlab/values#gitlabToken>
       GITLAB_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.gitlab}>/"
+      GITLAB_INTERNAL_URL: "http://{{ dsc.gitlab.subDomain }}-webservice-default.{{ dsc.gitlab.namespace }}.svc.cluster.local:8181/"
       HARBOR_ADMIN: admin
       HARBOR_ADMIN_PASSWORD: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/harbor/values#global| jsonPath {.harborAdminPassword}>
       HARBOR_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.harbor}>/"
+      HARBOR_INTERNAL_URL: "http://harbor-core.{{ dsc.harbor.namespace }}.svc.cluster.local/"
       KEYCLOAK_ADMIN: "dsoadmin"
       KEYCLOAK_ADMIN_PASSWORD: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/keycloak/values#auth| jsonPath {.adminPassword}>
       KEYCLOAK_URL: "http://{{ dsc.keycloak.subDomain }}.{{ dsc.keycloak.namespace }}.svc.cluster.local/realms/{{ dsc.keycloak.applicationRealm }}/.well-known/openid-configuration"
       NEXUS_ADMIN: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/nexus/values#auth| jsonPath {.adminUsername}>
       NEXUS_ADMIN_PASSWORD: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/nexus/values#auth| jsonPath {.adminPassword}>
       NEXUS_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.nexus}>/"
+      NEXUS_INTERNAL_URL: "http://{{ dsc.nexus.subDomain }}.{{ dsc.nexus.namespace }}.svc.cluster.local:8081/"
       SONAR_API_TOKEN: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/sonarqube/values#auth| jsonPath {.sonarApiToken}>"
       SONARQUBE_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.sonarqube}>/"
+      SONARQUBE_INTERNAL_URL: "http://{{ dsc.sonarqube.subDomain }}-sonarqube.{{ dsc.sonarqube.namespace }}.svc.cluster.local:9000/"
       VAULT_TOKEN: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/vault/values#vaultToken>
       VAULT_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.vault}>/"
+      VAULT_INTERNAL_URL: "http://{{ dsc_name }}-{{ dsc.vault.subDomain }}-active.{{ dsc.vault.namespace }}.svc.cluster.local:8200/"
   global:
     env:
       NODE_ENV: "production"

--- a/roles/gitops/rendering-apps-files/templates/console/values/10-proxy.j2
+++ b/roles/gitops/rendering-apps-files/templates/console/values/10-proxy.j2
@@ -1,11 +1,13 @@
 {% if dsc.proxy.enabled %}
 console:
-  global:
-    env:
-      HTTP_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
-      HTTPS_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
-      NO_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>,<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.kubeIp}>
-      http_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
-      https_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
-      no_proxy: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>,<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.kubeIp}>
+  server:
+    proxy:
+      enabled: true
+      env:
+      - name: http_proxy
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
+      - name: https_proxy
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
+      - name: no_proxy
+        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/observability/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/observability/values/00-main.j2
@@ -20,23 +20,7 @@ observatorium:
           path: roles/gitops/rendering-apps-files/templates/dashboard
           url: https://github.com/cloud-pi-native/socle.git
   ingress:
-    enabled: true
-    ingressClassName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#ingressClassName>
-    hosts:
-      - host: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.observatorium}>
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
-{% if dsc.ingress.tls.type != 'none' %}
-    tls:
-      - hosts:
-          - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.observatorium}>
-{% if dsc.ingress.tls.type == 'tlsSecret' %}
-        secretName: {{ dsc.ingress.tls.tlsSecret.name }}
-{% else %}
-        secretName: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.observatorium}>-tls
-{% endif %}
-{% endif %}
+    enabled: false
   api:
     loglevel: info
     config:
@@ -100,7 +84,7 @@ grafana:
   grafana:
     adminPassword: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/observability/values#grafana| jsonPath {.adminPassword}>
     isOpenShift: {{ dsc.global.platform == "openshift" }}
-    observatorium_url: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.observatorium}>
+    observatorium_url: http://{{ dsc.global.gitOps.envName }}-{{ dsc.observatorium.namespace }}-api.{{ dsc.observatorium.namespace }}.svc.cluster.local:8080
 {% if dsc.proxy.enabled %}
     env:
     - name: HTTP_PROXY

--- a/roles/gitops/vault-secrets/tasks/main.yaml
+++ b/roles/gitops/vault-secrets/tasks/main.yaml
@@ -88,13 +88,6 @@
         name: pg-cluster-console-app
       register: pg_console_db_secret
 
-    - name: Get kubernetes service
-      kubernetes.core.k8s_info:
-        namespace: default
-        kind: Service
-        name: kubernetes
-      register: kubernetes_service_clusterip
-
     - name: Get pg-cluster-gitlab-app secret
       kubernetes.core.k8s_info:
         namespace: "{{ dsc.gitlab.namespace }}"

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -1609,7 +1609,6 @@ spec:
                         metricsHost:
                           description: Host where metrics are aggregated for this environment.
                           type: string
-                    cnpg:
                   required:
                     - installEnabled
                   type: object

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -1576,12 +1576,6 @@ spec:
                     namespace:
                       description: The namespace for Observatorium.
                       type: string
-                    subDomain:
-                      description: The subdomain for Observatorium.
-                      type: string
-                    domain:
-                      description: The domain for Observatorium.
-                      type: string
                     helmRepoUrl:
                       description: Observatorium helm repository url.
                       type: string

--- a/roles/socle-config/tasks/envs.yaml
+++ b/roles/socle-config/tasks/envs.yaml
@@ -1,12 +1,4 @@
 ---
-- name: Get kubernetes service
-  kubernetes.core.k8s_info:
-    namespace: default
-    kind: Service
-    name: kubernetes
-  register: kubernetes_service_clusterip
-  when: dsc.proxy.enabled
-
 - name: CNPG s3 CA (secret)
   when: >
     dsc.global.backup.cnpg.enabled and
@@ -57,7 +49,6 @@
                 keycloak: "{{ keycloak_domain }}"
                 nexus: "{{ nexus_domain }}"
                 nexusDockerProxy: "{{ dsc.nexus.subDomain }}-docker-proxy{{ root_domain }}"
-                observatorium: "{{ observatorium_domain }}"
                 sonarqube: "{{ sonar_domain }}"
                 vault: "{{ vault_domain }}"
               proxy:
@@ -66,7 +57,6 @@
                 noProxy: "{{ dsc.proxy.no_proxy | default('') }}"
                 hostProxy: "{{ dsc.proxy.host | default('') }}"
                 portProxy: "{{ dsc.proxy.port | default('') }}"
-                kubeIp: "{{ kubernetes_service_clusterip.resources[0].spec.clusterIP | default('') }}"
               exposedCa: "{{ exposed_ca_pem | default('') }}"
               cnpgS3CaPem: "{{ cnpg_s3_ca_pem | default('') }}"
               ingressClassName: "{{ dsc.ingress.className | default('') }}"

--- a/roles/socle-config/tasks/main.yaml
+++ b/roles/socle-config/tasks/main.yaml
@@ -137,7 +137,6 @@
     keycloak_domain: "{{ dsc.keycloak.domain | default(dsc.keycloak.subDomain ~ root_domain) }}"
     keycloakinfra_domain: "{{ dsc.keycloakInfra.domain | default(dsc.keycloakInfra.subDomain ~ infra_root_domain) }}"
     nexus_domain: "{{ dsc.nexus.domain | default(dsc.nexus.subDomain ~ root_domain) }}"
-    observatorium_domain: "{{ dsc.observatorium.domain | default(dsc.observatorium.subDomain ~ root_domain) }}"
     sonar_domain: "{{ dsc.sonarqube.domain | default(dsc.sonarqube.subDomain ~ root_domain) }}"
     vault_domain: "{{ dsc.vault.domain | default(dsc.vault.subDomain ~ root_domain) }}"
 
@@ -177,7 +176,6 @@
       - "keycloak_domain: {{ keycloak_domain }}"
       - "keycloakinfra_domain: {{ keycloakinfra_domain }}"
       - "nexus_domain: {{ nexus_domain }}"
-      - "observatorium_domain: {{ observatorium_domain }}"
       - "sonar_domain: {{ sonar_domain }}"
       - "vault_domain: {{ vault_domain }}"
       - "vaultinfra_domain: {{ vaultinfra_domain }}"


### PR DESCRIPTION
## Issues liées

Issues numéro: #765 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
We are using exposed DNS for post-install tasks and for Console server plugins communication.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
We will use Kubernetes local DNS for post-install tasks and for Console server plugins communication.
Console should not need to go through proxy anymore.
It should reduce latency for post-install tasks (which are now running inside jobs pod), and also for Console server plugins communication.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Yes, post-install playbooks won't be able to run outside of the cluster anymore.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
All PR related to https://github.com/cloud-pi-native/socle/issues/765 must be merged at the same time.