### PR TITLE
fix: :bug: Keycloak metrics and ServiceMonitor

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/00-main.j2
@@ -145,27 +145,14 @@ keycloak:
 
   metrics:
     enabled: {{ dsc.global.metrics.enabled }}
-    service:
-      ports:
-        http: 8080
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "8080"
-      extraPorts: []
     serviceMonitor:
-      enabled: true
-      port: http
-      endpoints:
-        - path: '/metrics'
-        - path: '/realms/{{ dsc.keycloak.managementRealm }}/metrics'
-        - path: '/realms/{{ dsc.keycloak.applicationRealm }}/metrics'
+      enabled: {{ dsc.global.metrics.enabled }}
 {% if dsc.global.metrics.additionalLabels is defined %}
       labels: {{ dsc.global.metrics.additionalLabels }} 
 {% endif %}
     prometheusRule:
       enabled: {{ dsc.global.alerting.enabled }}
       namespace: {{ dsc.keycloak.namespace }}
-      labels: {}
 
   keycloakConfigCli:
     enabled: false


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Le paramètre `metrics.serviceMonitor.port` du chart Keycloak est erroné.

Le paramètre `metrics.serviceMonitor.enabled` n'est pas variabilisé.

Nous précisons par ailleurs un certain nombre de valeurs qui sont les valeurs par défaut du chart, ce qui n'est pas nécessaire.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous supprimons les valeurs superflues précisées dans le fichier `roles/gitops/rendering-apps-files/templates/keycloak/values/00-main.j2` pour la partie `metrics`, ce qui rétablit la valeur par défaut correcte pour le paramètre `metrics.serviceMonitor.port` .

Nous variabilisons le paramètre `metrics.serviceMonitor.enabled`, à l'image de ce qui est fait pour `metrics.enabled`.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement du scrapping de métriques keycloak testé et validé dans un cluster de développement suite à l'application de ce correctif.
