### PR TITLE
Fix usage of Vault infra token before retrieval

### DIFF
--- a/admin-tools/get-credentials.yaml
+++ b/admin-tools/get-credentials.yaml
@@ -3,7 +3,6 @@
   hosts: localhost
   gather_facts: false
   tasks:
-
     - name: Display tags list
       ansible.builtin.debug:
         msg:
@@ -208,7 +207,7 @@
         - name: Display Keycloak infra admin credentials
           ansible.builtin.debug:
             msg:
-              - "URL : https://{{ dsc.keycloakInfra.subDomain }}{{ dsc.global.rootDomain }} "
+              - "URL : https://{{ dsc.keycloakInfra.subDomain }}{{ dsc.global.infraRootDomain }} "
               - "Admin username: admininfra "
               - "Admin password: {{ keycloak_infra_admin_creds.resources[0].data['admin-password'] | b64decode }} "
 
@@ -284,32 +283,32 @@
       tags:
         - vault
 
-    - name: Get Vault Infra secrets
+    - name: Fetch Vault infra keys and token from infra Kubernetes cluster
       when: vault_infra_pods.resources | length > 0
       tags:
         - vault-infra
-      ignore_errors: true
       block:
-        - name: Get Vault Infra secrets
+        - name: Retrieve all secrets in the Vault infra namespace
           kubernetes.core.k8s_info:
             namespace: "{{ dsc.vaultInfra.namespace }}"
             kind: Secret
           register: vault_infra_secrets
 
-        - name: Set vault_infra_keys_secret_name
+        - name: Extract the name of the Vault keys secret
           ansible.builtin.set_fact:
             vault_infra_keys_secret_name: "{{ vault_infra_secrets.resources
               | selectattr('metadata.name', 'contains', 'vault-keys')
-              | map(attribute='metadata.name') | first }}"
+              | map(attribute='metadata.name')
+              | first | default('') }}"
 
-        - name: Get Vault Infra keys
-          kubernetes.core.k8s_info:
-            namespace: "{{ dsc.vaultInfra.namespace }}"
-            kind: Secret
-            name: "{{ vault_infra_keys_secret_name }}"
-          register: vault_infra_keys
+        - name: Error when Vault infra keys secret not found
+          when: vault_infra_keys_secret_name | length == 0
+          ansible.builtin.fail:
+            msg: "Vault infra keys secret not found. Please ensure Vault infra is initialized and unsealed."
+          ignore_errors: true # needed to display error and continue playbook execution if secret is not found
 
-        - name: Get Vault infra unseal keys and root token
+        - name: Fetch the Vault infra keys secret
+          when: vault_infra_keys_secret_name | length > 0
           kubernetes.core.k8s_info:
             namespace: "{{ dsc.vaultInfra.namespace }}"
             kind: Secret
@@ -317,9 +316,10 @@
           register: vault_infra_keys
 
         - name: Display Vault infra URL, root token and unseal keys
+          when: vault_infra_keys_secret_name | length > 0
           ansible.builtin.debug:
             msg:
-              - "URL: https://{{ dsc.vaultInfra.subDomain }}{{ dsc.global.rootDomain }} "
+              - "URL: https://{{ dsc.vaultInfra.subDomain }}{{ dsc.global.infraRootDomain }} "
               - "root_token: {{ vault_infra_keys.resources[0].data.root_token | b64decode }} "
               - "key1: {{ vault_infra_keys.resources[0].data.key1 | b64decode }} "
               - "key2: {{ vault_infra_keys.resources[0].data.key2 | b64decode }} "
@@ -328,7 +328,7 @@
         - name: Display Vault infra URL with OIDC method and credentials
           ansible.builtin.debug:
             msg:
-              - "URL: https://{{ dsc.vaultInfra.subDomain }}{{ dsc.global.rootDomain }}/ui/vault/auth?with=oidc "
+              - "URL: https://{{ dsc.vaultInfra.subDomain }}{{ dsc.global.infraRootDomain }}/ui/vault/auth?with=oidc "
               - "Admin username: {{ keycloak_infra_user }} "
               - "Admin password: {{ keycloak_infra_user_password }} "
 
@@ -366,7 +366,7 @@
       when: argocd_infra_pods.resources | length > 0
       ansible.builtin.debug:
         msg:
-          - "URL: https://{{ dsc.argocdInfra.subDomain }}{{ dsc.global.rootDomain }} "
+          - "URL: https://{{ dsc.argocdInfra.subDomain }}{{ dsc.global.infraRootDomain }} "
           - "Admin username: {{ keycloak_infra_user }} "
           - "Admin password: {{ keycloak_infra_user_password }} "
       tags:

--- a/admin-tools/get-credentials.yaml
+++ b/admin-tools/get-credentials.yaml
@@ -149,8 +149,14 @@
         - vault-infra
         - keycloak-infra
       block:
+        - name: Set infra kubeconfig facts
+          ansible.builtin.include_role:
+            name: gitops/local-config
+
         - name: Check Keycloak infra pods
           kubernetes.core.k8s_info:
+            kubeconfig: "{{ kubeconfig_infra }}"
+            proxy: "{{ kubeconfig_proxy_infra | default(omit) }}"
             namespace: "{{ dsc.keycloakInfra.namespace }}"
             kind: Pod
             label_selectors:
@@ -159,6 +165,8 @@
 
         - name: Check Argo CD infra pods
           kubernetes.core.k8s_info:
+            kubeconfig: "{{ kubeconfig_infra }}"
+            proxy: "{{ kubeconfig_proxy_infra | default(omit) }}"
             namespace: "{{ dsc.argocdInfra.namespace }}"
             kind: Pod
             label_selectors:
@@ -167,6 +175,8 @@
 
         - name: Check Vault infra pods
           kubernetes.core.k8s_info:
+            kubeconfig: "{{ kubeconfig_infra }}"
+            proxy: "{{ kubeconfig_proxy_infra | default(omit) }}"
             namespace: "{{ dsc.vaultInfra.namespace }}"
             kind: Pod
             label_selectors:
@@ -182,6 +192,8 @@
       block:
         - name: Get Keycloak Infra user credentials
           kubernetes.core.k8s_info:
+            kubeconfig: "{{ kubeconfig_infra }}"
+            proxy: "{{ kubeconfig_proxy_infra | default(omit) }}"
             namespace: "{{ dsc.keycloakInfra.namespace }}"
             kind: Secret
             name: infra-admin-user-secret
@@ -199,6 +211,8 @@
       block:
         - name: Get Keycloak Infra admin credentials
           kubernetes.core.k8s_info:
+            kubeconfig: "{{ kubeconfig_infra }}"
+            proxy: "{{ kubeconfig_proxy_infra | default(omit) }}"
             namespace: "{{ dsc.keycloakInfra.namespace }}"
             kind: Secret
             name: keycloak
@@ -283,40 +297,19 @@
       tags:
         - vault
 
-    - name: Fetch Vault infra keys and token from infra Kubernetes cluster
-      when: vault_infra_pods.resources | length > 0
+    - name: Get Vault infra unseal keys and root token
       tags:
         - vault-infra
       block:
-        - name: Retrieve all secrets in the Vault infra namespace
-          kubernetes.core.k8s_info:
-            namespace: "{{ dsc.vaultInfra.namespace }}"
-            kind: Secret
-          register: vault_infra_secrets
-
-        - name: Extract the name of the Vault keys secret
-          ansible.builtin.set_fact:
-            vault_infra_keys_secret_name: "{{ vault_infra_secrets.resources
-              | selectattr('metadata.name', 'contains', 'vault-keys')
-              | map(attribute='metadata.name')
-              | first | default('') }}"
-
-        - name: Error when Vault infra keys secret not found
-          when: vault_infra_keys_secret_name | length == 0
-          ansible.builtin.fail:
-            msg: "Vault infra keys secret not found. Please ensure Vault infra is initialized and unsealed."
-          ignore_errors: true # needed to display error and continue playbook execution if secret is not found
-
-        - name: Fetch the Vault infra keys secret
-          when: vault_infra_keys_secret_name | length > 0
-          kubernetes.core.k8s_info:
-            namespace: "{{ dsc.vaultInfra.namespace }}"
-            kind: Secret
-            name: "{{ vault_infra_keys_secret_name }}"
-          register: vault_infra_keys
+        - name: Fetch Vault infra keys and token from infra Kubernetes cluster
+          ansible.builtin.include_role:
+            name: shared_tasks
+          vars:
+            shared_tasks_run: fetch-vault-infra-keys.yaml
+            get_credentials_playbook: true # allows playbook to continue even when Vault infra keys are not be found
 
         - name: Display Vault infra URL, root token and unseal keys
-          when: vault_infra_keys_secret_name | length > 0
+          when: vault_infra_keys.resources is defined
           ansible.builtin.debug:
             msg:
               - "URL: https://{{ dsc.vaultInfra.subDomain }}{{ dsc.global.infraRootDomain }} "

--- a/install-gitops.yaml
+++ b/install-gitops.yaml
@@ -4,6 +4,10 @@
   gather_facts: false
 
   roles:
+    - role: gitops/local-config
+      tags:
+        - always
+
     - role: socle-config
       tags:
         - always
