### PR TITLE
fix: :art: Adapt code for Ansible 12 compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Un tableau synoptique des prérequis minimaux, pour chaque outil positionné dan
 
 Vous devrez disposer d'un **accès administrateur au cluster**.
 
-Vous aurez besoin d'une machine distincte du cluster, tournant sous GNU/Linux avec une distribution de la famille Debian ou Red Hat. Cette machine vous servira en tant qu'**environnement de déploiement** [Ansible control node](https://docs.ansible.com/ansible/latest/network/getting_started/basic_concepts.html#control-node). Elle nécessitera donc l'installation d'[Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html), et plus précisément du paquet **ansible**, pour disposer au moins de la commande `ansible-playbook` ainsi que de la collection [community.general](https://github.com/ansible-collections/community.general).
+Vous aurez besoin d'une machine distincte du cluster, tournant sous GNU/Linux avec une distribution de la famille Debian ou Red Hat. Cette machine vous servira en tant qu'**environnement de déploiement** [Ansible control node](https://docs.ansible.com/ansible/latest/network/getting_started/basic_concepts.html#control-node). Elle nécessitera donc l'installation d'[Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html), **en version supérieure ou égale à 12**, pour disposer au moins de la commande `ansible-playbook` ainsi que de la collection [community.general](https://github.com/ansible-collections/community.general) à jour.
 
 Toujours sur votre environnement de déploiement, vous devrez :
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,5 +6,5 @@ callbacks_enabled = timer, profile_tasks, profile_roles
 gathering = smart
 fact_caching = jsonfile
 fact_caching_connection = /tmp/ansible-facts
-stdout_callback = community.general.yaml
+callback_result_format = yaml
 bin_ansible_callbacks = True

--- a/roles/check-prerequisite/tasks/main.yml
+++ b/roles/check-prerequisite/tasks/main.yml
@@ -30,6 +30,6 @@
           - >
             cm_api == 'absent' or
             cm_mwhc.resources | length == 0 or
-            dsc.certmanager.forcedInstall
+            dsc.certmanager.forcedInstall is truthy
         fail_msg: " Certmanager is already installed in your cluster"
       ignore_errors: true

--- a/roles/cluster-offline/tasks/main.yml
+++ b/roles/cluster-offline/tasks/main.yml
@@ -1,15 +1,19 @@
 ---
-- name: Validate dsc.sonarqube.pluginDownloadUrl is not empty
+- name: Validate dsc.sonarqube.pluginDownloadUrl is defined and not empty
   ansible.builtin.assert:
     that:
-      - dsc.sonarqube.pluginDownloadUrl != ""
-    fail_msg: "'dsc.sonarqube.pluginDownloadUrl' must not be empty"
+      - >
+        dsc.sonarqube.pluginDownloadUrl is defined and
+        dsc.sonarqube.pluginDownloadUrl != ""
+    fail_msg: "'dsc.sonarqube.pluginDownloadUrl' must be set and not be empty"
 
-- name: Validate dsc.sonarqube.prometheusJavaagentVersion is not empty
+- name: Validate dsc.sonarqube.prometheusJavaagentVersion is defined and not empty
   ansible.builtin.assert:
     that:
-      - dsc.sonarqube.prometheusJavaagentVersion != ""
-    fail_msg: "'dsc.sonarqube.prometheusJavaagentVersion' must not be empty"
+      - >
+        dsc.sonarqube.prometheusJavaagentVersion is defined and
+        dsc.sonarqube.prometheusJavaagentVersion != ""
+    fail_msg: "'dsc.sonarqube.prometheusJavaagentVersion' must be set and not be empty"
 
 - name: Validate dsc.gitlabCatalog.catalogRepoUrl is different than default
   ansible.builtin.assert:
@@ -23,8 +27,10 @@
       - dsc.console.helmRepoUrl != "https://cloud-pi-native.github.io/helm-charts"
     fail_msg: "'dsc.console.helmRepoUrl' is same as 'https://cloud-pi-native.github.io/helm-charts'"
 
-- name: Validate dsc.argocd.privateGitlabDomain is not empty
+- name: Validate dsc.argocd.privateGitlabDomain is defined and not empty
   ansible.builtin.assert:
     that:
-      - dsc.argocd.privateGitlabDomain != ""
-    fail_msg: "'dsc.argocd.privateGitlabDomain' is empty"
+      - >
+        dsc.argocd.privateGitlabDomain is defined and
+        dsc.argocd.privateGitlabDomain != ""
+    fail_msg: "'dsc.argocd.privateGitlabDomain' must be set and not be empty"

--- a/roles/gitops/rendering-apps-files/tasks/template.yml
+++ b/roles/gitops/rendering-apps-files/tasks/template.yml
@@ -75,7 +75,7 @@
       vars:
         rendered_content: "{{ lookup('ansible.builtin.template', my_template) }}"
       when:
-        - rendered_content | trim != ''
+        - rendered_content | trim != 'None'
         - not (my_template | basename == 'users.yaml.j2' and keycloak_users_file_stat.stat.exists)
       ansible.builtin.copy:
         content: "{{ rendered_content }}"


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Si nous basculons notre installation d'Ansible en dernière version (12.1.0) au niveau de notre control node, certaines tasks génèrent des erreurs ou bien n'ont pas le comportement attendu.

D'autres pourraient échouer si nous entrons dans certaines boucles de condition.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous corrigeons les éléments problématiques pour maintenir la compatibilité avec la dernière version d'Ansible.

Pour cela, nous nous aidons notamment de la documentation officielle suivante :
- https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_12.html

Nous précisons par ailleurs dans le README la version d'Ansible minimale à utiliser.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Oui.
Nécessité de basculer sur ansible >= 12 au niveau du control node utilisé pour l'installation du Socle.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement, avec un control node utilisant Ansible 12.

La PR corrige les éléments suivants :
- Problème sur task `Render "{{ item.1.argocd_app }}" templates and write yaml files to destination` du fichier `socle/roles/gitops/rendering-apps-files/tasks/template.yml` qui sinon prenait en compte des templates vides qu'elle devrait normalement ignorer.
- Problème dans fichier `socle/ansible.cfg` avec le paramètre `stdout_callback = community.general.yaml` deprecated qui doit être remplacé par `callback_result_format = yaml`  ([source](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/default_callback.html#parameter-result_format)).
- Problème sur task `Check if cert-manager is absent` du fichier `socle/roles/check-prerequisite/tasks/main.yml` dont l'un des éléments d'assert est un booléen qui nécessite désormais une vérification plus stricte ([source](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_12.html#broken-conditionals)).

Bien que la problématique ne soit pas liée à l'upgrade d'Ansible, nous corrigeons également le fichier `socle/roles/cluster-offline/tasks/main.yml` au niveau de certaines variables qui pouvaient être undefined alors que ce point n'était pas vérifié par les tasks concernées.