### PR TITLE
fix: :bug: Ansible stdout format

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,3 +6,5 @@ callbacks_enabled = timer, profile_tasks, profile_roles
 gathering = smart
 fact_caching = jsonfile
 fact_caching_connection = /tmp/ansible-facts
+stdout_callback = community.general.yaml
+bin_ansible_callbacks = True


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Avec la sortie stdout par défaut d'Ansible, les messages de debug protègent certains caractères spéciaux par un antislash.

Ceci est en particulier problématique lors de l'affichage des messages qui nous fournissent les mots de passe de nos outils avec l'aide du playbook `admin-tools/get-credentials.yaml`. En effet, les mots de passe affichés peuvent alors contenir des antislashes indésirables.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous ajoutons les options `stdout_callback` et `bin_ansible_callbacks` à notre fichier `ansible.cfg` de sorte que les sorties des commandes s'effectuent en YAML, ce qui évite l'affichage de caractères d'échappement indésirables.

Ces options facilitent aussi grandement la lecture des longs messages d'erreur.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Voir à ce sujet les documentations et discussions suivantes :
* https://docs.ansible.com/ansible/latest/plugins/callback.html#callback-plugins
* https://docs.ansible.com/ansible/latest/reference_appendices/config.html
* https://stackoverflow.com/questions/71655776/removing-escape-characters-and-format-ansible-debug-output
* https://stackoverflow.com/questions/50009505/formatting-stdout-in-a-debug-task-of-ansible/50017860#50017860