@@ -57,13 +61,6 @@
         - argocd-infra
         - argo-infra
       when: dsc.argocdInfra.installEnabled
-
-    - role: gitops/local-config
-      tags:
-        - rendering-apps-files
-        - apps-files
-        - dso-app
-        - vault-secrets
 
     - role: gitops/vault-secrets
       tags:

--- a/roles/gitops/dso-app/tasks/main.yaml
+++ b/roles/gitops/dso-app/tasks/main.yaml
@@ -3,7 +3,7 @@
   when: argo_infra_ns_check.resources is defined and not (argo_infra_ns_check.resources | length == 0)
   kubernetes.core.k8s:
     kubeconfig: "{{ kubeconfig_infra }}"
-    proxy: "{{ kubeconfig_proxy_infra | default('') }}"
+    proxy: "{{ kubeconfig_proxy_infra | default(omit) }}"
     namespace: "{{ dsc.argocdInfra.namespace }}"
     definition: "{{ lookup('ansible.builtin.template', role_path + '/templates/dso-app.yaml.j2') | from_yaml }}"
     state: present

--- a/roles/gitops/local-config/tasks/main.yaml
+++ b/roles/gitops/local-config/tasks/main.yaml
@@ -1,5 +1,5 @@
 - name: Check GitOps repository local clone
-  when: lookup('ansible.builtin.env', 'GITOPS_REPO_PATH') == ''
+  when: lookup('ansible.builtin.env', 'GITOPS_REPO_PATH') | length == 0
   block:
     - name: Missing "GITOPS_REPO_PATH" environment variable
       ansible.builtin.debug:
@@ -16,7 +16,7 @@
     gitops_local_repo: "{{ lookup('ansible.builtin.env', 'GITOPS_REPO_PATH') }}"
 
 - name: Check infrastructure cluster access
-  when: lookup('ansible.builtin.env', 'KUBECONFIG_INFRA') == ''
+  when: lookup('ansible.builtin.env', 'KUBECONFIG_INFRA') | length == 0
   block:
     - name: Missing "KUBECONFIG_INFRA" environment variable
       ansible.builtin.debug:
@@ -32,7 +32,7 @@
     kubeconfig_infra: "{{ lookup('ansible.builtin.env', 'KUBECONFIG_INFRA') }}"
 
 - name: Check infrastructure cluster access
-  when: lookup('ansible.builtin.env', 'KUBECONFIG_PROXY_INFRA') == ''
+  when: lookup('ansible.builtin.env', 'KUBECONFIG_PROXY_INFRA') | length == 0
   block:
     - name: Undefined "KUBECONFIG_PROXY_INFRA" environment variable
       ansible.builtin.debug:
@@ -42,6 +42,6 @@
           - "Dans ce cas, veuillez la définir avec la valeur requises pour accéder au cluster d'admnistration (Argo CD et Vault d'infra)."
 
 - name: "Déclaration du kubeconfig proxy infra"
-  when: lookup('ansible.builtin.env', 'KUBECONFIG_PROXY_INFRA') != ''
+  when: lookup('ansible.builtin.env', 'KUBECONFIG_PROXY_INFRA') | length > 0
   ansible.builtin.set_fact:
     kubeconfig_proxy_infra: "{{ lookup('ansible.builtin.env', 'KUBECONFIG_PROXY_INFRA') }}"

--- a/roles/gitops/post-install/gitlab/tasks/main.yaml
+++ b/roles/gitops/post-install/gitlab/tasks/main.yaml
@@ -190,42 +190,15 @@
         protected: "{{ item.protected }}"
   with_items: "{{ dsc.gitlab.extraCIVars }}"
 
-# Retrieve Vault Infra token
-
-- name: Get Vault Infra token
-  when: lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') != ''
-  ansible.builtin.set_fact:
-    vault_infra_token: "{{ lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') }}"
-
-- name: Get Vault Infra keys and token
-  when: lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') == ''
-  block:
-    - name: Get Vault Infra secrets
-      kubernetes.core.k8s_info:
-        kubeconfig: "{{ kubeconfig_infra }}"
-        proxy: "{{ kubeconfig_proxy_infra | default('') }}"
-        namespace: "{{ dsc.vaultInfra.namespace }}"
-        kind: Secret
-      register: vault_infra_secrets
-
-    - name: Set vault_infra_keys_secret_name
-      ansible.builtin.set_fact:
-        vault_infra_keys_secret_name: "{{ vault_infra_secrets.resources
-          | selectattr('metadata.name', 'contains', 'vault-keys')
-          | map(attribute='metadata.name') | first }}"
-
-    - name: Get Vault Infra keys
-      kubernetes.core.k8s_info:
-        kubeconfig: "{{ kubeconfig_infra }}"
-        proxy: "{{ kubeconfig_proxy_infra | default('') }}"
-        namespace: "{{ dsc.vaultInfra.namespace }}"
-        kind: Secret
-        name: "{{ vault_infra_keys_secret_name }}"
-      register: vault_infra_keys
-
-    - name: Get Vault Infra token
-      ansible.builtin.set_fact:
-        vault_infra_token: "{{ vault_infra_keys.resources[0].data.root_token | b64decode }}"
+- name: Wait gitlab-webservice-default endpoint
+  kubernetes.core.k8s_info:
+    kind: Endpoints
+    namespace: "{{ dsc.gitlab.namespace }}"
+    name: gitlab-webservice-default
+  register: endpoint
+  until: endpoint.resources[0].subsets[0].addresses[0] is defined
+  retries: 15
+  delay: 5
 
 - name: Get runner token from infra Vault
   block:

--- a/roles/gitops/post-install/sonarqube/tasks/main.yaml
+++ b/roles/gitops/post-install/sonarqube/tasks/main.yaml
@@ -55,43 +55,6 @@
   retries: 45
   delay: 5
 
-# Retrieve Vault Infra token
-
-- name: Get Vault Infra token
-  when: lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') != ''
-  ansible.builtin.set_fact:
-    vault_infra_token: "{{ lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') }}"
-
-- name: Get Vault Infra keys and token
-  when: lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') == ''
-  block:
-    - name: Get Vault Infra secrets
-      kubernetes.core.k8s_info:
-        kubeconfig: "{{ kubeconfig_infra }}"
-        proxy: "{{ kubeconfig_proxy_infra | default('') }}"
-        namespace: "{{ dsc.vaultInfra.namespace }}"
-        kind: Secret
-      register: vault_infra_secrets
-
-    - name: Set vault_infra_keys_secret_name
-      ansible.builtin.set_fact:
-        vault_infra_keys_secret_name: "{{ vault_infra_secrets.resources
-          | selectattr('metadata.name', 'contains', 'vault-keys')
-          | map(attribute='metadata.name') | first }}"
-
-    - name: Get Vault Infra keys
-      kubernetes.core.k8s_info:
-        kubeconfig: "{{ kubeconfig_infra }}"
-        proxy: "{{ kubeconfig_proxy_infra | default('') }}"
-        namespace: "{{ dsc.vaultInfra.namespace }}"
-        kind: Secret
-        name: "{{ vault_infra_keys_secret_name }}"
-      register: vault_infra_keys
-
-    - name: Get Vault Infra token
-      ansible.builtin.set_fact:
-        vault_infra_token: "{{ vault_infra_keys.resources[0].data.root_token | b64decode }}"
-
 - name: Get sonarApiToken from infra Vault
   block:
     - name: Retrieve SonarQube values from infra Vault

--- a/roles/gitops/post-install/vault/tasks/join_and_unseal_node.yml
+++ b/roles/gitops/post-install/vault/tasks/join_and_unseal_node.yml
@@ -1,0 +1,31 @@
+---
+- name: "Process node {{ vault_node_index }}"
+  vars:
+    vault_pod: "{{ dsc_name }}-vault-{{ vault_node_index }}"
+  block:
+    # Join node to Vault cluster
+    - name: "Check vault-{{ vault_node_index }} status"
+      ansible.builtin.include_tasks: check.yml
+
+    - name: "Join vault-{{ vault_node_index }} node to cluster"
+      when: vault_status == 'not init'
+      kubernetes.core.k8s_exec:
+        container: vault
+        pod: "{{ vault_pod }}"
+        namespace: "{{ dsc.vault.namespace }}"
+        command: vault operator raft join http://"{{ dsc_name }}"-vault-0."{{ dsc_name }}"-vault-internal:8200
+      register: "node_join_state_{{ vault_node_index }}"
+      retries: 3
+      delay: 20
+
+    # Unseal node
+    - name: "Check vault-{{ vault_node_index }} status again"
+      ansible.builtin.include_tasks: check.yml
+
+    - name: Set seal count
+      ansible.builtin.set_fact:
+        unseal_key_index: "0"
+
+    - name: "Unseal vault node {{ vault_node_index }}"
+      when: vault_status == 'not init' or vault_status == 'sealed'
+      ansible.builtin.include_tasks: unseal.yml

--- a/roles/gitops/post-install/vault/tasks/join_and_unseal_node.yml
+++ b/roles/gitops/post-install/vault/tasks/join_and_unseal_node.yml
@@ -14,7 +14,6 @@
         pod: "{{ vault_pod }}"
         namespace: "{{ dsc.vault.namespace }}"
         command: vault operator raft join http://"{{ dsc_name }}"-vault-0."{{ dsc_name }}"-vault-internal:8200
