### PR TITLE
fix: :bug: Argo CD admin password

### DIFF
--- a/roles/gitops/vault-secrets/tasks/main.yaml
+++ b/roles/gitops/vault-secrets/tasks/main.yaml
@@ -71,6 +71,58 @@
         namespace: "{{ dsc.keycloak.namespace }}"
       register: keycloak_admin_secret
 
+# Set Argo CD admin password when required
+
+- name: Set Argo CD admin password
+  when: dsc.argocd.admin.enabled
+  block:
+    - name: Set argocd_clear_password fact
+      ansible.builtin.set_fact:
+        argocd_clear_password: "{{ lookup('ansible.builtin.password', '/dev/null', length=24, chars=['ascii_letters', 'digits']) }}"
+
+    - name: Set argocd encrypted password
+      block:
+        - name: Encrypt password
+          changed_when: false
+          ansible.builtin.shell:
+            cmd: |
+              set -o pipefail
+              htpasswd -nbBC 10 "" "{{ argocd_clear_password }}" | tr -d ':\n' | sed 's/$2y/$2a/'
+            executable: /bin/bash
+          register: password_encryption
+
+        - name: Set argocd_encrypted_password fact
+          ansible.builtin.set_fact:
+            argocd_encrypted_password: "{{ password_encryption.stdout }}"
+
+    - name: Set argocd_values
+      ansible.builtin.set_fact:
+        argocd_values:
+          argocdServerAdminClearPassword: "{{ argocd_clear_password }}"
+          argocdServerAdminPassword: "{{ argocd_encrypted_password }}"
+
+    - name: Merge argocd_values into envs vault_values only for argocd
+      ansible.builtin.set_fact:
+        envs: "{{ merged_envs | from_json }}"
+      vars:
+        merged_envs: |
+          {%- set res = [] -%}
+          {%- for e in envs | default([]) -%}
+            {%- set apps = [] -%}
+            {%- for a in e.apps | default([]) -%}
+              {#-- On ne merge que si argocd_app == 'argocd' --#}
+              {%- if a.argocd_app | default('') == 'argocd' -%}
+                {%- set merged_vault = (a.vault_values | default({})) | combine(argocd_values | default({})) -%}
+                {%- set new_app = a | combine({'vault_values': merged_vault}) -%}
+              {%- else -%}
+                {%- set new_app = a -%}
+              {%- endif -%}
+              {%- set _ = apps.append(new_app) -%}
+            {%- endfor -%}
+            {%- set _ = res.append(e | combine({'apps': apps})) -%}
+          {%- endfor -%}
+          {{ res | to_nice_json }}
+
 # Write Vault infra secrets
 
 - name: Write secrets

--- a/roles/socle-config/tasks/envs.yaml
+++ b/roles/socle-config/tasks/envs.yaml
@@ -184,9 +184,7 @@
             nameSpace: "argocd"
             customNamespacePrefix: ""
             syncWave: 50
-            vault_values:
-              argocdServerAdminPassword: |
-                "{{ lookup('ansible.builtin.password', '/dev/null', length=24, chars=['ascii_letters', 'digits']) }}"
+            vault_values: {}
           - argocd_app: sonarqube
             clusterName: ""
             nameSpace: "sonarqube"


### PR DESCRIPTION
## Issues liées

Issues numéro: #935 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Nous générons un mot de passe admin pour Argo CD qui n'est pas fonctionnel.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous générons un password que nous chiffrons à l'aide de la commande `htpasswd` fournie par la documentation officielle d'Argo CD.
Nous mettons à jour à la volée le fact `envs` pour les values d'Argo CD uniquement.
Ceci nous permet de stocker le mot de passe admin en clair dans le Vault d'infrastructure, à côté de sa version chiffrée qui sera utilisée par le chart Helm.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non, compte tenu du fait que le mot de passe n'était pas fonctionnel auparavant.

Le changement nécessite toutefois un reset manuel du mot de passe admin d'Argo CD.

Pour cela, il faudra préalablement vider le secret d'Argo CD dans notre Vault d'infra, puis rejouer le role `vault-secrets` :

```shell
 ansible-playbook install-gitops.yaml -t vault-secrets
```

Ceci générera un nouveau secret avec notamment le mot de passe admin en clair (clé `argocdServerAdminClearPassword` dans le Vault d'infra) et sa version chiffrée avec bcrypt (clé `argocdServerAdminPassword` dans le Vault d'infra).

Au cours de la procédure de reset du mot de passe admin, il faudra utiliser le mot de passe chiffré généré et stocké dans le Vault d'infra (clé `argocdServerAdminPassword`).

Cette procédure est documentée ici de manière officielle :
  * https://argo-cd.readthedocs.io/en/stable/faq/#i-forgot-the-admin-password-how-do-i-reset-it

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de test.