### PR TITLE
fix: :art: Keycloak alerting rules

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/dashboard/files/rules/metrics/keycloak-alerts.yaml.tpl
+++ b/roles/gitops/rendering-apps-files/templates/dashboard/files/rules/metrics/keycloak-alerts.yaml.tpl
@@ -7,11 +7,11 @@ groups:
           summary: Keycloak instance down (no ready container)
         expr: |
           (absent(kube_pod_container_status_ready{
-          pod=~"keycloak-\\d+",
+          pod!~"pg-cluster.*",
           container="keycloak",
           namespace="{{ .Values.app.namespacePrefix }}keycloak"}) == 1)
           or sum(kube_pod_container_status_ready{
-          pod=~"keycloak-\\d+",
+          pod!~"pg-cluster.*",
           container="keycloak",
           namespace="{{ .Values.app.namespacePrefix }}keycloak"}) == 0
         for: 5m
@@ -23,7 +23,7 @@ groups:
           summary: Keycloak pod not healthy (container is not ready)
         expr: |
           kube_pod_container_status_ready{
-          pod=~"keycloak-\\d+",
+          pod!~"pg-cluster.*",
           container="keycloak",
           namespace="{{ .Values.app.namespacePrefix }}keycloak"} == 0
         for: 5m


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Les règles d'alerting qui s'appuient sur la surveillance du container keycloak dans les pods keycloak utilisent le nom "keycloak" dans la regex de capture du pod. Or ce nom peut changer si nous avons paramétré un fullnameOverride dans les values du chart keycloak. Si tel est le cas, alors en l'état actuel les règles en question ne fonctionneront pas. 

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous modifions les regex de capture des pods keycloak, en considérant qu'il s'agit de capturer tous les pods du namespace qui ne sont pas préfixés en "pg-cluster". Ainsi, les pods "keycloak", quel que soit leur nom hérité du fullnameOverride, seront bien capturés par nos règles.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.