### PR TITLE
Fix/keycloak infra password generation

### DIFF
--- a/roles/gitops/post-install/keycloak/tasks/main.yml
+++ b/roles/gitops/post-install/keycloak/tasks/main.yml
@@ -62,7 +62,7 @@
     permanent_admin_present: false
 
 - name: Update admin_present fact
-  when: kc_master_users.json | selectattr('username', 'equalto', 'dsoadmin')
+  when: (kc_master_users.json | selectattr('username', 'equalto', 'dsoadmin') | length) > 0
   ansible.builtin.set_fact:
     permanent_admin_present: true
 
@@ -126,7 +126,7 @@
     temporary_admin_present: false
 
 - name: Update temporary_admin_present fact
-  when: kc_master_users.json | selectattr('username', 'equalto', 'admin')
+  when: (kc_master_users.json | selectattr('username', 'equalto', 'admin') | length) > 0
   ansible.builtin.set_fact:
     temporary_admin_present: true
 
@@ -254,7 +254,7 @@
   block:
     - name: Generate admin user password
       ansible.builtin.set_fact:
-        admin_user_password: "{{ lookup('community.general.random_string', length=16, min_lower=1, min_upper=1, min_special=1, min_numeric=1) }}"
+        admin_user_password: "{{ lookup('community.general.random_string', length=16, min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='!#$%&()*+,-./:;<=>?@[/]^_`{|}~') }}" # exclude " and ' which pose problem with Keycloak
 
     - name: Create dso secret
       kubernetes.core.k8s:

--- a/roles/infra/keycloak-infra/tasks/main.yml
+++ b/roles/infra/keycloak-infra/tasks/main.yml
@@ -221,7 +221,7 @@
     permanent_admin_present: false
 
 - name: Update admin_present fact
-  when: kc_master_users.json | selectattr('username', 'equalto', 'admininfra')
+  when: (kc_master_users.json | selectattr('username', 'equalto', 'admininfra') | length) > 0
   ansible.builtin.set_fact:
     permanent_admin_present: true
 
@@ -285,7 +285,7 @@
     temporary_admin_present: false
 
 - name: Update temporary_admin_present fact
-  when: kc_master_users.json | selectattr('username', 'equalto', 'admin')
+  when: (kc_master_users.json | selectattr('username', 'equalto', 'admin') | length) > 0
   ansible.builtin.set_fact:
     temporary_admin_present: true
 
@@ -378,6 +378,8 @@
   with_items:
     - admin
     - ArgoCDAdmins
+  retries: 3 # Contournement temporaire - Problème de probes/loadbalancing Keycloak
+  delay: 5 # Issue ouverte : https://github.com/cloud-pi-native/socle/issues/876
 
 - name: Get keycloak infra realm users from API
   ansible.builtin.uri:
@@ -405,7 +407,7 @@
   block:
     - name: Generate admin user password
       ansible.builtin.set_fact:
-        admin_user_password: "{{ lookup('community.general.random_string', length=16, min_lower=1, min_upper=1, min_special=1, min_numeric=1) }}"
+        admin_user_password: "{{ lookup('community.general.random_string', length=16, min_lower=1, min_upper=1, min_special=1, min_numeric=1, override_special='!#$%&()*+,-./:;<=>?@[/]^_`{|}~') }}" # exclude " and ' which pose problem with Keycloak
 
     - name: Create infra secret
       kubernetes.core.k8s:
@@ -559,8 +561,7 @@
         name: "{{ item }}"
         definition:
           metadata:
-            labels:
-              "{{ dsc.global.metrics.additionalLabels }}"
+            labels: "{{ dsc.global.metrics.additionalLabels }}"
       loop: "{{ service_monitors_names }}"
 
 - name: Patch podMonitors
@@ -587,6 +588,5 @@
         name: "{{ item }}"
         definition:
           metadata:
-            labels:
-              "{{ dsc.global.metrics.additionalLabels }}"
+            labels: "{{ dsc.global.metrics.additionalLabels }}"
       loop: "{{ pod_monitors_names }}"


### PR DESCRIPTION
## Quel est le comportement actuel ?
Les mots de passe générés pour les instances Keycloak d'infra et de la forge peuvent contenir des guillemets et des apostrophes qui sont mal affichés par Ansible (et/ou interprété par Keycloak pour les guillemets potentiellement). 
J'ai repris la liste des caractères spéciaux du module python utilisé par Ansible : https://docs.python.org/3/library/string.html#string.punctuation

Avec Ansible 2.19, des erreurs de [Broken Conditionals](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_core_2.19.html#broken-conditionals) apparaissent à cause de conversions booléennes implicite de liste.

Enfin, la tâche "Create base admins groups" à beaucoup de mal à passer d'après mon expérience, donc j'ai mis un `retry` à trois fois. J'ai parfois eu des timeout sur d'autres tâches dans ce fichier, mais ce n'est pas prédictible. Je pense qu'au démarrage, Keycloak est un peu lent à répondre le pendant qu'il fasse ses migrations, etc. 

## Quel est le nouveau comportement ?
Le mot de passe  généré pour les instances Keycloak d'infra et de la forge ne contiennent plus de " ou '.

Les conversions booléennes implicite sont maintenant explicites.

Pour le retry, la tâche passe généralement au bout du quatrième essai (dernier) pour le groupe `admin` et au deuxième essai avec le deuxième groupe, `ArgoCDAdmins`.

## Cette PR introduit-elle un breaking change ?
non

## Autres informations