-      register: "node_join_state_{{ vault_node_index }}"
       retries: 3
       delay: 20
 

--- a/roles/gitops/post-install/vault/tasks/main.yml
+++ b/roles/gitops/post-install/vault/tasks/main.yml
@@ -1,11 +1,10 @@
 ---
-# Find Vault keys
 - name: Find vault keys
   kubernetes.core.k8s_info:
     namespace: "{{ dsc.vault.namespace }}"
     kind: Secret
     name: "{{ dsc_name }}-vault-keys"
-  register: vaut_keys
+  register: vault_keys
 
 # Check Vault status - node 1
 - name: Check vault status - node 1
@@ -16,11 +15,17 @@
 - name: Check if vault is coherent
   ansible.builtin.assert:
     that:
-      - ((vault_status in ['sealed', 'OK']) and (vaut_keys.resources | length > 0)) or ((vault_status == 'not init') and (vaut_keys.resources | length == 0))
+      - (vault_status in ['sealed', 'OK']) and (vault_keys.resources | length > 0)
     fail_msg:
-      - Attention ! Soit le vault n'est pas initialisé mais vous avez un secret {{ dsc_name }}-vault-keys dans {{ dsc.vault.namespace }}
+      - Attention ! Vault n'est pas initialisé mais vous avez un secret {{ dsc_name }}-vault-keys dans {{ dsc.vault.namespace }}
       - Veuillez le supprimer et relancer si vous souhaitez lancer une initialisation
-      - Soit le vault est initialisé mais vous n'avez pas de secret {{ dsc_name }}-vault-keys dans {{ dsc.vault.namespace }}, et c'est inquiétant !
+
+- name: Check if vault is coherent
+  ansible.builtin.assert:
+    that:
+      - (vault_status == 'not init') and (vault_keys.resources | length == 0)
+    fail_msg:
+      - Attention ! Vault est initialisé mais vous n'avez pas de secret {{ dsc_name }}-vault-keys dans {{ dsc.vault.namespace }}. C'est inquiétant !
 
 # Init Vault - node 1
 - name: Init vault node - node 1
@@ -57,7 +62,7 @@
       | map(attribute='value') | first }}"
 
 - name: Store vault keys and token
-  when: vaut_keys.resources | length == 0
+  when: vault_keys.resources | length == 0
   kubernetes.core.k8s:
     definition:
       kind: Secret
@@ -71,115 +76,8 @@
         root_token: "{{ root_token | b64encode }}"
         init_config: "{{ init.stdout | from_json | b64encode }}"
 
-# Unseal Vault - node 1
-- name: Set seal count - node 1
-  ansible.builtin.set_fact:
-    vault_pod: "{{ dsc_name }}-vault-0"
-    unseal_key_index: "0"
-
 - name: Get vault keys
-  kubernetes.core.k8s_info:
-    namespace: "{{ dsc.vault.namespace }}"
-    kind: Secret
-    name: "{{ dsc_name }}-vault-keys"
-  register: vault_keys
-
-- name: Unseal vault primary - node 1
-  when: vault_status == 'not init' or vault_status == 'sealed'
-  ansible.builtin.include_tasks: unseal.yml
-  vars:
-    vault_pod: "{{ dsc_name }}-vault-0"
-
-- name: Join and unseal node 2
-  when: vault_values.vault.server.ha.enabled
-  block:
-    # Join node 2 to Vault cluster
-    - name: Check vault-1 status - node 2
-      ansible.builtin.include_tasks: check.yml
-      vars:
-        vault_pod: "{{ dsc_name }}-vault-1"
-
-    - name: Join vault-1 node to cluster - node 2
-      when: vault_status == 'not init'
-      kubernetes.core.k8s_exec:
-        container: vault
-        pod: "{{ dsc_name }}-vault-1"
-        namespace: "{{ dsc.vault.namespace }}"
-        command: vault operator raft join http://"{{ dsc_name }}"-vault-0."{{ dsc_name }}"-vault-internal:8200
-      register: node2_join_state
-      retries: 3
-      delay: 20
-
-    # Unseal node 2
-    - name: Check vault-1 status - node 2
-      ansible.builtin.include_tasks: check.yml
-      vars:
-        vault_pod: "{{ dsc_name }}-vault-1"
-
-    - name: Set seal count - node 2
-      ansible.builtin.set_fact:
-        vault_pod: "{{ dsc_name }}-vault-1"
-        unseal_key_index: "0"
-
-    - name: Get vault keys
-      kubernetes.core.k8s_info:
-        namespace: "{{ dsc.vault.namespace }}"
-        kind: Secret
-        name: "{{ dsc_name }}-vault-keys"
-      register: vault_keys
-
-    - name: Unseal vault node - node 2
-      when: vault_status == 'not init' or vault_status == 'sealed'
-      ansible.builtin.include_tasks: unseal.yml
-      vars:
-        vault_pod: "{{ dsc_name }}-vault-1"
-
-- name: Join and unseal node 3
-  when: vault_values.vault.server.ha.enabled
-  block:
-    # Join node 3 to Vault cluster
-    - name: Check vault-2 status - node 3
-      ansible.builtin.include_tasks: check.yml
-      vars:
-        vault_pod: "{{ dsc_name }}-vault-2"
-
-    - name: Join vault-2 to cluster - node 3
-      when: vault_status == 'not init'
-      kubernetes.core.k8s_exec:
-        container: vault
-        pod: "{{ dsc_name }}-vault-2"
-        namespace: "{{ dsc.vault.namespace }}"
-        command: vault operator raft join http://"{{ dsc_name }}"-vault-0."{{ dsc_name }}"-vault-internal:8200
-      register: node3_join_state
-      retries: 3
-      delay: 20
-
-    # Unseal node 3
-    - name: Check vault-2 status - node 3
-      ansible.builtin.include_tasks: check.yml
-      vars:
-        vault_pod: "{{ dsc_name }}-vault-2"
-
-    - name: Set seal count - node 3
-      ansible.builtin.set_fact:
-        vault_pod: "{{ dsc_name }}-vault-2"
-        unseal_key_index: "0"
-
-    - name: Get vault keys
-      kubernetes.core.k8s_info:
-        namespace: "{{ dsc.vault.namespace }}"
-        kind: Secret
-        name: "{{ dsc_name }}-vault-keys"
-      register: vault_keys
-
-    - name: Unseal vault node - node 3
-      when: vault_status == 'not init' or vault_status == 'sealed'
-      ansible.builtin.include_tasks: unseal.yml
-      vars:
-        vault_pod: "{{ dsc_name }}-vault-2"
-
-# Retrieve Vault token
-- name: Get Vault keys
+  when: vault_keys.resources | length == 0
   kubernetes.core.k8s_info:
     namespace: "{{ dsc.vault.namespace }}"
     kind: Secret
@@ -189,6 +87,21 @@
 - name: Get Vault token
   ansible.builtin.set_fact:
     vault_token: "{{ vault_keys.resources[0].data.root_token | b64decode }}"
+
+# Unseal Vault
+- name: Unseal vault primary - node 1
+  when: vault_status == 'not init' or vault_status == 'sealed'
+  ansible.builtin.include_tasks: unseal.yml
+  vars:
+    vault_pod: "{{ dsc_name }}-vault-0"
+    unseal_key_index: "0"
+
+- name: Join and unseal other nodes
+  when: vault_values.vault.server.ha.enabled
+  ansible.builtin.include_tasks: join_and_unseal_node.yml
+  loop: "{{ range(1, 3) | list }}"
+  loop_control:
+    loop_var: vault_node_index
 
 # Create kv engine
 - name: Get kv engines

--- a/roles/gitops/post-install/vault/tasks/main.yml
+++ b/roles/gitops/post-install/vault/tasks/main.yml
@@ -12,20 +12,18 @@
   vars:
     vault_pod: "{{ dsc_name }}-vault-0"
 
-- name: Check if vault is coherent
+- name: Check if Vault is coherent
   ansible.builtin.assert:
     that:
-      - (vault_status in ['sealed', 'OK']) and (vault_keys.resources | length > 0)
-    fail_msg:
-      - Attention ! Vault n'est pas initialisé mais vous avez un secret {{ dsc_name }}-vault-keys dans {{ dsc.vault.namespace }}
-      - Veuillez le supprimer et relancer si vous souhaitez lancer une initialisation
-
-- name: Check if vault is coherent
-  ansible.builtin.assert:
-    that:
-      - (vault_status == 'not init') and (vault_keys.resources | length == 0)
-    fail_msg:
-      - Attention ! Vault est initialisé mais vous n'avez pas de secret {{ dsc_name }}-vault-keys dans {{ dsc.vault.namespace }}. C'est inquiétant !
+      - ((vault_status in ['sealed', 'OK']) and (vault_keys.resources | length > 0)) or ((vault_status == 'not init') and (vault_keys.resources | length == 0))
+    fail_msg: >
+      {% if vault_status == 'not init' %}
+      Attention ! Vault n'est pas initialisé mais vous avez un secret {{ dsc_name }}-vault-keys dans le namespace : {{ dsc.vault.namespace }}
+      Veuillez le supprimer et relancer si vous souhaitez lancer une initialisation
+      {% else %}
+      Attention ! Vault est initialisé mais vous n'avez pas de secret {{ dsc_name }}-vault-keys dans le namespace : {{ dsc.vault.namespace }}
+      C'est inquiétant !
+      {% endif %}
 
 # Init Vault - node 1
 - name: Init vault node - node 1
