### PR TITLE
Feat: check ca certificate presence

### DIFF
--- a/roles/ca/tasks/get-ca.yaml
+++ b/roles/ca/tasks/get-ca.yaml
@@ -6,6 +6,12 @@
     name: "{{ ca_name }}"
   register: ca_cert
 
+- name: Verify that the ressource exists
+  ansible.builtin.assert:
+    that: ca_cert.resources | length > 0
+    fail_msg: "The Kubernetes resource (Kind: {{ ca_kind }}, Name: {{ ca_name }}) in namespace '{{ ca_namespace }}' does not exist or could not be retrieved."
+    success_msg: "Successfully verified existence of {{ ca_kind }} '{{ ca_name }}' in namespace '{{ ca_namespace }}'."
+
 - name: Set ca fact (cm)
   ansible.builtin.set_fact:
     additionals_ca_pem_array: "{{ additionals_ca_pem_array + [ca_cert.resources[0].data[key]] }}"


### PR DESCRIPTION
---------

## Quel est le comportement actuel ?
Lorsque la DsoSocleConfig défini l'utilisation dun secret ou configmap, il est possible que celui-ci ne soit pas créé. Une erreur assez obscure arrive plus tard dans execution du playbook Ansible (je ne l'ai plus sous la main parce que j'ai eu ce problème il y a un bon mois déjà).

## Quel est le nouveau comportement ?
Affiche une erreur claire lorsque le ca cert n'existe pas dans le cluster Kubernetes.

## Cette PR introduit-elle un breaking change ?
non

## Autres informations

