### PR TITLE
feat: :sparkles: add the root application to deploy applications as driven by the Console gitlab repository

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/argocd/templates/argocd-zone-app.yml.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/templates/argocd-zone-app.yml.j2
@@ -1,0 +1,49 @@
+{% set dsoZoneRepo = 'https://' + gitlab_domain + '/' + dsc.global.projectsRootDir | join('/') + '/infra/' + dsc.argocd.zoneName + '.git' %}
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: zone-{{ dsc.argocd.zoneName }}-project
+  namespace: {{ dsc.argocd.namespace }}
+spec:
+  description: "Projet contenant l'Application responsable de tous les déploiements par zone"
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+  sourceRepos:
+    - https://cloud-pi-native.github.io/helm-charts
+    - {{ dsoZoneRepo }}
+  destinations:
+    - namespace: {{ dsc.argocd.namespace }}
+      server: "https://kubernetes.default.svc"
+
+---      
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: zone-{{ dsc.argocd.zoneName }}-app
+  namespace: {{ dsc.argocd.namespace }}
+spec:
+  destination:
+    namespace: {{ dsc.argocd.namespace }}
+    server: https://kubernetes.default.svc
+  project: zone-{{ dsc.argocd.zoneName }}-project
+  sources:
+  - chart: dso-argocd-zone
+    targetRevision: {{ dsc.argocd.zoneChartVersion | quote }}
+    repoURL: https://cloud-pi-native.github.io/helm-charts
+    helm:
+      valueFiles:
+      - ./values.yaml
+      - $argocdValues/argocd-values.yaml
+      values: |
+        dsoZoneRepo: {{ dsoZoneRepo }}
+  - repoURL: {{ dsoZoneRepo }}
+    targetRevision: HEAD
+    ref: argocdValues
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true
+    - ServerSideApply=true

--- a/roles/socle-config/files/config.yaml
+++ b/roles/socle-config/files/config.yaml
@@ -11,6 +11,7 @@ spec:
     subDomain: argocd
     helmRepoUrl: https://argoproj.github.io/argo-helm
     values: {}
+    zoneName: default
   argocdInfra:
     installEnabled: false
     namespace: infra-argocd

--- a/roles/socle-config/files/cr-conf-dso-default.yaml
+++ b/roles/socle-config/files/cr-conf-dso-default.yaml
@@ -53,13 +53,12 @@ spec:
   argocd:
     admin:
       enabled: false
-  #    password: WeAreThePasswords
+    zoneName: default
   argocdInfra:
     admin:
       enabled: false
     namespace: infra-argocd
     projectName: default
-  #    password: WeAreThePasswords
   awx: {}
   certmanager: {}
   cloudnativepg: {}

--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -155,6 +155,12 @@ spec:
                     privateGitlabDomain:
                       description: Private Gitlab repository for Argo CD to access.
                       type: string
+                    zoneName:
+                      description: Name of the zone (multiple clusters) managed by this Argo CD instance.
+                      type: string
+                    zoneChartVersion:
+                      description: Version of the Helm Chart to use to manage zone objects. See https://github.com/cloud-pi-native/helm-charts/tree/main/charts/dso-argocd-zone
+                      type: string
                   required:
                     - admin
                     - installEnabled

--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -6,6 +6,8 @@ spec:
   argocd:
     # https://artifacthub.io/packages/helm/argo/argo-cd
     chartVersion: 8.5.6
+    # https://github.com/cloud-pi-native/helm-charts/tree/main/charts/dso-argocd-zone
+    zoneChartVersion: ">=1.0.0 <2.0.0"
   argocdInfra:
     # https://artifacthub.io/packages/helm/argo/argo-cd
     chartVersion: 8.5.6


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
La Console produit des fichiers values dans un dépôt Gitlab dédié (par zone) mais ces values ne sont pas utilisées

## Quel est le nouveau comportement ?
Utilisation des values pour piloter le déploiement des Applications demandées par la Console

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
Oui si les Applications ont été modifiées à la main par les projets

## Autres informations
Résultat sur sdid-hp : https://github.com/cloud-pi-native/socle-scw-sdid-hp/commit/3180c4c26c6db0b966c29dfa46747c23b514d1d2

<img width="1370" height="904" alt="image" src="https://github.com/user-attachments/assets/a7a64f21-bde7-4dfc-802a-e01e0195e8b0" />