@@ -77,7 +75,6 @@
         init_config: "{{ init.stdout | from_json | b64encode }}"
 
 - name: Get vault keys
-  when: vault_keys.resources | length == 0
   kubernetes.core.k8s_info:
     namespace: "{{ dsc.vault.namespace }}"
     kind: Secret
@@ -87,6 +84,7 @@
 - name: Get Vault token
   ansible.builtin.set_fact:
     vault_token: "{{ vault_keys.resources[0].data.root_token | b64decode }}"
+    unseal_key_index: "0" # will not increment if defined in "vars" of unseal task
 
 # Unseal Vault
 - name: Unseal vault primary - node 1
@@ -94,12 +92,11 @@
   ansible.builtin.include_tasks: unseal.yml
   vars:
     vault_pod: "{{ dsc_name }}-vault-0"
-    unseal_key_index: "0"
 
 - name: Join and unseal other nodes
   when: vault_values.vault.server.ha.enabled
   ansible.builtin.include_tasks: join_and_unseal_node.yml
-  loop: "{{ range(1, 3) | list }}"
+  loop: "{{ range(1, 3) | list }}" # nodes index 1 and 2
   loop_control:
     loop_var: vault_node_index
 
@@ -113,6 +110,8 @@
     headers:
       "X-Vault-Token": "{{ vault_token }}"
   register: get_engines
+  retries: 3
+  delay: 5
 
 - name: Create default 'forge-dso/' kv engine
   when: get_engines.status == 400

--- a/roles/gitops/rendering-apps-files/templates/awx/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/awx/values/200-ansible-job.j2
@@ -10,10 +10,10 @@ cpn-ansible-job:
       git clone https://github.com/cloud-pi-native/socle.git && \
       cd socle && \
       ansible-playbook post-install/awx-oidc.yaml
+{% if dsc.proxy.enabled %}
     extraEnvFrom:
     - secretRef: 
         name: ansible-secret
-{% if dsc.proxy.enabled %}
     extraEnv:
     - name: GIT_HTTP_PROXY_AUTHMETHOD
       value: basic

--- a/roles/gitops/vault-secrets/tasks/argocd.yml
+++ b/roles/gitops/vault-secrets/tasks/argocd.yml
@@ -2,7 +2,7 @@
 - name: Hard refresh argocd applications
   kubernetes.core.k8s:
     kubeconfig: "{{ kubeconfig_infra }}"
-    proxy: "{{ kubeconfig_proxy_infra | default('') }}"
+    proxy: "{{ kubeconfig_proxy_infra | default(omit) }}"
     kind: Application
     api_version: argoproj.io/v1alpha1
     name: "{{ item }}"
@@ -16,7 +16,7 @@
 - name: Sync argocd applications
   kubernetes.core.k8s:
     kubeconfig: "{{ kubeconfig_infra }}"
-    proxy: "{{ kubeconfig_proxy_infra | default('') }}"
+    proxy: "{{ kubeconfig_proxy_infra | default(omit) }}"
     kind: Application
     api_version: argoproj.io/v1alpha1
     name: "{{ item }}"

--- a/roles/gitops/vault-secrets/tasks/main.yaml
+++ b/roles/gitops/vault-secrets/tasks/main.yaml
@@ -1,60 +1,9 @@
 ---
-# Retrieve Vault infra token
-- name: Set Vault infra token fact from environment variable
-  when: lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') | length > 0
-  ansible.builtin.set_fact:
-    vault_infra_token: "{{ lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') }}"
-
-- name: Set Vault infra token fact from Kubernetes secret when environment variable not set
-  when: lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') | length == 0
-  block:
-    - name: Check Vault infra pods
-      kubernetes.core.k8s_info:
-        kubeconfig: "{{ kubeconfig_infra }}"
-        proxy: "{{ kubeconfig_proxy_infra | default(omit) }}"
-        namespace: "{{ dsc.vaultInfra.namespace }}"
-        kind: Pod
-        label_selectors:
-          - app.kubernetes.io/name = vault
-      register: vault_infra_pods
-
-    - name: Fetch Vault infra keys and token from infra Kubernetes cluster
-      when: vault_infra_pods.resources | length > 0
-      block:
-        - name: Retrieve all secrets in the Vault infra namespace
-          kubernetes.core.k8s_info:
-            kubeconfig: "{{ kubeconfig_infra }}"
-            proxy: "{{ kubeconfig_proxy_infra | default(omit) }}"
-            namespace: "{{ dsc.vaultInfra.namespace }}"
-            kind: Secret
-          register: vault_infra_secrets
-
-        - name: Extract the name of the Vault keys secret
-          ansible.builtin.set_fact:
-            vault_infra_keys_secret_name: "{{ vault_infra_secrets.resources
-              | selectattr('metadata.name', 'contains', 'vault-keys')
-              | map(attribute='metadata.name')
-              | first | default('') }}"
-
-        - name: Fail if Vault infra keys secret not found (unless vault-infra role is executed)
-          when: vault_infra_keys_secret_name | length == 0 and 'vault-infra' not in ansible_run_tags or not dsc.vaultInfra.installEnabled
-          ansible.builtin.fail:
-            msg: "Vault infra keys secret not found. Please ensure Vault infra is initialized and unsealed."
-
-        - name: Fetch the Vault infra keys secret
-          when: vault_infra_keys_secret_name | length > 0
-          kubernetes.core.k8s_info:
-            kubeconfig: "{{ kubeconfig_infra }}"
-            proxy: "{{ kubeconfig_proxy_infra | default(omit) }}"
-            namespace: "{{ dsc.vaultInfra.namespace }}"
-            kind: Secret
-            name: "{{ vault_infra_keys_secret_name }}"
-          register: vault_infra_keys
-
-        - name: Decode and set the Vault infra token
-          when: vault_infra_keys_secret_name | length > 0
-          ansible.builtin.set_fact:
-            vault_infra_token: "{{ vault_infra_keys.resources[0].data.root_token | b64decode }}"
+- name: Retrieve Vault infra token
+  ansible.builtin.include_role:
+    name: shared_tasks
+  vars:
+    shared_tasks_run: vault-infra-token.yaml
 
 # Create kv engine
 - name: Get kv engines

--- a/roles/gitops/vault-secrets/tasks/main.yaml
+++ b/roles/gitops/vault-secrets/tasks/main.yaml
@@ -1,40 +1,60 @@
 ---
-# Retrieve Vault Infra token
-
-- name: Get Vault Infra token
-  when: lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') != ''
+# Retrieve Vault infra token
+- name: Set Vault infra token fact from environment variable
+  when: lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') | length > 0
   ansible.builtin.set_fact:
     vault_infra_token: "{{ lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') }}"
 
-- name: Get Vault Infra keys and token
-  when: lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') == ''
+- name: Set Vault infra token fact from Kubernetes secret when environment variable not set
+  when: lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') | length == 0
   block:
-    - name: Get Vault Infra secrets
+    - name: Check Vault infra pods
       kubernetes.core.k8s_info:
         kubeconfig: "{{ kubeconfig_infra }}"
-        proxy: "{{ kubeconfig_proxy_infra | default('') }}"
+        proxy: "{{ kubeconfig_proxy_infra | default(omit) }}"
         namespace: "{{ dsc.vaultInfra.namespace }}"
-        kind: Secret
-      register: vault_infra_secrets
+        kind: Pod
+        label_selectors:
+          - app.kubernetes.io/name = vault
+      register: vault_infra_pods
 
-    - name: Set vault_infra_keys_secret_name
-      ansible.builtin.set_fact:
-        vault_infra_keys_secret_name: "{{ vault_infra_secrets.resources
-          | selectattr('metadata.name', 'contains', 'vault-keys')
-          | map(attribute='metadata.name') | first }}"
+    - name: Fetch Vault infra keys and token from infra Kubernetes cluster
+      when: vault_infra_pods.resources | length > 0
+      block:
+        - name: Retrieve all secrets in the Vault infra namespace
+          kubernetes.core.k8s_info:
+            kubeconfig: "{{ kubeconfig_infra }}"
+            proxy: "{{ kubeconfig_proxy_infra | default(omit) }}"
+            namespace: "{{ dsc.vaultInfra.namespace }}"
+            kind: Secret
+          register: vault_infra_secrets
 
-    - name: Get Vault Infra keys
-      kubernetes.core.k8s_info:
-        kubeconfig: "{{ kubeconfig_infra }}"
-        proxy: "{{ kubeconfig_proxy_infra | default('') }}"
-        namespace: "{{ dsc.vaultInfra.namespace }}"
-        kind: Secret
-        name: "{{ vault_infra_keys_secret_name }}"
-      register: vault_infra_keys
+        - name: Extract the name of the Vault keys secret
+          ansible.builtin.set_fact:
+            vault_infra_keys_secret_name: "{{ vault_infra_secrets.resources
+              | selectattr('metadata.name', 'contains', 'vault-keys')
+              | map(attribute='metadata.name')
+              | first | default('') }}"
 
