### PR TITLE
fix: :bug: nexus admin username Vault value absent for console helm values

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/console/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/console/values/00-main.j2
@@ -18,7 +18,7 @@ console:
       KEYCLOAK_ADMIN: "dsoadmin"
       KEYCLOAK_ADMIN_PASSWORD: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/keycloak/values#auth| jsonPath {.adminPassword}>
       KEYCLOAK_URL: "http://{{ dsc.keycloak.subDomain }}.{{ dsc.keycloak.namespace }}.svc.cluster.local/realms/{{ dsc.keycloak.applicationRealm }}/.well-known/openid-configuration"
-      NEXUS_ADMIN: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/nexus/values#auth| jsonPath {.adminUsername}>
+      NEXUS_ADMIN: admin
       NEXUS_ADMIN_PASSWORD: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/nexus/values#auth| jsonPath {.adminPassword}>
       NEXUS_URL: "https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain| jsonPath {.nexus}>/"
       NEXUS_INTERNAL_URL: "http://nexus.{{ dsc.nexus.namespace }}.svc.cluster.local:8081/"


### PR DESCRIPTION
Origine du bug: https://github.com/cloud-pi-native/socle/pull/862#discussion_r2403005978

## Quel est le comportement actuel ?
Lorsqu'Argo CD résous les valeures pour le Helm chart avec APV (argocd-plugin-vault) au début de l'installation de la console, une erreur survient (extrêmement longue, donc résumée ici) :
```
Replace: could not replace all placeholders in Template: jsonPath: adminUsername is not found for placeholder path:dso-gcp-dev/data/env/conf-dso/apps/nexus/values#auth in string NEXUS_ADMIN: <path:dso-gcp-dev/data/env/conf-dso/apps/nexus/values#auth| jsonPath {.adminUsername}>
```

AVP récupère correctement la plupart des secrets (ex: sonarApiToken, gitlabToken, harborAdminPassword, etc.) pour les injecter dans les helm values, mais pour NEXUS_ADMIN, il s’attend à trouver `adminUsername` dans le secret Vault à l'emplacement suivant : `dso-gcp-dev/data/env/conf-dso/apps/nexus/values#auth`. Or, celui-ci n'est pas présent dans ce secret.

```json
"auth": {
  "adminPassword": "XXXXXXXXXXXXXXXXXXXXXXXX"
}
```

## Quel est le nouveau comportement ?
Remplace l'utilisation du secret Vault par la valeur définie en claire depuis la PR mentionnée.

## Cette PR introduit-elle un breaking change ?
non

## Autres informations
Testé et vérifié fonctionnel
