### PR TITLE
fix: :art: Vault serverTelemetry values

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/vault/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/vault/values/00-main.j2
@@ -1,17 +1,6 @@
 vault:
   fullnameOverride: "{{ dsc_name }}-vault"
 {% if dsc.global.metrics.enabled %}
-  serverTelemetry:
-    serviceMonitor:
-      enabled: true
-      authorization:
-        credentials:
-          name: {{ dsc_name }}-vault-keys
-          key: root_token
-{% if dsc.global.metrics.additionalLabels is defined %}
-      selectors:
-        labels: {{ dsc.global.metrics.additionalLabels }}
-{% endif %}
   global:
     serverTelemetry:
       prometheusOperator: true

--- a/roles/gitops/rendering-apps-files/vars/main.yaml
+++ b/roles/gitops/rendering-apps-files/vars/main.yaml
@@ -231,6 +231,11 @@ values:
       serverTelemetry:
         serviceMonitor:
           enabled: {{ (dsc.global.metrics.enabled or dsc.global.alerting.enabled) | lower }}
+          authorization:
+            credentials:
+              name: {{ dsc_name }}-vault-keys
+              key: root_token
+          selectors: {{ dsc.global.metrics.additionalLabels | default ('{}', true) }}
         prometheusRules:
           enabled: {{ (dsc.global.metrics.enabled or dsc.global.alerting.enabled) | lower }}
           rules:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Nous positionnons les values de serverTelemetry pour Vault depuis deux fichiers sources distincts : un template Jinja2 et un fichier de variables.
Il en résulte à l'arrivée un doublon de la clé `serverTelemetry` dans les values du chart de Vault.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous retirons la clé `serverTelemetry` du template Jinja2 et positionnons les values requises dans le fichier de variables.

Nous corrigeons au passage la clé `serverTelemetry.serviceMonitor.selectors` qui était erronée.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement de rendu des values validé, et application testée dans un cluster de développement.