-    - name: Get Vault Infra token
-      ansible.builtin.set_fact:
-        vault_infra_token: "{{ vault_infra_keys.resources[0].data.root_token | b64decode }}"
+        - name: Fail if Vault infra keys secret not found (unless vault-infra role is executed)
+          when: vault_infra_keys_secret_name | length == 0 and 'vault-infra' not in ansible_run_tags or not dsc.vaultInfra.installEnabled
+          ansible.builtin.fail:
+            msg: "Vault infra keys secret not found. Please ensure Vault infra is initialized and unsealed."
+
+        - name: Fetch the Vault infra keys secret
+          when: vault_infra_keys_secret_name | length > 0
+          kubernetes.core.k8s_info:
+            kubeconfig: "{{ kubeconfig_infra }}"
+            proxy: "{{ kubeconfig_proxy_infra | default(omit) }}"
+            namespace: "{{ dsc.vaultInfra.namespace }}"
+            kind: Secret
+            name: "{{ vault_infra_keys_secret_name }}"
+          register: vault_infra_keys
+
+        - name: Decode and set the Vault infra token
+          when: vault_infra_keys_secret_name | length > 0
+          ansible.builtin.set_fact:
+            vault_infra_token: "{{ vault_infra_keys.resources[0].data.root_token | b64decode }}"
 
 # Create kv engine
 - name: Get kv engines
@@ -102,7 +122,7 @@
         namespace: "{{ dsc.keycloak.namespace }}"
       register: keycloak_admin_secret
 
-# Write Vault Infra secrets
+# Write Vault infra secrets
 
 - name: Write secrets
   ansible.builtin.include_tasks: write.yml

--- a/roles/infra/argocd-infra/tasks/main.yaml
+++ b/roles/infra/argocd-infra/tasks/main.yaml
@@ -1,12 +1,12 @@
 ---
-- name: Create Argo CD Infra namespace
+- name: Create Argo CD infra namespace
   kubernetes.core.k8s:
     name: "{{ dsc.argocdInfra.namespace }}"
     api_version: v1
     kind: Namespace
     state: present
 
-- name: Get argo client secret
+- name: Get Argo CD client secret
   kubernetes.core.k8s_info:
     kind: Secret
     namespace: "{{ dsc.keycloakInfra.namespace }}"
@@ -45,17 +45,17 @@
           namespace: "{{ dsc.argocdInfra.namespace }}"
           name: "{{ dsc_name }}-argo-infra-redis-ha-haproxy"
 
+- name: Add Argo CD helm repo
+  changed_when: false
+  kubernetes.core.helm_repository:
+    name: argo
+    repo_url: "{{ dsc.argocdInfra.helmRepoUrl }}"
+    force_update: true
+
 # Vault plugin setup
 
-- name: Get Argo CD Infra app version
+- name: Get Argo CD infra app version
   block:
-    - name: Add Argo CD helm repo
-      changed_when: false
-      kubernetes.core.helm_repository:
-        name: argo
-        repo_url: "{{ dsc.argocdInfra.helmRepoUrl }}"
-        force_update: true
-
     - name: Retrieve Argo CD Helm infos
       changed_when: false
       ansible.builtin.shell:
@@ -69,32 +69,7 @@
       ansible.builtin.set_fact:
         argo_app_version: "{{ argo_infos.stdout | regex_search('v([0-9]*\\.)+([0-9]+)') }}"
 
-- name: Retrieve Vault infra token
-  block:
-    - name: Get Vault infra secrets
-      kubernetes.core.k8s_info:
-        namespace: "{{ dsc.vaultInfra.namespace }}"
-        kind: Secret
-      register: vault_infra_secrets
-
-    - name: Get Vault infra keys secret name
-      ansible.builtin.set_fact:
-        vault_infra_keys_secret: "{{ vault_infra_secrets.resources
-          | map(attribute='metadata.name')
-          | select('contains', 'vault-keys') | first }}"
-
-    - name: Find Vault infra keys
-      kubernetes.core.k8s_info:
-        namespace: "{{ dsc.vaultInfra.namespace }}"
-        kind: Secret
-        name: "{{ vault_infra_keys_secret }}"
-      register: vault_infra_keys
-
-    - name: Set fact for Vault infra secrets
-      ansible.builtin.set_fact:
-        vault_infra_token: "{{ vault_infra_keys.resources[0].data.root_token | b64decode }}"
-
-- name: Deploy Argo CD Infra Vault plugin config
+- name: Deploy Argo CD infra Vault plugin config
   kubernetes.core.k8s:
     template: "{{ item }}"
     state: present
@@ -111,14 +86,7 @@
     - helm-docker-registry-secret.yml.j2
     - repo-creds.yml.j2
 
-# Argo CD Infra installation
-
-- name: Add helm repo
-  changed_when: false
-  kubernetes.core.helm_repository:
-    name: argo
-    repo_url: "{{ dsc.argocdInfra.helmRepoUrl }}"
-    force_update: true
+# Argo CD infra installation
 
 - name: Set path fact
   ansible.builtin.set_fact:

--- a/roles/infra/vault-infra/tasks/check.yml
+++ b/roles/infra/vault-infra/tasks/check.yml
@@ -1,6 +1,5 @@
 ---
 - name: Get vault status
-  changed_when: false
   kubernetes.core.k8s_exec:
     container: vault
     pod: "{{ vault_pod }}"
@@ -9,6 +8,7 @@
     validate_certs: "{{ dsc.exposedCA.type == 'none' }}"
   register: vault_status
   ignore_errors: true
+  changed_when: false
 
 - name: Set vault_initialized fact
   ansible.builtin.set_fact:

--- a/roles/infra/vault-infra/tasks/join_and_unseal_node.yml
+++ b/roles/infra/vault-infra/tasks/join_and_unseal_node.yml
@@ -14,7 +14,6 @@
         pod: "{{ vault_pod }}"
         namespace: "{{ dsc.vaultInfra.namespace }}"
         command: vault operator raft join http://"{{ dsc_name }}"-vault-infra-0."{{ dsc_name }}"-vault-infra-internal:8200
-      register: "node_join_state_{{ vault_node_index }}"
       retries: 3
       delay: 20
 

--- a/roles/infra/vault-infra/tasks/join_and_unseal_node.yml
+++ b/roles/infra/vault-infra/tasks/join_and_unseal_node.yml
@@ -1,0 +1,31 @@
+---
+- name: "Process node {{ vault_node_index }}"
+  vars:
+    vault_pod: "{{ dsc_name }}-vault-infra-{{ vault_node_index }}"
+  block:
+    # Join node to Vault cluster
+    - name: "Check vault-{{ vault_node_index }} status"
+      ansible.builtin.include_tasks: check.yml
+
+    - name: "Join vault-{{ vault_node_index }} node to cluster"
+      when: vault_status == 'not init'
+      kubernetes.core.k8s_exec:
+        container: vault
+        pod: "{{ vault_pod }}"
+        namespace: "{{ dsc.vaultInfra.namespace }}"
+        command: vault operator raft join http://"{{ dsc_name }}"-vault-infra-0."{{ dsc_name }}"-vault-infra-internal:8200
+      register: "node_join_state_{{ vault_node_index }}"
+      retries: 3
+      delay: 20
+
+    # Unseal node
+    - name: "Check vault-{{ vault_node_index }} status again"
+      ansible.builtin.include_tasks: check.yml
+
+    - name: Set seal count
+      ansible.builtin.set_fact:
+        unseal_key_index: "0"
+
+    - name: "Unseal vault node {{ vault_node_index }}"
+      when: vault_status == 'not init' or vault_status == 'sealed'
+      ansible.builtin.include_tasks: unseal.yml

--- a/roles/infra/vault-infra/tasks/post-install.yml
+++ b/roles/infra/vault-infra/tasks/post-install.yml
@@ -22,20 +22,18 @@
   vars:
     vault_pod: "{{ dsc_name }}-vault-infra-0"
 
-- name: Check if vault is coherent
+- name: Check if Vault infra is coherent
   ansible.builtin.assert:
     that:
-      - (vault_status in ['sealed', 'OK']) and (vault_keys.resources | length > 0)
-    fail_msg:
-      - Attention ! Vault n'est pas initialisé mais vous avez un secret {{ dsc_name }}-vault-keys dans {{ dsc.vaultInfra.namespace }}
-      - Veuillez le supprimer et relancer si vous souhaitez lancer une initialisation
-
-- name: Check if vault is coherent
-  ansible.builtin.assert:
-    that:
-      - (vault_status == 'not init') and (vault_keys.resources | length == 0)
-    fail_msg:
-      - Attention ! Vault est initialisé mais vous n'avez pas de secret {{ dsc_name }}-vault-keys dans {{ dsc.vaultInfra.namespace }}. C'est inquiétant !
+      - ((vault_status in ['sealed', 'OK']) and (vault_keys.resources | length > 0)) or ((vault_status == 'not init') and (vault_keys.resources | length == 0))
+    fail_msg: >
+      {% if vault_status == 'not init' %}
+      Attention ! Le Vault d'infra n'est pas initialisé mais vous avez un secret {{ dsc_name }}-vault-keys dans le namespace : {{ dsc.vaultInfra.namespace }}
+      Veuillez le supprimer et relancer si vous souhaitez lancer une initialisation
+      {% else %}
+      Attention ! Le Vault d'infra est initialisé mais vous n'avez pas de secret {{ dsc_name }}-vault-keys dans le namespace : {{ dsc.vaultInfra.namespace }}
+      C'est inquiétant !
+      {% endif %}
 
 # Init Vault - node 1
 - name: Init vault node - node 1
