### PR TITLE
refactor: :recycle: switch to dso-job chart and reference sensitive env vars from secrets

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/awx/Chart.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/awx/Chart.yaml.j2
@@ -12,7 +12,7 @@ dependencies:
   alias: awx
   version: {{ dsc.awx.chartVersion }}
   repository: {{ dsc.awx.helmRepoUrl }}
-- name: cpn-ansible-job
+- name: cpn-job
   alias: cpn-ansible-job
   version: {{ dsc.cpnAnsibleJob.chartVersion | quote }}
   repository: {{ dsc.cpnAnsibleJob.helmRepoUrl }}

--- a/roles/gitops/rendering-apps-files/templates/awx/templates/secret-ansible.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/awx/templates/secret-ansible.yaml.j2
@@ -1,21 +1,13 @@
-{% if dsc.global.backup.cnpg.enabled %}
+{% if dsc.proxy.enabled %}
 apiVersion: v1
 kind: Secret
 metadata:
+  name: ansible-secret
   annotations:
     avp.kubernetes.io/remove-missing: "true"
-  name: ansible-secret
 type: Opaque
-{% if dsc.global.backup.s3.endpointCA.namespace is defined and
-dsc.global.backup.s3.endpointCA.name is defined and
-dsc.global.backup.s3.endpointCA.key is defined %}
-data:
-  ca.pem: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#cnpgS3CaPem>
-{% endif %}
-{% if dsc.proxy.enabled %}
 stringData:
   HTTP_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
   HTTPS_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
   NO_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
-{% endif %}
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/awx/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/awx/values/200-ansible-job.j2
@@ -1,19 +1,20 @@
 cpn-ansible-job:
   job:
-    name: "awx-oidc"
-    dscName: "{{ dsc_name }}"
-{% if use_private_registry %}
     image:
-      repository: "{{ dsc.global.registry }}/cloud-pi-native/git-ansible"
-{% endif %}
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloud-pi-native/git-ansible"
+      tag: "1"
+    command:
+    - /bin/sh
+    - -c
+    - |
+      git clone https://github.com/cloud-pi-native/socle.git && \
+      cd socle && \
+      ansible-playbook post-install/awx-oidc.yaml
+    extraEnvFrom:
+    - secretRef: 
+        name: ansible-secret
 {% if dsc.proxy.enabled %}
     extraEnv:
-    - name: http_proxy
-      value: "{{ dsc.proxy.http_proxy }}"
-    - name: https_proxy
-      value: "{{ dsc.proxy.https_proxy }}"
-    - name: no_proxy
-      value: "{{ dsc.proxy.no_proxy }}"
     - name: GIT_HTTP_PROXY_AUTHMETHOD
       value: basic
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/gitlab/Chart.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlab/Chart.yaml.j2
@@ -12,7 +12,7 @@ dependencies:
   alias: gitlab
   version: {{ dsc.gitlabOperator.chartVersion }}
   repository: "{{ dsc.gitlabOperator.helmRepoUrl }}"
-- name: cpn-ansible-job
+- name: cpn-job
   alias: cpn-ansible-job
   version: {{ dsc.cpnAnsibleJob.chartVersion | quote }}
   repository: {{ dsc.cpnAnsibleJob.helmRepoUrl }}

--- a/roles/gitops/rendering-apps-files/templates/gitlab/templates/secret-ansible.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlab/templates/secret-ansible.yaml.j2
@@ -1,21 +1,14 @@
-{% if dsc.global.backup.cnpg.enabled %}
 apiVersion: v1
 kind: Secret
 metadata:
+  name: ansible-secret
   annotations:
     avp.kubernetes.io/remove-missing: "true"
-  name: ansible-secret
 type: Opaque
-{% if dsc.global.backup.s3.endpointCA.namespace is defined and
-dsc.global.backup.s3.endpointCA.name is defined and
-dsc.global.backup.s3.endpointCA.key is defined %}
-data:
-  ca.pem: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#cnpgS3CaPem>
-{% endif %}
-{% if dsc.proxy.enabled %}
 stringData:
+  VAULT_INFRA_TOKEN: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>
+{% if dsc.proxy.enabled %}
   HTTP_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
   HTTPS_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
   NO_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
