### PR TITLE
refactor: :art: Clean CRD

### DIFF
--- a/roles/socle-config/files/crd-conf-dso.yaml
+++ b/roles/socle-config/files/crd-conf-dso.yaml
@@ -461,7 +461,7 @@ spec:
                       default: false
                       description: |
                         Specifies whether we should install Socle dashboards.
-                        This is disable by default since the Loki and Mimir code is not yet opensource.
+                        This is disabled by default since the Loki and Mimir code is not yet opensource.
                       type: boolean
                 gitlab:
                   description: Configuration for GitLab.
@@ -1781,29 +1781,8 @@ spec:
                     - installEnabled
                   type: object
               required:
-                - additionalsCA
-                - argocd
-                - argocdInfra
-                - certmanager
-                - cloudnativepg
-                - console
-                - exposedCA
-                - gitlab
-                - glexporter
-                - gitlabOperator
-                - gitlabrunner
                 - global
-                - grafana
-                - harbor
                 - ingress
-                - keycloak
-                - keycloakInfra
-                - kyverno
-                - nexus
-                - proxy
-                - sonarqube
-                - vault
-                - vaultInfra
               type: object
           required:
             - spec


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Notre CRD de type dsc (DsoSocleConfig) nécessite d'être retravaillée.
Elle embarque notamment beaucoup de specs qui sont "required" alors qu'elles pourraient être optionnelles.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous retravaillons la CRD au niveau des "required" de manière à ce qu'elle soit plus simple et cohérente tout en restant sûre.
Après relecture et adaptation, nous ne conservons que `global` et `ingress` en required. Ainsi, nous ne forçons que ce qui est réellement indispensable au bon fonctionnement.

Nous conservons `global` car cet objet possède plusieurs champs obligatoires internes (required: [projectsRootDir, rootDomain, environment, metrics, alerting, platform, offline, gitOps, dockerAccount, smtp]). C’est la configuration transversale utilisée partout. La garder en  « required » au niveau spec évite d’accepter des CRs invalides/inexploitables.

Nous conservons aussi `ingress` car il possède un sous‑objet tls avec required internes (type requis, et selon type, d’autres champs comme acme.email/environment ou ca.secretName). Beaucoup d’autres composants s’appuient sur une config d’ingress partagée. Comme notre logique de déploiement suppose l’existence d’un bloc ingress clair, conserver ingress dans required est raisonnable.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Les éléments retirés du « required » sont sans risques et donc purement optionnels.
- `additionalsCA` : Type array, aucun default ni contrainte globale. S’il est absent, rien ne casse. S’il est présent, chaque item a un `required: [kind, name, namespace]`, ce qui ne concerne que le cas où on l’utilise.
- `exposedCA` : Objet avec `required: [type]` à l’intérieur, et type a `default: none`. Si l’objet complet n’est pas fourni (et qu’il n’est pas « required » au niveau spec), on s’en passe. Si nous souhaitons gérer le cas « pas de CA privée », nous pouvons soit omettre complètement exposedCA, soit le fournir avec type: none.
- `proxy` : Objet avec `enabled default: false` et aucun champ interne requis. Si omis, pas d’activation du proxy.
- `grafana` : Objet sans champs required internes (que des propriétés optionnelles).
- `kyverno` : A un `installEnabled default: false`, et `required: [installEnabled]` interne uniquement si l’objet est fourni. Si on enlève l’obligation au niveau spec, on peut tout à fait omettre kyverno.
- `argocdInfra`, `keycloakInfra`, `vaultInfra` : Tous ont `installEnabled default: false` et des champs internes facultatifs. Ce sont des instances infra qu’on n’a pas toujours besoin d’installer.
- `certmanager` : `installEnabled default: false`, pas d’autre contrainte. Aujourd’hui il est dans required, mais nous acceptons explicitement le non‑déploiement par défaut.
- `glexporter`, `gitlabOperator`, `gitlabrunner`, `nexus`, `sonarqube`, `harbor`, `keycloak`, `console`, `cloudnativepg`, `vault`, `gitlab` : Tous suivent le même motif. Un sous‑objet « produit » avec `installEnabled` (souvent `default: true`), et pas d’autre contrainte bloquante au niveau racine. Les rendre « required » oblige à fournir au moins un objet vide (ou explicite), ce qui n’apporte rien au schéma ; on peut les rendre optionnels et se contenter des valeurs par défaut lorsqu’ils ne sont pas fournis.