@@ -87,7 +85,6 @@
         init_config: "{{ init.stdout | from_json | b64encode }}"
 
 - name: Get vault keys
-  when: vault_keys.resources | length == 0
   kubernetes.core.k8s_info:
     namespace: "{{ dsc.vaultInfra.namespace }}"
     kind: Secret
@@ -97,6 +94,7 @@
 - name: Get Vault token
   ansible.builtin.set_fact:
     vault_token: "{{ vault_keys.resources[0].data.root_token | b64decode }}"
+    unseal_key_index: "0" # will not increment if defined in "vars" of unseal task
 
 # Unseal Vault
 - name: Unseal vault primary - node 1
@@ -104,12 +102,11 @@
   ansible.builtin.include_tasks: unseal.yml
   vars:
     vault_pod: "{{ dsc_name }}-vault-infra-0"
-    unseal_key_index: "0"
 
 - name: Join and unseal other nodes
   when: vault_values.server.ha.enabled
   ansible.builtin.include_tasks: join_and_unseal_node.yml
-  loop: "{{ range(1, 3) | list }}"
+  loop: "{{ range(1, 3) | list }}" # nodes index 1 and 2
   loop_control:
     loop_var: vault_node_index
 
@@ -123,6 +120,8 @@
     headers:
       "X-Vault-Token": "{{ vault_token }}"
   register: get_engines
+  retries: 3
+  delay: 5
 
 - name: Create default {{ vaultinfra_kv_name }} kv engine
   when: get_engines.status == 400

--- a/roles/infra/vault-infra/tasks/post-install.yml
+++ b/roles/infra/vault-infra/tasks/post-install.yml
@@ -1,4 +1,4 @@
-- name: Wait vault pod to be running
+- name: Wait for vault pod to be running
   kubernetes.core.k8s_info:
     kind: Pod
     name: "{{ dsc_name }}-vault-infra-0"
@@ -9,13 +9,12 @@
   retries: 15
   delay: 5
 
-# Find Vault keys
 - name: Find vault keys
   kubernetes.core.k8s_info:
     namespace: "{{ dsc.vaultInfra.namespace }}"
     kind: Secret
     name: "{{ dsc_name }}-vault-keys"
-  register: vaut_keys
+  register: vault_keys
 
 # Check Vault status - node 1
 - name: Check vault status - node 1
@@ -26,11 +25,17 @@
 - name: Check if vault is coherent
   ansible.builtin.assert:
     that:
-      - ((vault_status in ['sealed', 'OK']) and (vaut_keys.resources | length > 0)) or ((vault_status == 'not init') and (vaut_keys.resources | length == 0))
+      - (vault_status in ['sealed', 'OK']) and (vault_keys.resources | length > 0)
     fail_msg:
-      - Attention ! Soit le vault n'est pas initialisé mais vous avez un secret {{ dsc_name }}-vault-keys dans {{ dsc.vaultInfra.namespace }}
+      - Attention ! Vault n'est pas initialisé mais vous avez un secret {{ dsc_name }}-vault-keys dans {{ dsc.vaultInfra.namespace }}
       - Veuillez le supprimer et relancer si vous souhaitez lancer une initialisation
-      - Soit le vault est initialisé mais vous n'avez pas de secret {{ dsc_name }}-vault-keys dans {{ dsc.vaultInfra.namespace }}, et c'est inquiétant !
+
+- name: Check if vault is coherent
+  ansible.builtin.assert:
+    that:
+      - (vault_status == 'not init') and (vault_keys.resources | length == 0)
+    fail_msg:
+      - Attention ! Vault est initialisé mais vous n'avez pas de secret {{ dsc_name }}-vault-keys dans {{ dsc.vaultInfra.namespace }}. C'est inquiétant !
 
 # Init Vault - node 1
 - name: Init vault node - node 1
@@ -67,7 +72,7 @@
       | map(attribute='value') | first }}"
 
 - name: Store vault keys and token
-  when: vaut_keys.resources | length == 0
+  when: vault_keys.resources | length == 0
   kubernetes.core.k8s:
     definition:
       kind: Secret
@@ -81,115 +86,8 @@
         root_token: "{{ root_token | b64encode }}"
         init_config: "{{ init.stdout | from_json | b64encode }}"
 
-# Unseal Vault - node 1
-- name: Set seal count - node 1
-  ansible.builtin.set_fact:
-    vault_pod: "{{ dsc_name }}-vault-infra-0"
-    unseal_key_index: "0"
-
 - name: Get vault keys
-  kubernetes.core.k8s_info:
-    namespace: "{{ dsc.vaultInfra.namespace }}"
-    kind: Secret
-    name: "{{ dsc_name }}-vault-keys"
-  register: vault_keys
-
-- name: Unseal vault primary - node 1
-  when: vault_status == 'not init' or vault_status == 'sealed'
-  ansible.builtin.include_tasks: unseal.yml
-  vars:
-    vault_pod: "{{ dsc_name }}-vault-infra-0"
-
-- name: Join and unseal node 2
-  when: vault_values.server.ha.enabled
-  block:
-    # Join node 2 to Vault cluster
-    - name: Check vault-1 status - node 2
-      ansible.builtin.include_tasks: check.yml
-      vars:
-        vault_pod: "{{ dsc_name }}-vault-infra-1"
-
-    - name: Join vault-1 node to cluster - node 2
-      when: vault_status == 'not init'
-      kubernetes.core.k8s_exec:
-        container: vault
-        pod: "{{ dsc_name }}-vault-infra-1"
-        namespace: "{{ dsc.vaultInfra.namespace }}"
-        command: vault operator raft join http://"{{ dsc_name }}"-vault-infra-0."{{ dsc_name }}"-vault-infra-internal:8200
-      register: node2_join_state
-      retries: 3
-      delay: 20
-
-    # Unseal node 2
-    - name: Check vault-1 status - node 2
-      ansible.builtin.include_tasks: check.yml
-      vars:
-        vault_pod: "{{ dsc_name }}-vault-infra-1"
-
-    - name: Set seal count - node 2
-      ansible.builtin.set_fact:
-        vault_pod: "{{ dsc_name }}-vault-infra-1"
-        unseal_key_index: "0"
-
-    - name: Get vault keys
-      kubernetes.core.k8s_info:
-        namespace: "{{ dsc.vaultInfra.namespace }}"
-        kind: Secret
-        name: "{{ dsc_name }}-vault-keys"
-      register: vault_keys
-
-    - name: Unseal vault node - node 2
-      when: vault_status == 'not init' or vault_status == 'sealed'
-      ansible.builtin.include_tasks: unseal.yml
-      vars:
-        vault_pod: "{{ dsc_name }}-vault-infra-1"
-
-- name: Join and unseal node 3
-  when: vault_values.server.ha.enabled
-  block:
-    # Join node 3 to Vault cluster
-    - name: Check vault-2 status - node 3
-      ansible.builtin.include_tasks: check.yml
-      vars:
-        vault_pod: "{{ dsc_name }}-vault-infra-2"
-
-    - name: Join vault-2 to cluster - node 3
-      when: vault_status == 'not init'
-      kubernetes.core.k8s_exec:
-        container: vault
-        pod: "{{ dsc_name }}-vault-infra-2"
-        namespace: "{{ dsc.vaultInfra.namespace }}"
-        command: vault operator raft join http://"{{ dsc_name }}"-vault-infra-0."{{ dsc_name }}"-vault-infra-internal:8200
-      register: node3_join_state
-      retries: 3
-      delay: 20
-
-    # Unseal node 3
-    - name: Check vault-2 status - node 3
-      ansible.builtin.include_tasks: check.yml
-      vars:
-        vault_pod: "{{ dsc_name }}-vault-infra-2"
-
-    - name: Set seal count - node 3
-      ansible.builtin.set_fact:
-        vault_pod: "{{ dsc_name }}-vault-infra-2"
-        unseal_key_index: "0"
-
-    - name: Get vault keys
-      kubernetes.core.k8s_info:
-        namespace: "{{ dsc.vaultInfra.namespace }}"
-        kind: Secret
-        name: "{{ dsc_name }}-vault-keys"
-      register: vault_keys
-
-    - name: Unseal vault node - node 3
-      when: vault_status == 'not init' or vault_status == 'sealed'
-      ansible.builtin.include_tasks: unseal.yml
-      vars:
-        vault_pod: "{{ dsc_name }}-vault-infra-2"
-
-# Retrieve Vault token
-- name: Get Vault keys
+  when: vault_keys.resources | length == 0
   kubernetes.core.k8s_info:
     namespace: "{{ dsc.vaultInfra.namespace }}"
     kind: Secret
