### PR TITLE
fix: :bug: Keycloak infra registry values

### DIFF
--- a/roles/infra/keycloak-infra/templates/values/10-registry.j2
+++ b/roles/infra/keycloak-infra/templates/values/10-registry.j2
@@ -1,13 +1,13 @@
-{% if use_private_registry %}
+global:
+  security:
+    allowInsecureImages: true
 image:
-  registry: "{{ dsc.global.registry }}"
+  registry: "{{ dsc.global.registry | default('docker.io') }}"
   repository: bitnamilegacy/keycloak
-{% endif %}
+  pullPolicy: "IfNotPresent"
 
 {% if use_image_pull_secrets %}
 global:
   imagePullSecrets: 
   - dso-config-pull-secret
-  security:
-    allowInsecureImages: true
 {% endif %}


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Le déploiement du Keycloak d'infra n'est pas aligné avec les changements survenus récemment sur le Keycloak de la chaîne DSO, au niveau du repository de l'image qui a évolué vers `bitnamilegacy/keycloak`.

Il en résulte notamment une erreur `imagePullBackOff` sur les pods keycloak en cas de redémarrage des nodes, car l'ancienne image n'est plus présente localement et ne peut plus être récupérée puisque dépréciée.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous adaptons le template `10-registry.j2` utilisé afin de peupler les values du chart pour la partie image, de manière à l'aligner sur ce qui a été fait pour le Keycloak de la chaîne DSO et donc utiliser à présent le repository `bitnamilegacy/keycloak`.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé sur un cluster de tests où l'instance Keycloak d'infra était "cassée".