-{% endif %}
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/gitlab/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlab/values/200-ansible-job.j2
@@ -1,23 +1,27 @@
 cpn-ansible-job:
   job:
-    name: "gitlab"
-    dscName: "{{ dsc_name }}"
     image:
-      tag: "{{ dsc.cpnAnsibleJob.imageTag }}"
-    extraEnv:
-      - name: VAULT_INFRA_TOKEN
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>
-{% if dsc.proxy.enabled %}
-      - name: HTTP_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
-      - name: HTTPS_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
-      - name: NO_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
-{% endif %}
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloud-pi-native/git-ansible"
+      tag: "1"
+    command:
+    - /bin/sh
+    - -c
+    - |
+      git clone https://github.com/cloud-pi-native/socle.git && \
+      cd socle && \
+      ansible-playbook post-install/gitlab.yaml
+    extraEnvFrom:
+    - secretRef: 
+        name: ansible-secret
   # Wait longer enough for GitLab instance to be ready
     activeDeadlineSeconds: 1800
     backoffLimit: 60
   cronJob:
     create: true
-    name: "gitlab-ci-catalog"
+    command:
+    - /bin/sh
+    - -c
+    - |
+      git clone https://github.com/cloud-pi-native/socle.git && \
+      cd socle && \
+      ansible-playbook post-install/gitlab-ci-catalog.yaml

--- a/roles/gitops/rendering-apps-files/templates/global/Chart.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/global/Chart.yaml.j2
@@ -5,7 +5,7 @@ type: application
 version: 1.0.0
 {% if dsc.global.backup.cnpg.enabled %}
 dependencies:
-- name: cpn-ansible-job
+- name: cpn-job
   alias: cpn-ansible-job
   version: {{ dsc.cpnAnsibleJob.chartVersion | quote }}
   repository: {{ dsc.cpnAnsibleJob.helmRepoUrl }}

--- a/roles/gitops/rendering-apps-files/templates/global/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/global/values/200-ansible-job.j2
@@ -1,26 +1,31 @@
 {% if dsc.global.backup.cnpg.enabled %}
 cpn-ansible-job:
   job:
-    name: "pgdump"
-    dscName: "{{ dsc_name }}"
     image:
-      tag: "{{ dsc.cpnAnsibleJob.imageTag }}"
-    extraEnv:
-{% if dsc.proxy.enabled %}
-      - name: HTTP_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
-      - name: HTTPS_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
-      - name: NO_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
-{% endif %}
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloud-pi-native/git-ansible"
+      tag: "1"
+    command:
+    - /bin/sh
+    - -c
+    - |
+      git clone https://github.com/cloud-pi-native/socle.git && \
+      cd socle && \
+      ansible-playbook post-install/pgdump.yaml
 {% if dsc.global.backup.s3.endpointCA is defined %}
+    extraEnv:
       - name: AWS_CA_BUNDLE
         value: /bundle-s3-dir/ca.pem
+{% endif %}
+{% if dsc.proxy.enabled %}
+    extraEnvFrom:
+    - secretRef: 
+        name: ansible-secret
+{% endif %}
+{% if dsc.global.backup.s3.endpointCA is defined %} 
     extraVolumes:
     - name: bundle-s3
       secret:
-        secretName: bundle-cnpg-s3
+        secretName: ansible-secret
     extraVolumeMounts:
     - name: bundle-s3
       mountPath: /bundle-s3-dir
@@ -28,6 +33,5 @@ cpn-ansible-job:
 {% endif %}
   cronJob:
     create: true
-    name: "pgdump"
     schedule: "7 1 * * *"
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/harbor/Chart.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/harbor/Chart.yaml.j2
@@ -12,7 +12,7 @@ dependencies:
   alias: harbor
   version: {{ dsc.harbor.chartVersion }}
   repository: {{ dsc.harbor.helmRepoUrl }}
-- name: cpn-ansible-job
+- name: cpn-job
   alias: cpn-ansible-job
   version: {{ dsc.cpnAnsibleJob.chartVersion | quote }}
   repository: {{ dsc.cpnAnsibleJob.helmRepoUrl }}