@@ -199,6 +97,21 @@
 - name: Get Vault token
   ansible.builtin.set_fact:
     vault_token: "{{ vault_keys.resources[0].data.root_token | b64decode }}"
+
+# Unseal Vault
+- name: Unseal vault primary - node 1
+  when: vault_status == 'not init' or vault_status == 'sealed'
+  ansible.builtin.include_tasks: unseal.yml
+  vars:
+    vault_pod: "{{ dsc_name }}-vault-infra-0"
+    unseal_key_index: "0"
+
+- name: Join and unseal other nodes
+  when: vault_values.server.ha.enabled
+  ansible.builtin.include_tasks: join_and_unseal_node.yml
+  loop: "{{ range(1, 3) | list }}"
+  loop_control:
+    loop_var: vault_node_index
 
 # Create kv engine
 - name: Get kv engines

--- a/roles/shared_tasks/tasks/fetch-vault-infra-keys.yaml
+++ b/roles/shared_tasks/tasks/fetch-vault-infra-keys.yaml
@@ -1,0 +1,44 @@
+---
+- name: Check Vault infra pods
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ kubeconfig_infra }}"
+    proxy: "{{ kubeconfig_proxy_infra | default(omit) }}"
+    namespace: "{{ dsc.vaultInfra.namespace }}"
+    kind: Pod
+    label_selectors:
+      - app.kubernetes.io/name = vault
+  register: vault_infra_pods
+
+- name: Fetch Vault infra keys and token from infra Kubernetes cluster
+  when: vault_infra_pods.resources | length > 0
+  block:
+    - name: Retrieve all secrets in the Vault infra namespace
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ kubeconfig_infra }}"
+        proxy: "{{ kubeconfig_proxy_infra | default(omit) }}"
+        namespace: "{{ dsc.vaultInfra.namespace }}"
+        kind: Secret
+      register: vault_infra_secrets
+
+    - name: Extract the name of the Vault keys secret
+      ansible.builtin.set_fact:
+        vault_infra_keys_secret_name: "{{ vault_infra_secrets.resources
+          | selectattr('metadata.name', 'contains', 'vault-keys')
+          | map(attribute='metadata.name')
+          | first | default('') }}"
+
+    - name: Fail when Vault infra keys secret not found (unless vault-infra role is executed)
+      when: vault_infra_keys_secret_name | length == 0 and (get_credentials_playbook | default(false) or 'vault-infra' not in ansible_run_tags or not dsc.vaultInfra.installEnabled)
+      ansible.builtin.fail:
+        msg: "Vault infra keys secret not found. Please ensure Vault infra is initialized and unsealed."
+      ignore_errors: "{{ get_credentials_playbook | default(omit) }}" # needed to display error and continue playbook execution if secret is not found
+
+    - name: Fetch the Vault infra keys secret
+      when: vault_infra_keys_secret_name | length > 0
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ kubeconfig_infra }}"
+        proxy: "{{ kubeconfig_proxy_infra | default(omit) }}"
+        namespace: "{{ dsc.vaultInfra.namespace }}"
+        kind: Secret
+        name: "{{ vault_infra_keys_secret_name }}"
+      register: vault_infra_keys

--- a/roles/shared_tasks/tasks/main.yaml
+++ b/roles/shared_tasks/tasks/main.yaml
@@ -1,0 +1,9 @@
+- name: Include task file
+  ansible.builtin.include_tasks: "{{ shared_tasks_run }}"
+#
+# Example usage:
+# - name: Run dynamic task from shared_tasks role
+#   include_role:
+#     name: shared_tasks
+#   vars:
+#     shared_tasks_run: example_task.yaml

--- a/roles/shared_tasks/tasks/vault-infra-token.yaml
+++ b/roles/shared_tasks/tasks/vault-infra-token.yaml
@@ -6,10 +6,17 @@
 
 - name: Set Vault infra token fact from Kubernetes secret when environment variable not set
   when: lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') | length == 0
-  ansible.builtin.include_tasks:
-    file: fetch-vault-infra-keys.yaml
+  block:
+    - name: Set empty Vault infra token
+      ansible.builtin.set_fact:
+        vault_infra_token: ""
 
-- name: Decode and set the Vault infra token
-  when: vault_infra_keys is defined and vault_infra_keys | length > 0
-  ansible.builtin.set_fact:
-    vault_infra_token: "{{ vault_infra_keys.resources[0].data.root_token | b64decode }}"
+    - name: Fetch Vault infra keys
+      when: kubeconfig_infra is defined
+      ansible.builtin.include_tasks:
+        file: fetch-vault-infra-keys.yaml
+
+    - name: Decode and set the Vault infra token
+      when: vault_infra_keys is defined and vault_infra_keys.resources is defined and vault_infra_keys.resources[0].data.root_token | length > 0
+      ansible.builtin.set_fact:
+        vault_infra_token: "{{ vault_infra_keys.resources[0].data.root_token | b64decode }}"

--- a/roles/shared_tasks/tasks/vault-infra-token.yaml
+++ b/roles/shared_tasks/tasks/vault-infra-token.yaml
@@ -1,0 +1,15 @@
+---
+- name: Set Vault infra token fact from environment variable
+  when: lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') | length > 0
+  ansible.builtin.set_fact:
+    vault_infra_token: "{{ lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') }}"
+
+- name: Set Vault infra token fact from Kubernetes secret when environment variable not set
+  when: lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') | length == 0
+  ansible.builtin.include_tasks:
+    file: fetch-vault-infra-keys.yaml
+
+- name: Decode and set the Vault infra token
+  when: vault_infra_keys is defined and vault_infra_keys | length > 0
+  ansible.builtin.set_fact:
+    vault_infra_token: "{{ vault_infra_keys.resources[0].data.root_token | b64decode }}"

--- a/roles/socle-config/tasks/envs.yaml
+++ b/roles/socle-config/tasks/envs.yaml
@@ -28,7 +28,7 @@
             customNamespacePrefix: ""
             syncWave: 10
             vault_values:
-              vault_infra_token: "{{ vault_infra_token | default(lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN')) }}"
+              vault_infra_token: "{{ vault_infra_token }}"
               image:
                 repository:
                   docker: "{{ dsc.global.registry | default('docker.io') }}"

--- a/roles/socle-config/tasks/main.yaml
+++ b/roles/socle-config/tasks/main.yaml
@@ -151,55 +151,11 @@
   ansible.builtin.set_fact:
     vaultinfra_domain: "{{ dsc.vaultInfra.domain | default(dsc.vaultInfra.subDomain ~ infra_root_domain) }}"
 
-- name: Set Vault infra token fact from environment variable
-  when: lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') | length > 0
-  ansible.builtin.set_fact:
-    vault_infra_token: "{{ lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') }}"
-
-- name: Set Vault infra token fact from Kubernetes secret when environment variable not set
-  when: lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') | length == 0
-  block:
-    - name: Check Vault infra pods
-      kubernetes.core.k8s_info:
-        namespace: "{{ dsc.vaultInfra.namespace }}"
-        kind: Pod
-        label_selectors:
-          - app.kubernetes.io/name = vault
-      register: vault_infra_pods
-
-    - name: Fetch Vault infra keys and token from infra Kubernetes cluster
-      when: vault_infra_pods.resources | length > 0
-      block:
-        - name: Retrieve all secrets in the Vault infra namespace
-          kubernetes.core.k8s_info:
-            namespace: "{{ dsc.vaultInfra.namespace }}"
-            kind: Secret
-          register: vault_infra_secrets
-
-        - name: Extract the name of the Vault keys secret
-          ansible.builtin.set_fact:
-            vault_infra_keys_secret_name: "{{ vault_infra_secrets.resources
-              | selectattr('metadata.name', 'contains', 'vault-keys')
-              | map(attribute='metadata.name')
-              | first | default('') }}"
-
-        - name: Fail if Vault infra keys secret not found (unless vault-infra role is executed)
-          when: vault_infra_keys_secret_name | length == 0 and 'vault-infra' not in ansible_run_tags or not dsc.vaultInfra.installEnabled
-          ansible.builtin.fail:
-            msg: "Vault infra keys secret not found. Please ensure Vault infra is initialized and unsealed."
-
-        - name: Fetch the Vault infra keys secret
-          when: vault_infra_keys_secret_name | length > 0
-          kubernetes.core.k8s_info:
-            namespace: "{{ dsc.vaultInfra.namespace }}"
-            kind: Secret
-            name: "{{ vault_infra_keys_secret_name }}"
-          register: vault_infra_keys
-
-        - name: Decode and set the Vault infra token
-          when: vault_infra_keys_secret_name | length > 0
-          ansible.builtin.set_fact:
-            vault_infra_token: "{{ vault_infra_keys.resources[0].data.root_token | b64decode }}"
+- name: Set Vault infra token fact
+  ansible.builtin.include_role:
+    name: shared_tasks
+  vars:
+    shared_tasks_run: vault-infra-token.yaml
 
 - name: Probe Vault infra domain cert validity
   ansible.builtin.uri:

