### PR TITLE
fix: :bug: Nexus ServiceMonitor

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/nexus/templates/secret-admin.yml.j2
+++ b/roles/gitops/rendering-apps-files/templates/nexus/templates/secret-admin.yml.j2
@@ -7,5 +7,6 @@ metadata:
     avp.kubernetes.io/remove-missing: "true"
   labels:
     app: nexus3
-data:
-  password: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/nexus/values#auth | jsonPath {.adminPassword} | base64encode>
+stringData:
+  username: admin
+  password: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/nexus/values#auth | jsonPath {.adminPassword}>

--- a/roles/gitops/rendering-apps-files/templates/nexus/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/nexus/values/00-main.j2
@@ -152,7 +152,15 @@ nexus3:
     enabled: {{ dsc.global.metrics.enabled }}
     serviceMonitor:
       enabled: {{ dsc.global.metrics.enabled }}
+      endpointConfig:
+        basicAuth:
+          username:
+            name: admin-creds
+            key: username
+          password:
+            name: admin-creds
+            key: password
 {% if dsc.global.metrics.additionalLabels is defined %}
-      labels: {{ dsc.global.metrics.additionalLabels }} 
+      labels: {{ dsc.global.metrics.additionalLabels }}
 {% endif %}
 {% endif %}

--- a/roles/socle-config/tasks/envs.yaml
+++ b/roles/socle-config/tasks/envs.yaml
@@ -234,7 +234,6 @@
             syncWave: 60
             vault_values:
               auth:
-                adminUsername: "admin"
                 adminPassword: "{{ lookup('ansible.builtin.password', '/dev/null', length=24, chars=['ascii_letters', 'digits']) }}"
           - argocd_app: dashboard
             clusterName: ""


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Le secret `admin-creds` de Nexus est créé sans le username.
Il manque les éléments d'authentification dans le ServiceMonitor, dont le username de l'admin.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous actualisons le secret `admin-creds` afin de lui ajouter le username dont le ServiceMonitor aura besoin.
Nous ajoutons les éléments d'authentification au ServiceMonitor.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
