### PR TITLE
fix: :bug: add missing cert-manager installation

### DIFF
--- a/install-gitops.yaml
+++ b/install-gitops.yaml
@@ -31,6 +31,13 @@
     - role: cloudnativepg
       tags:
         - cloudnativepg
+        - cnpg
+        - never
+
+    - role: cert-manager
+      tags:
+        - cert-manager
+        - cm
         - never
 
     - role: infra/keycloak-infra


### PR DESCRIPTION
## Issues liées

Issues numéro: #792

---

## Quel est le comportement actuel ?
Il n'y a, pour le moment, plus moyen d'installer cert-manager quand bien même le role ait été gardé.

## Quel est le nouveau comportement ?
Il est de nouveau possible d'installer cert-manager comme suit:
```sh
ansible-playbook install-gitops.yaml -t cert-manager
```

## Cette PR introduit-elle un breaking change ?
Non, au contraire elle réintroduit la possibilité d'installer cert-manager

## Autres informations
J'avais ajouté deux commentaires dans l'issue liée, mais l'issue a été fermé sans qu'ils ne soient pris en compte !