--- a/roles/gitops/rendering-apps-files/templates/harbor/templates/secret-ansible.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/harbor/templates/secret-ansible.yaml.j2
@@ -1,21 +1,14 @@
-{% if dsc.global.backup.cnpg.enabled %}
 apiVersion: v1
 kind: Secret
 metadata:
+  name: ansible-secret
   annotations:
     avp.kubernetes.io/remove-missing: "true"
-  name: ansible-secret
 type: Opaque
-{% if dsc.global.backup.s3.endpointCA.namespace is defined and
-dsc.global.backup.s3.endpointCA.name is defined and
-dsc.global.backup.s3.endpointCA.key is defined %}
-data:
-  ca.pem: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#cnpgS3CaPem>
-{% endif %}
-{% if dsc.proxy.enabled %}
 stringData:
+  VAULT_INFRA_TOKEN: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>
+{% if dsc.proxy.enabled %}
   HTTP_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
   HTTPS_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
   NO_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
-{% endif %}
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/harbor/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/harbor/values/200-ansible-job.j2
@@ -1,17 +1,15 @@
 cpn-ansible-job:
   job:
-    name: "harbor"
-    dscName: "{{ dsc_name }}"
     image:
-      tag: "{{ dsc.cpnAnsibleJob.imageTag }}"
-    extraEnv:
-      - name: VAULT_INFRA_TOKEN
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>
-{% if dsc.proxy.enabled %}
-      - name: HTTP_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
-      - name: HTTPS_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
-      - name: NO_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
-{% endif %}
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloud-pi-native/git-ansible"
+      tag: "1"
+    command:
+    - /bin/sh
+    - -c
+    - |
+      git clone https://github.com/cloud-pi-native/socle.git && \
+      cd socle && \
+      ansible-playbook post-install/harbor.yaml
+    extraEnvFrom:
+    - secretRef: 
+        name: ansible-secret

--- a/roles/gitops/rendering-apps-files/templates/keycloak/Chart.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/Chart.yaml.j2
@@ -12,7 +12,7 @@ dependencies:
   alias: keycloak
   version: {{ dsc.keycloak.chartVersion }}
   repository: "{{ dsc.keycloak.helmRepoUrl if 'oci://' in dsc.keycloak.helmRepoUrl else dsc.keycloak.helmRepoUrl ~ '/keycloak' }}"
-- name: cpn-ansible-job
+- name: cpn-job
   alias: cpn-ansible-job
   version: {{ dsc.cpnAnsibleJob.chartVersion | quote }}
   repository: {{ dsc.cpnAnsibleJob.helmRepoUrl }}

--- a/roles/gitops/rendering-apps-files/templates/keycloak/templates/secret-ansible.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/templates/secret-ansible.yaml.j2
@@ -1,21 +1,14 @@
-{% if dsc.global.backup.cnpg.enabled %}
 apiVersion: v1
 kind: Secret
 metadata:
+  name: ansible-secret
   annotations:
     avp.kubernetes.io/remove-missing: "true"
-  name: ansible-secret
 type: Opaque
-{% if dsc.global.backup.s3.endpointCA.namespace is defined and
-dsc.global.backup.s3.endpointCA.name is defined and
-dsc.global.backup.s3.endpointCA.key is defined %}
-data:
-  ca.pem: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#cnpgS3CaPem>
-{% endif %}
-{% if dsc.proxy.enabled %}
 stringData:
+  VAULT_INFRA_TOKEN: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>
+{% if dsc.proxy.enabled %}
   HTTP_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
   HTTPS_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
   NO_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
-{% endif %}
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/200-ansible-job.j2
@@ -1,20 +1,18 @@
 cpn-ansible-job:
   job:
-    name: "keycloak"
-    dscName: "{{ dsc_name }}"
     image:
-      tag: "{{ dsc.cpnAnsibleJob.imageTag }}"
-    extraEnv:
-    - name: VAULT_INFRA_TOKEN
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>
-{% if dsc.proxy.enabled %}
-    - name: HTTP_PROXY
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
-    - name: HTTPS_PROXY
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
-    - name: NO_PROXY
-      value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
-{% endif %}
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloud-pi-native/git-ansible"
+      tag: "1"
+    command:
+    - /bin/sh
+    - -c
+    - |
+      git clone https://github.com/cloud-pi-native/socle.git && \
+      cd socle && \
+      ansible-playbook post-install/keycloak.yaml
+    extraEnvFrom:
+    - secretRef: 
+        name: ansible-secret
     extraVolumes:
     - name: users-csv
       configMap:

--- a/roles/gitops/rendering-apps-files/templates/sonarqube/Chart.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/sonarqube/Chart.yaml.j2
@@ -12,7 +12,7 @@ dependencies:
   alias: sonarqube
   version: {{ dsc.sonarqube.chartVersion }}
   repository: "{{ dsc.sonarqube.helmRepoUrl }}"
-- name: cpn-ansible-job
+- name: cpn-job
   alias: cpn-ansible-job
   version: {{ dsc.cpnAnsibleJob.chartVersion | quote }}
   repository: {{ dsc.cpnAnsibleJob.helmRepoUrl }}

--- a/roles/gitops/rendering-apps-files/templates/sonarqube/templates/secret-ansible.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/sonarqube/templates/secret-ansible.yaml.j2
@@ -1,21 +1,14 @@
-{% if dsc.global.backup.cnpg.enabled %}
 apiVersion: v1
 kind: Secret
 metadata:
+  name: ansible-secret
   annotations:
     avp.kubernetes.io/remove-missing: "true"
-  name: ansible-secret
 type: Opaque
-{% if dsc.global.backup.s3.endpointCA.namespace is defined and
-dsc.global.backup.s3.endpointCA.name is defined and
-dsc.global.backup.s3.endpointCA.key is defined %}
-data:
-  ca.pem: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#cnpgS3CaPem>
-{% endif %}
-{% if dsc.proxy.enabled %}
 stringData:
+  VAULT_INFRA_TOKEN: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>
+{% if dsc.proxy.enabled %}
   HTTP_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
   HTTPS_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
   NO_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
-{% endif %}
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/sonarqube/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/sonarqube/values/200-ansible-job.j2
@@ -1,17 +1,15 @@
 cpn-ansible-job:
   job:
-    name: "sonarqube"
-    dscName: "{{ dsc_name }}"
     image:
-      tag: "{{ dsc.cpnAnsibleJob.imageTag }}"
-    extraEnv:
-      - name: VAULT_INFRA_TOKEN
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>
-{% if dsc.proxy.enabled %}
-      - name: HTTP_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
-      - name: HTTPS_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
-      - name: NO_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
-{% endif %}
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloud-pi-native/git-ansible"
+      tag: "1"
+    command:
+    - /bin/sh
+    - -c
+    - |
+      git clone https://github.com/cloud-pi-native/socle.git && \
+      cd socle && \
+      ansible-playbook post-install/sonarqube.yaml
+    extraEnvFrom:
+    - secretRef: 
+        name: ansible-secret

--- a/roles/gitops/rendering-apps-files/templates/vault/Chart.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/vault/Chart.yaml.j2
@@ -14,7 +14,7 @@ dependencies:
   version: {{ dsc.global.backup.vault.chartVersion }}
   repository: {{ dsc.cpnAnsibleJob.helmRepoUrl }}
 {% endif %}
-- name: cpn-ansible-job
+- name: cpn-job
   alias: cpn-ansible-job
   version: {{ dsc.cpnAnsibleJob.chartVersion | quote }}
   repository: {{ dsc.cpnAnsibleJob.helmRepoUrl }}

--- a/roles/gitops/rendering-apps-files/templates/vault/templates/secret-ansible.yaml.j2
+++ b/roles/gitops/rendering-apps-files/templates/vault/templates/secret-ansible.yaml.j2
@@ -1,21 +1,14 @@
-{% if dsc.global.backup.cnpg.enabled %}
 apiVersion: v1
 kind: Secret
 metadata:
+  name: ansible-secret
   annotations:
     avp.kubernetes.io/remove-missing: "true"
-  name: ansible-secret
 type: Opaque
-{% if dsc.global.backup.s3.endpointCA.namespace is defined and
-dsc.global.backup.s3.endpointCA.name is defined and
-dsc.global.backup.s3.endpointCA.key is defined %}
-data:
-  ca.pem: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#cnpgS3CaPem>
-{% endif %}
-{% if dsc.proxy.enabled %}
 stringData:
+  VAULT_INFRA_TOKEN: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>
+{% if dsc.proxy.enabled %}
   HTTP_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
   HTTPS_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
   NO_PROXY: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
-{% endif %}
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/vault/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/vault/values/200-ansible-job.j2
@@ -1,22 +1,19 @@
 cpn-ansible-job:
   job:
-    name: "vault"
-    dscName: "{{ dsc_name }}"
     image:
-      tag: "{{ dsc.cpnAnsibleJob.imageTag }}"
-    extraEnv:
-      - name: VAULT_INFRA_TOKEN
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#vault_infra_token>
-{% if dsc.proxy.enabled %}
-      - name: HTTP_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpProxy}>
-      - name: HTTPS_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.httpsProxy}>
-      - name: NO_PROXY
-        value: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#proxy | jsonPath {.noProxy}>
-{% endif %}
+      repository: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.ghcr}>/cloud-pi-native/git-ansible"
+      tag: "1"
+    command:
+    - /bin/sh
+    - -c
+    - |
+      git clone https://github.com/cloud-pi-native/socle.git && \
+      cd socle && \
+      ansible-playbook post-install/vault.yaml
+    extraEnvFrom:
+    - secretRef: 
+        name: ansible-secret
     annotations:
       argocd.argoproj.io/hook: Sync
   cronJob:
     create: true
-    name: "vault"

--- a/roles/socle-config/files/config.yaml
+++ b/roles/socle-config/files/config.yaml
@@ -49,7 +49,6 @@ spec:
     values: {}
   cpnAnsibleJob:
     helmRepoUrl: https://cloud-pi-native.github.io/helm-charts
-    imageTag: 1
     values: {}
   dashboard: {}
   gitlab:

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -420,11 +420,6 @@ spec:
                     chartVersion:
                       description: Cloud-Pi-Native helm chart version (e.g., "1.0.0").
                       type: string
-                    imageTag:
-                      description: |
-                        Git-ansible image tag (e.g., "1.1.0").
-                        https://github.com/cloud-pi-native/Dockerfile/blob/main/docker/git-ansible/Dockerfile
-                      type: string
                     values:
                       description: |
                         You can add custom values for cpn-ansible-job, they will be merged with roles/gitops/rendering-apps-files/

--- a/versions.md
+++ b/versions.md
@@ -6,7 +6,7 @@
 | cloudnativepg.cluster     | N/A              | 0.3.1         | [cluster](https://artifacthub.io/packages/helm/cloudnative-pg/cluster)                                               |
 | cloudnativepg.operator    | 1.26.1           | 0.25.0        | [cloudnative-pg](https://artifacthub.io/packages/helm/cloudnative-pg/cloudnative-pg)                                 |
 | console                   | 9.\*.\*          | 2.\*.\*       | [console](https://github.com/cloud-pi-native/helm-charts)                                                            |
-| cpn-ansible-job           | 1.\*.\*            | 1.\*.\*         | [cpn-ansible-job](https://github.com/cloud-pi-native/helm-charts)                                                    |
+| cpn-job                   | 1.\*.\*          | 1.\*.\*       | [cpn-job](https://github.com/cloud-pi-native/helm-charts)                                                            |
 | gitlab                    | 18.4.1         | 9.4.1       | [gitlab](https://artifacthub.io/packages/helm/gitlab/gitlab)                                                         |
 | glexporter | 0.5.10           | 0.3.5         | [glexporter](https://github.com/mvisonneau/helm-charts/tree/main/charts/gitlab-ci-pipelines-exporter) |
 | gitlabOperator            | 2.4.1           | 2.4.1        | [gitlabOperator](https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/tags)                                  |


### PR DESCRIPTION
## Issues liées

Closes: https://github.com/cloud-pi-native/helm-charts/issues/161

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Sensitive ENV vars are passed with `env:` which is considered insecure (visible with a `kubectl describe po)`.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Sensitive ENV vars are pulled from secrets.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
No.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
Also, we are moving from `cpn-ansible-job` chart to more generic `cpn-job` chart.