### PR TITLE
feat: :sparkles: Introducing credentials-to-vault admin tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -969,7 +969,27 @@ En résumé, il vous faudra renseigner si besoin, et en complément de ce que vo
   - Stockage S3
   - Docker Hub
 
-Lorsque vous avez terminé les vérifications requises, pousser les changements sur votre branche "ma-branche" :
+Afin de vous faciliter cette étape, nous proposons le playbook `credentials-to-vault.yaml` situé dans le répertoire `admin-tools`.
+
+Pour le lancer en utilisant la configuration par défaut (dsc `conf-dso`) :
+
+```shell
+ansible-playbook admin-tools/credentials-to-vault.yaml
+```
+
+Il créera pour vous le fichier `/tmp/my-credentials.yaml` qu'il vous invitera à remplir avant de relancer le playbook.
+
+Une fois ce fichier rempli avec les credentials souhaités pour la partie dont vous avez besoin (S3, Docker Hub et/ou SMTP), relancez simplement le playbook qui ira remplir pour vous les secrets correspondants dans votre Vault d'infrastructure :
+
+```shell
+ansible-playbook admin-tools/credentials-to-vault.yaml
+```
+
+Notez qu'il vous aura également demandé de remplir la variable d'environnement `KUBECONFIG_INFRA` (vue plus haut) qui lui servira pour aller récupérer le token de votre Vault d'infrastructure. Il est également possible de lui fournir plusieurs autres variables d'environnement vues précédemment si besoin, à savoir `KUBECONFIG_PROXY_INFRA`, `VAULT_INFRA_DOMAIN` et `VAULT_INFRA_TOKEN`.
+
+Une fois le playbook `credentials-to-vault.yaml` exécuté si nécessaire, pensez à supprimer le fichier `/tmp/my-credentials.yaml`.
+
+Lorsque vous avez terminé les vérifications requises vues précédemment (cohérences des fichiers générés et des secrets Vault), poussez les changements sur votre branche "ma-branche" :
 
 ```shell
 git ls-files --modified | xargs git add

--- a/admin-tools/credentials-to-vault.yaml
+++ b/admin-tools/credentials-to-vault.yaml
@@ -1,0 +1,221 @@
+---
+- name: Credentials to vault
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: "Get socle config from conf-dso dsc (default)"
+      kubernetes.core.k8s_info:
+        kind: dsc
+        name: conf-dso
+        api_version: cloud-pi-native.fr/v1alpha
+      register: socle_config
+      tags:
+        - always
+
+    - name: Get socle config from dsc_cr extra var when defined
+      when: dsc_cr is defined
+      kubernetes.core.k8s_info:
+        kind: dsc
+        name: "{{ dsc_cr }}"
+        api_version: cloud-pi-native.fr/v1alpha
+      register: socle_config_custom
+      tags:
+        - always
+
+    - name: Check socle_config_custom and exit if empty
+      when: (dsc_cr is defined) and (socle_config_custom.resources | length == 0)
+      tags:
+        - always
+      block:
+        - name: Warning message
+          ansible.builtin.debug:
+            msg:
+              - "Attention ! Vous avez lancé le playbook avec l'option '-e dsc_cr={{ dsc_cr }}'"
+              - "mais la ressource dsc nommée '{{ dsc_cr }}' est vide ou inexistante côté cluster !"
+              - ""
+              - "Vérifiez que vous ne vous êtes pas trompé de nom et que la ressource existe bien, via la commande suivante :"
+              - ""
+              - " kubectl get dsc {{ dsc_cr }} "
+              - ""
+              - "Si elle n'est pas trouvée (not found), listez simplement les resources dsc actuellement déclarées :"
+              - ""
+              - " kubectl get dsc "
+              - ""
+              - "Puis relancez le playbook avec une resource dsc existante."
+              - ""
+              - "Rappel : le présent playbook lancé seul, sans extra vars, écrira dans le Vault d'infrastructure les credentials associés à la configuration dsc par défaut (conf-dso)."
+
+        - name: Exit playbook
+          ansible.builtin.meta: end_play
+
+    - name: Set socle_config fact when dsc_cr defined and not empty
+      ansible.builtin.set_fact:
+        socle_config: "{{ socle_config_custom }}"
+      when: (socle_config_custom is not skipped) and (socle_config_custom.resources | length > 0)
+      tags:
+        - always
+
+    - name: Set DSC facts
+      ansible.builtin.set_fact:
+        dsc_name: "{{ socle_config.resources[0].metadata.name }}"
+        dsc: "{{ socle_config.resources[0] }}"
+        dsc_default_config: "{{ lookup('ansible.builtin.file', '../roles/socle-config/files/config.yaml') | from_yaml }}"
+        dsc_default_releases: "{{ lookup('ansible.builtin.file', '../roles/socle-config/files/releases.yaml') | from_yaml }}"
+      tags:
+        - always
+
+    - name: Combine DSC with config and releases
+      ansible.builtin.set_fact:
+        dsc: "{{ (dsc_default_releases | combine(dsc_default_config, recursive=True) | combine(dsc, recursive=True)).spec }}"
+      tags:
+        - always
+
+    - name: Get DSO config Secret from DSO console namespace
+      kubernetes.core.k8s_info:
+        kind: Secret
+        name: dso-config
+        namespace: "{{ dsc.console.namespace }}"
+      register: dso_console_config
+      tags:
+        - always
+
+    # Reusing some tasks from gitops/local-config
+
+    - name: Check infrastructure cluster access
+      when: lookup('ansible.builtin.env', 'KUBECONFIG_INFRA') | length == 0
+      block:
+        - name: Missing "KUBECONFIG_INFRA" environment variable
+          ansible.builtin.debug:
+            msg:
+              - "La variable d'environnement KUBECONFIG_INFRA n'est pas définie."
+              - "Veuillez la définir avec le chemin absolu vers votre kubeconfig pour accéder au cluster d'admnistration (Argo CD et Vault d'infra)."
+
+        - name: Exit playbook
+          ansible.builtin.meta: end_play
+
+    - name: "Déclaration du kubeconfig infra"
+      ansible.builtin.set_fact:
+        kubeconfig_infra: "{{ lookup('ansible.builtin.env', 'KUBECONFIG_INFRA') }}"
+
+    - name: Check infrastructure cluster access
+      when: lookup('ansible.builtin.env', 'KUBECONFIG_PROXY_INFRA') | length == 0
+      block:
+        - name: Undefined "KUBECONFIG_PROXY_INFRA" environment variable
+          ansible.builtin.debug:
+            msg:
+              - "La variable d'environnement KUBECONFIG_PROXY_INFRA n'est pas définie."
+              - "Elle est nécessaire en cas d'utilisation de tsh proxy kube."
+              - "Dans ce cas, veuillez la définir avec la valeur requises pour accéder au cluster d'admnistration (Argo CD et Vault d'infra)."
+
+    - name: "Déclaration du kubeconfig proxy infra"
+      when: lookup('ansible.builtin.env', 'KUBECONFIG_PROXY_INFRA') | length > 0
+      ansible.builtin.set_fact:
+        kubeconfig_proxy_infra: "{{ lookup('ansible.builtin.env', 'KUBECONFIG_PROXY_INFRA') }}"
+
+    # Reusing some tasks from socle-config
+
+    - name: Set root_domain fact from dsc global config
+      ansible.builtin.set_fact:
+        root_domain: "{{ dsc.global.rootDomain }}"
+
+    - name: Set infra_root_domain fact from dsc global config
+      ansible.builtin.set_fact:
+        infra_root_domain: "{{ dsc.global.infraRootDomain }}"
+
+    - name: Set vault_domain fact from dsc config
+      ansible.builtin.set_fact:
+        vault_domain: "{{ dsc.vault.domain | default(dsc.vault.subDomain ~ root_domain) }}"
+
+    - name: Set Vault infra domain fact from environment variable
+      when: lookup('ansible.builtin.env', 'VAULT_INFRA_DOMAIN') | length > 0
+      ansible.builtin.set_fact:
+        vaultinfra_domain: "{{ lookup('ansible.builtin.env', 'VAULT_INFRA_DOMAIN') }}"
+
+    - name: Set Vault infra domain fact from dsc config when environment variable not set
+      when: lookup('ansible.builtin.env', 'VAULT_INFRA_DOMAIN') | length == 0
+      ansible.builtin.set_fact:
+        vaultinfra_domain: "{{ dsc.vaultInfra.domain | default(dsc.vaultInfra.subDomain ~ infra_root_domain) }}"
+
+    - name: Set Vault infra token fact
+      ansible.builtin.include_role:
+        name: shared_tasks
+      vars:
+        shared_tasks_run: vault-infra-token.yaml
+
+    - name: Probe Vault infra domain cert validity
+      ansible.builtin.uri:
+        url: "https://{{ vaultinfra_domain }}"
+        method: GET
+        return_content: false
+        validate_certs: true
+      register: vaultinfra_probe
+      ignore_errors: true
+
+    - name: Set Vault infra certificate validity fact based on domain probe result
+      ansible.builtin.set_fact:
+        vaultinfra_cert_valid: "{{ vaultinfra_probe.failed is not defined or not vaultinfra_probe.failed }}"
+
+    - name: Debug vaultinfra_domain fact
+      ansible.builtin.debug:
+        msg:
+          - "vaultinfra_domain: {{ vaultinfra_domain }}"
+
+    - name: Set vaultinfra_kv_name fact
+      ansible.builtin.set_fact:
+        vaultinfra_kv_name: "dso-{{ dsc.global.gitOps.envName }}"
+
+    - name: Import ca role
+      ansible.builtin.import_role:
+        name: ca
+
+    # Managing yaml file and envs
+
+    - name: Check if /tmp/my-credentials.yaml exists
+      ansible.builtin.file:
+        state: file
+        path: /tmp/my-credentials.yaml
+      register: tmp_file
+      ignore_errors: true
+
+    - name: Manage /tmp/my-credentials.yaml file if absent
+      when: tmp_file.state == 'absent'
+      block:
+        - name: Copy credentials template to /tmp
+          ansible.builtin.copy:
+            content: "{{ lookup('ansible.builtin.template', './templates/my-credentials-example.yaml') }}"
+            dest: /tmp/my-credentials.yaml
+            mode: "0600"
+
+        - name: Dislay warning message
+          ansible.builtin.debug:
+            msg: |
+              "
+              Le fichier /tmp/my-credentials.yaml vient d'être créé.
+
+              Veuillez le remplir avec les credentials requis puis relancer le playbook.
+              "
+
+        - name: Terminate playbook execution
+          ansible.builtin.meta:
+            end_play
+
+    - name: Set envs facts from yaml file
+      ansible.builtin.set_fact:
+        envs: "{{ lookup('ansible.builtin.template', '/tmp/my-credentials.yaml') | from_yaml }}"
+
+    # Reusing some tasks from gitops/vault-secrets
+
+    - name: Retrieve Vault infra token
+      ansible.builtin.include_role:
+        name: shared_tasks
+      vars:
+        shared_tasks_run: vault-infra-token.yaml
+
+    - name: Write secrets
+      ansible.builtin.include_tasks: ../roles/gitops/vault-secrets/tasks/write.yml
+      loop: "{{ envs | subelements('apps') }}"
+      loop_control:
+        label: "{{ item.0.name }}"
+      vars:
+        vault_secrets_post_install: true
+        post_vault_update: true

--- a/admin-tools/templates/my-credentials-example.yaml
+++ b/admin-tools/templates/my-credentials-example.yaml
@@ -1,0 +1,30 @@
+- name: "{{ dsc_name }}"
+  apps:
+    - argocd_app: global
+      vault_values:
+        dockerAccount:
+          username: ""
+          password: ""
+        backup:
+          s3AccessKey: ""
+          s3SecretKey: ""
+        smtp:
+          authentication:
+            user: ""
+            password: ""
+    - argocd_app: harbor
+      vault_values:
+        global:
+          s3ImageChartStorage:
+            accesskey: ""
+            secretkey: ""
+          proxyCache:
+            - name: dockerhub
+              registry:
+                credential:
+                  accessKey: ""
+                  accessSecret: ""
+                  type: basic
+                endpointUrl: https://hub.docker.com
+                insecure: false
+                provider: docker-hub

--- a/roles/gitops/vault-secrets/tasks/write.yml
+++ b/roles/gitops/vault-secrets/tasks/write.yml
@@ -23,14 +23,15 @@
     - name: Retrieve current vault secret
       community.hashi_vault.vault_kv2_get:
         url: "https://{{ vaultinfra_domain }}"
-        auth_method: token
-        token: "{{ vault_infra_token }}"
         namespace: "{{ dsc.vaultInfra.namespace }}"
         engine_mount_point: "{{ vaultinfra_kv_name }}"
         path: "env/{{ item.0.name }}/apps/{{ item.1.argocd_app }}/values"
         validate_certs: "{{ vaultinfra_cert_valid }}"
+      environment:
+        VAULT_TOKEN: "{{ vault_infra_token }}"
       register: current_vault_values
       ignore_errors: true
+      no_log: true
 
     - name: Get current non null values
       when: not vault_secrets_post_install
@@ -77,6 +78,6 @@
         data: "{{ current_vault_values_combined.stdout | from_json }}"
         validate_certs: "{{ vaultinfra_cert_valid }}"
 
-    - name: Set {{ item.1.argocd_app }}_current_vault_values
+    - name: Set_current_vault_values for {{ item.1.argocd_app }}
       ansible.builtin.set_fact:
         "{{ item.1.argocd_app }}_current_vault_values": "{{ current_vault_values }}"


### PR DESCRIPTION
## Issues liées

Issues numéro: #940 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Dans le cadre du versioning de la crd/dsc, nous avons introduit une initialisation à vide pour plusieurs secrets de credentials dans le Vault d'infrastructure (parties S3, Docker Hub et SMTP). Il s'agit typiquement de secrets qui ne peuvent être remplis automatiquement par l'installateur du Socle et nécessitent donc une intervention de l'utilisateur.

Il nous faudrait un playbook d'admin, utilisable notamment lors d'une first install, qui faciliterait le peuplement de ces éléments dans le Vault d'infrastructure à partir d'un fichier YAML. Il permettrait ainsi de ne rien oublier.

L'utilisation de ce playbook devra par ailleurs être documentée dans le Readme du Socle.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous proposons le playbook `admin-tools/credentials-to-vault.yaml` qui répond au besoin.

Il créera pour l'utilisateur un fichier `/tmp/my-credentials.yaml` qu'il lui suffira de remplir avant de relancer le playbook pour que les secrets correspondants soient actualisés dans le Vault d'infrastructure.

L'utilisation de ce playbook est par ailleurs documentée dans le Readme du Socle.

Nous corrigeons aussi à cette occasion le fichier de tasks `write.yml` du role `vault-secrets`, au niveau de la task `Retrieve current vault secret`. En effet, celle-ci protégeait auparavant le contenu de la clé `vault_infra_token` pour l'application `global` car elle détectait que cette clé contenait le token utilisé par le module `community.hashi_vault.vault_kv2_get` lui-même.
Elle remplaçait donc son contenu par `VALUE_SPECIFIED_IN_NO_LOG_PARAMETER` et c'est cette valeur qui se retrouvait inscrite dans le Vault d'infrastructure à la place du token, puisque du point de vue des tasks subséquentes elle avait changé.
Pour éviter ce désagrément, tout en maintenant le niveau de sécurité requis, nous contournons ce comportement du module en lui fournissant plutôt le token sous forme de variable d'environnement (sur laquelle il n'effectue pas de vérification), tout en ajoutant le paramètre `no_log: true` à la task ansible.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de développement.