### PR TITLE
Fix internal urls for GitLab, SonarQube, Nexus and Vault

### DIFF
--- a/roles/gitops/post-install/gitlab-catalog/vars/main.yaml
+++ b/roles/gitops/post-install/gitlab-catalog/vars/main.yaml
@@ -1,2 +1,2 @@
 ---
-gitlab_auth_url: "http://{{ dsc.gitlab.subDomain }}-webservice-default.{{ dsc.gitlab.namespace }}.svc.cluster.local:8181"
+gitlab_auth_url: "http://gitlab-webservice-default.{{ dsc.gitlab.namespace }}.svc.cluster.local:8181"

--- a/roles/gitops/post-install/gitlab/tasks/main.yaml
+++ b/roles/gitops/post-install/gitlab/tasks/main.yaml
@@ -96,17 +96,17 @@
       - name: PROJECTS_ROOT_DIR
         value: "{{ dsc.global.projectsRootDir | join('/') }}"
       - name: NEXUS_HOST_URL
-        value: "http://{{ dsc.nexus.subDomain }}.{{ dsc.nexus.namespace }}.svc.cluster.local:8081"
+        value: "http://nexus.{{ dsc.nexus.namespace }}.svc.cluster.local:8081"
       - name: NEXUS_HOSTNAME
         value: "{{ nexus_domain }}"
       - name: SONAR_HOST_URL
-        value: "http://{{ dsc.sonarqube.subDomain }}-sonarqube.{{ dsc.sonarqube.namespace }}.svc.cluster.local:9000"
+        value: "http://sonarqube-sonarqube.{{ dsc.sonarqube.namespace }}.svc.cluster.local:9000"
       - name: VAULT_AUTH_PATH
         value: "{{ vault_auth_path }}"
       - name: VAULT_AUTH_ROLE
         value: "{{ vault_auth_role }}"
       - name: VAULT_SERVER_URL
-        value: "http://{{ dsc_name }}-{{ dsc.vault.subDomain }}-active.{{ dsc.vault.namespace }}.svc.cluster.local:8200"
+        value: "http://{{ dsc_name }}-vault-active.{{ dsc.vault.namespace }}.svc.cluster.local:8200"
       - name: MVN_CONFIG_FILE
         variable_type: file
         value: "{{ mvn_config_file }}"

--- a/roles/gitops/post-install/gitlab/vars/main.yaml
+++ b/roles/gitops/post-install/gitlab/vars/main.yaml
@@ -1,2 +1,2 @@
 ---
-gitlab_auth_url: "http://{{ dsc.gitlab.subDomain }}-webservice-default.{{ dsc.gitlab.namespace }}.svc.cluster.local:8181"
+gitlab_auth_url: "http://gitlab-webservice-default.{{ dsc.gitlab.namespace }}.svc.cluster.local:8181"

--- a/roles/gitops/post-install/sonarqube/vars/main.yaml
+++ b/roles/gitops/post-install/sonarqube/vars/main.yaml
@@ -1,2 +1,2 @@
 ---
-sonar_auth_url: "http://{{ dsc.sonarqube.subDomain }}-sonarqube.{{ dsc.sonarqube.namespace }}.svc.cluster.local:9000"
+sonar_auth_url: "http://sonarqube-sonarqube.{{ dsc.sonarqube.namespace }}.svc.cluster.local:9000"

--- a/roles/gitops/post-install/vault/vars/main.yaml
+++ b/roles/gitops/post-install/vault/vars/main.yaml
@@ -1,2 +1,2 @@
 ---
-vault_auth_url: "http://{{ dsc_name }}-{{ dsc.vault.subDomain }}-active.{{ dsc.vault.namespace }}.svc.cluster.local:8200"
+vault_auth_url: "http://{{ dsc_name }}-vault-active.{{ dsc.vault.namespace }}.svc.cluster.local:8200"

--- a/roles/gitops/rendering-apps-files/templates/console/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/console/values/00-main.j2
@@ -10,7 +10,7 @@ console:
       ARGOCD_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.argocd}>/"
       GITLAB_TOKEN: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/gitlab/values#gitlabToken>
       GITLAB_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.gitlab}>/"
-      GITLAB_INTERNAL_URL: "http://{{ dsc.gitlab.subDomain }}-webservice-default.{{ dsc.gitlab.namespace }}.svc.cluster.local:8181/"
+      GITLAB_INTERNAL_URL: "http://gitlab-webservice-default.{{ dsc.gitlab.namespace }}.svc.cluster.local:8181/"
       HARBOR_ADMIN: admin
       HARBOR_ADMIN_PASSWORD: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/harbor/values#global| jsonPath {.harborAdminPassword}>
       HARBOR_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.harbor}>/"
@@ -21,13 +21,13 @@ console:
       NEXUS_ADMIN: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/nexus/values#auth| jsonPath {.adminUsername}>
       NEXUS_ADMIN_PASSWORD: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/nexus/values#auth| jsonPath {.adminPassword}>
       NEXUS_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.nexus}>/"
-      NEXUS_INTERNAL_URL: "http://{{ dsc.nexus.subDomain }}.{{ dsc.nexus.namespace }}.svc.cluster.local:8081/"
+      NEXUS_INTERNAL_URL: "http://nexus.{{ dsc.nexus.namespace }}.svc.cluster.local:8081/"
       SONAR_API_TOKEN: "<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/sonarqube/values#auth| jsonPath {.sonarApiToken}>"
       SONARQUBE_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.sonarqube}>/"
       SONARQUBE_INTERNAL_URL: "http://sonarqube-sonarqube.{{ dsc.sonarqube.namespace }}.svc.cluster.local:9000/"
       VAULT_TOKEN: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/vault/values#vaultToken>
       VAULT_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.vault}>/"
-      VAULT_INTERNAL_URL: "http://{{ dsc_name }}-{{ dsc.vault.subDomain }}-active.{{ dsc.vault.namespace }}.svc.cluster.local:8200/"
+      VAULT_INTERNAL_URL: "http://{{ dsc_name }}-vault-active.{{ dsc.vault.namespace }}.svc.cluster.local:8200/"
   global:
     env:
       NODE_ENV: "production"


### PR DESCRIPTION
## Commits liées
https://github.com/cloud-pi-native/socle/commit/79e33fa7b29aa5fcd98db58bdbc56f9679e6a2a6
Correction partielle:
https://github.com/cloud-pi-native/socle/commit/6618770b4227704df1a4f9ba8bf67dca00e8271a

---------

## Quel est le comportement actuel ?
Avec des sous-domaines différents des noms des applications, les jobs de post-installation s'arrêtent avec l'erreur suivante :

```yaml
fatal: [localhost]: FAILED! => changed=false 
  elapsed: 0
  msg: 'Status code was -1 and not [200]: Request failed: <urlopen error [Errno -2] Name does not resolve>'
  redirected: false
  status: -1
  url: http://code-webservice-default.dso-gitlab.svc.cluster.local:8181/api/v4/admin/ci/variables
```

## Quel est le nouveau comportement ?
Les post-installation se terminent avec succès.

## Cette PR introduit-elle un breaking change ?
non

## Autres informations
Je pense qu'il s'agit d'un problème de copier coller de Keycloak qui est la seule application à se baser sur le sous-domaine comme nom de pod.