### PR TITLE
chore: :construction: Use bitnamilegacy repository for keycloak, Gitlab, Gitlab-pipeline-exporter

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/glexporter/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/glexporter/values/00-main.j2
@@ -16,3 +16,7 @@ glexporter:
         path: /metrics
   redis:
     fullnameOverride: "glexporter-redis"
+    global:
+      imageRegistry: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>"
+    image:
+      repository: bitnamilegacy/redis

--- a/roles/infra/keycloak-infra/templates/values/10-registry.j2
+++ b/roles/infra/keycloak-infra/templates/values/10-registry.j2
@@ -1,6 +1,7 @@
 {% if use_private_registry %}
 image:
   registry: "{{ dsc.global.registry }}"
+  repository: bitnamilegacy/keycloak
 {% endif %}
 
 {% if use_image_pull_secrets %}

--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -38,10 +38,10 @@ spec:
     chartVersion: "0.3.5"
   gitlabOperator:
     # https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/tags
-    chartVersion: "2.1.2"
+    chartVersion: "2.4.1"
   gitlabrunner:
     # https://gitlab.com/gitlab-org/charts/gitlab-runner/-/tags
-    chartVersion: "0.78.1"
+    chartVersion: "0.81.0"
   grafana:
     # https://github.com/grafana/grafana/tags
     imageVersion: "10.4.3"

--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -32,7 +32,7 @@ spec:
     chartVersion: ">=1.0.0 <2.0.0"
   gitlab:
     # https://artifacthub.io/packages/helm/gitlab/gitlab
-    chartVersion: "9.1.2"
+    chartVersion: "9.4.1"
   glexporter:
     # https://github.com/mvisonneau/helm-charts/tree/main/charts/gitlab-ci-pipelines-exporter
     chartVersion: "0.3.5"

--- a/versions.md
+++ b/versions.md
@@ -7,10 +7,10 @@
 | cloudnativepg.operator    | 1.26.1           | 0.25.0        | [cloudnative-pg](https://artifacthub.io/packages/helm/cloudnative-pg/cloudnative-pg)                                 |
 | console                   | 9.\*.\*          | 2.\*.\*       | [console](https://github.com/cloud-pi-native/helm-charts)                                                            |
 | cpn-ansible-job           | 1.\*.\*            | 1.\*.\*         | [cpn-ansible-job](https://github.com/cloud-pi-native/helm-charts)                                                    |
-| gitlab                    | 18.1.2          | 9.1.2        | [gitlab](https://artifacthub.io/packages/helm/gitlab/gitlab)                                                         |
+| gitlab                    | 18.4.1         | 9.4.1       | [gitlab](https://artifacthub.io/packages/helm/gitlab/gitlab)                                                         |
 | glexporter | 0.5.10           | 0.3.5         | [glexporter](https://github.com/mvisonneau/helm-charts/tree/main/charts/gitlab-ci-pipelines-exporter) |
-| gitlabOperator            | 2.1.2           | 2.1.2        | [gitlabOperator](https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/tags)                                  |
-| gitlabrunner              | 18.1.1          | 0.78.1        | [gitlabrunner](https://gitlab.com/gitlab-org/charts/gitlab-runner/-/tags)                                            |
+| gitlabOperator            | 2.4.1           | 2.4.1        | [gitlabOperator](https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/tags)                                  |
+| gitlabrunner              | 18.4.0          | 0.78.1        | [gitlabrunner](https://gitlab.com/gitlab-org/charts/gitlab-runner/-/tags)                                            |
 | grafana                   | 10.4.3           | N/A           | [grafana](https://github.com/grafana/grafana/tags)                                                                   |
 | harbor                    | 2.12.0           | 1.16.0        | [harbor](https://artifacthub.io/packages/helm/harbor/harbor)                                                         |
 | keycloak                  | 26.3.3           | 25.2.0        | [keycloak](https://artifacthub.io/packages/helm/bitnami/keycloak)                                                    |


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Le keycloak se base sur l'image bitnami/keycloak
Le Gitlab a des dépendances bitnami/redis et bitnami/redis-exporter sur plusieurs de ses composants 
Le gitlab-pipeline-exporter a des dépendances bitnami/redis

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Le keycloak se base sur l'image bitnamilegacy/keycloak
Le Gitlab a des dépendances bitnamilegacy/redis et bitnamilegacy/redis-exporter via une upgrade du Chart qui utilise des values qui pointent vers bitnamilegacy
Le gitlab-pipeline-exporter a des dépendances bitnamilegacy/redis 
## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
No
## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