--- a/roles/socle-config/tasks/main.yaml
+++ b/roles/socle-config/tasks/main.yaml
@@ -200,5 +200,6 @@
     name: ca
 
 - name: Set envs fact
+  when: post_conf_job is not defined
   ansible.builtin.include_tasks:
     file: envs.yaml

--- a/roles/socle-config/tasks/main.yaml
+++ b/roles/socle-config/tasks/main.yaml
@@ -93,23 +93,24 @@
   ansible.builtin.set_fact:
     dsc: "{{ socle_config.resources[0] }}"
 
-- name: Set some instance name
+- name: Set instance name fact
   ansible.builtin.set_fact:
     instance_name: "{{ dsc.metadata.name }}"
 
-- name: Set some facts
+- name: Set default config and releases facts
   ansible.builtin.set_fact:
     dsc_default_config: "{{ lookup('ansible.builtin.file', 'config.yaml') | from_yaml }}"
     dsc_default_releases: "{{ lookup('ansible.builtin.file', 'releases.yaml') | from_yaml }}"
 
-- name: Set some facts
+- name: Combine and merge DSC fact
   ansible.builtin.set_fact:
     dsc: "{{ dsc_default_releases | combine(dsc_default_config, recursive=True) | combine(dsc, recursive=True) }}"
-- name: Set some facts
+
+- name: Set dsc spec fact
   ansible.builtin.set_fact:
     dsc: "{{ dsc.spec }}"
 
-- name: Set private registry
+- name: Set private registry fact
   ansible.builtin.set_fact:
     use_private_registry: "{{ dsc.global.registry is defined and dsc.global.registry | length > 0 | bool }}"
 
@@ -117,15 +118,15 @@
   ansible.builtin.set_fact:
     use_image_pull_secrets: "{{ dsc.global.imagePullSecretsData is defined and dsc.global.imagePullSecretsData | length > 0 | bool }}"
 
-- name: Set root_domain fact
+- name: Set root_domain fact from dsc global config
   ansible.builtin.set_fact:
     root_domain: "{{ dsc.global.rootDomain }}"
 
-- name: Set infra_root_domain fact
+- name: Set infra_root_domain fact from dsc global config
   ansible.builtin.set_fact:
     infra_root_domain: "{{ dsc.global.infraRootDomain }}"
 
-- name: Set tools domains facts
+- name: Set tools domains facts from dsc config
   ansible.builtin.set_fact:
     argocd_domain: "{{ dsc.argocd.domain | default(dsc.argocd.subDomain ~ root_domain) }}"
     awx_domain: "{{ dsc.awx.domain | default(dsc.awx.subDomain ~ root_domain) }}"
@@ -140,17 +141,67 @@
     sonar_domain: "{{ dsc.sonarqube.domain | default(dsc.sonarqube.subDomain ~ root_domain) }}"
     vault_domain: "{{ dsc.vault.domain | default(dsc.vault.subDomain ~ root_domain) }}"
 
-- name: Set Vault infra domain fact
-  when: lookup('ansible.builtin.env', 'VAULT_INFRA_DOMAIN') == ''
-  ansible.builtin.set_fact:
-    vaultinfra_domain: "{{ dsc.vaultInfra.domain | default(dsc.vaultInfra.subDomain ~ infra_root_domain) }}"
-
-- name: Set Vault infra domain fact
-  when: lookup('ansible.builtin.env', 'VAULT_INFRA_DOMAIN') != ''
+- name: Set Vault infra domain fact from environment variable
+  when: lookup('ansible.builtin.env', 'VAULT_INFRA_DOMAIN') | length > 0
   ansible.builtin.set_fact:
     vaultinfra_domain: "{{ lookup('ansible.builtin.env', 'VAULT_INFRA_DOMAIN') }}"
 
-- name: Probe Vaultinfra domain cert validity
+- name: Set Vault infra domain fact from dsc config when environment variable not set
+  when: lookup('ansible.builtin.env', 'VAULT_INFRA_DOMAIN') | length == 0
+  ansible.builtin.set_fact:
+    vaultinfra_domain: "{{ dsc.vaultInfra.domain | default(dsc.vaultInfra.subDomain ~ infra_root_domain) }}"
+
+- name: Set Vault infra token fact from environment variable
+  when: lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') | length > 0
+  ansible.builtin.set_fact:
+    vault_infra_token: "{{ lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') }}"
+
+- name: Set Vault infra token fact from Kubernetes secret when environment variable not set
+  when: lookup('ansible.builtin.env', 'VAULT_INFRA_TOKEN') | length == 0
+  block:
+    - name: Check Vault infra pods
+      kubernetes.core.k8s_info:
+        namespace: "{{ dsc.vaultInfra.namespace }}"
+        kind: Pod
+        label_selectors:
+          - app.kubernetes.io/name = vault
+      register: vault_infra_pods
+
+    - name: Fetch Vault infra keys and token from infra Kubernetes cluster
+      when: vault_infra_pods.resources | length > 0
+      block:
+        - name: Retrieve all secrets in the Vault infra namespace
+          kubernetes.core.k8s_info:
+            namespace: "{{ dsc.vaultInfra.namespace }}"
+            kind: Secret
+          register: vault_infra_secrets
+
+        - name: Extract the name of the Vault keys secret
+          ansible.builtin.set_fact:
+            vault_infra_keys_secret_name: "{{ vault_infra_secrets.resources
+              | selectattr('metadata.name', 'contains', 'vault-keys')
+              | map(attribute='metadata.name')
+              | first | default('') }}"
+
+        - name: Fail if Vault infra keys secret not found (unless vault-infra role is executed)
+          when: vault_infra_keys_secret_name | length == 0 and 'vault-infra' not in ansible_run_tags or not dsc.vaultInfra.installEnabled
+          ansible.builtin.fail:
+            msg: "Vault infra keys secret not found. Please ensure Vault infra is initialized and unsealed."
+
+        - name: Fetch the Vault infra keys secret
+          when: vault_infra_keys_secret_name | length > 0
+          kubernetes.core.k8s_info:
+            namespace: "{{ dsc.vaultInfra.namespace }}"
+            kind: Secret
+            name: "{{ vault_infra_keys_secret_name }}"
+          register: vault_infra_keys
+
+        - name: Decode and set the Vault infra token
+          when: vault_infra_keys_secret_name | length > 0
+          ansible.builtin.set_fact:
+            vault_infra_token: "{{ vault_infra_keys.resources[0].data.root_token | b64decode }}"
+
+- name: Probe Vault infra domain cert validity
   ansible.builtin.uri:
     url: "https://{{ vaultinfra_domain }}"
     method: GET
@@ -159,7 +210,7 @@
   register: vaultinfra_probe
   ignore_errors: true
 
-- name: Set vaultinfra_cert_valid fact
+- name: Set Vault infra certificate validity fact based on domain probe result
   ansible.builtin.set_fact:
     vaultinfra_cert_valid: "{{ vaultinfra_probe.failed is not defined or not vaultinfra_probe.failed }}"
 


### PR DESCRIPTION
Cette PR est un peu plus qu'un fix, c'est un grand nettoyage de la récupération du root_token du Vault d'infra pour que ce ne soit fait qu'une seule fois dans le rôle `socle-config` et à l'installation de Vault ou  dans le rôle `vault-secrets`.

## Quel est le comportement actuel ?
Si la variable d'environnement `VAULT_INFRA_TOKEN` n'est pas défini, le root_token du Vault d'infra n'est pas récupéré avant qu'il ne soit enregistré dans les `envs` utilisé par toutes les tâches AWX. Elles se retrouvent donc toutes en erreur, en commençant par Keycloak :

```yaml
fatal: [localhost]: FAILED! => 
  msg: |-
    The task includes an option with an undefined variable.. 'kubeconfig_infra' is undefined

    The error appears to be in '/workspace/socle/roles/gitops/vault-secrets/tasks/main.yaml': line 12, column 7,
    but may be elsewhere in the file depending on the exact syntax problem.

    The offending line appears to be:

      block:
        - name: Get Vault Infra secrets
          ^ here
```

Cette erreur est contre-intuitive car AWX est rentré dans un block qu'il ne devrait pas utiliser.

Pour l'anecdote, il y avait 4 fois la tâche de récupération du secret `{{ dsc_name }}-vault-keys` en l'espace de 15 tâches ! Et ce dans chacun des deux fichiers : `roles/infra/vault-infra/tasks/post-install.yml` et `roles/gitops/post-install/vault/tasks/main.yml`.
De même, dans `get-credentials.yaml`, il y avait 2 fois cette même tâche successivement. :joy:

## Quel est le nouveau comportement ?
Je pense avoir pris en compte tous les cas possibles et affiché des erreurs lorsque cela est nécessaire.
J'ai aussi corrigé l'affichage de `get-credentials.yaml` lors de la récupération de l'url des applications d'infra qui n'étaient pas celles d'infra :wink:

## Cette PR introduit-elle un breaking change ?
non

## Autres informations
J'aimerai mettre la récupération des secrets vault dans un fichier à part et l’appeler avec `include_tasks`, mais je ne sais pas vraiment où le mettre pour qu'il soit accessible par les roles `socle-config` et `vault-secrets`. Que pouvez vous me conseiller ?
