### PR TITLE
feat: :sparkles: Add socleVersion annotation to crd and dsc

### DIFF
--- a/roles/socle-config/tasks/main.yaml
+++ b/roles/socle-config/tasks/main.yaml
@@ -1,7 +1,11 @@
 ---
+- name: Set socle_version fact
+  ansible.builtin.set_fact:
+    socle_version: "{{ (lookup('ansible.builtin.file', '../../package.json') | from_json).version }}"
+
 - name: Create or update DsoSocleConfig CRD
   kubernetes.core.k8s:
-    definition: "{{ lookup('ansible.builtin.file', 'crd-conf-dso.yaml') | from_yaml }}"
+    definition: "{{ lookup('ansible.builtin.template', './templates/crd-conf-dso.yaml') | from_yaml }}"
   when: post_conf_job is not defined
 
 - name: Get socle config from conf-dso dsc (default)
@@ -106,7 +110,7 @@
 
     - name: Render CRD file into GitOps local repo
       ansible.builtin.copy:
-        src: crd-conf-dso.yaml
+        content: "{{ lookup('ansible.builtin.template', './templates/crd-conf-dso.yaml') }}"
         dest: "{{ gitops_local_repo }}/{{ dsc.spec.global.gitOps.repo.path }}/envs/{{ dsc_name }}/apps/global/crds/dsc-crd.yaml"
         mode: "0644"
 
@@ -115,6 +119,26 @@
     dsc_yaml: "{{ dsc
       | ansible.utils.remove_keys(target=['annotations', 'creationTimestamp', 'generation', 'managedFields', 'resourceVersion', 'uid'])
       | to_nice_yaml(indent=2) }}"
+
+- name: Annotate dsc_yaml with socle_version
+  block:
+    - name: Parsing YAML to dict
+      ansible.builtin.set_fact:
+        dsc_yaml_dict: "{{ dsc_yaml | from_yaml }}"
+
+    - name: Adding annotation
+      ansible.builtin.set_fact:
+        dsc_yaml_dict: >-
+          {{ dsc_yaml_dict
+            | combine(
+                {'metadata': {'annotations': {'socleVersion': socle_version}}},
+                recursive=True
+              )
+          }}
+
+    - name: Set back to nice YAML
+      ansible.builtin.set_fact:
+        dsc_yaml: "{{ dsc_yaml_dict | to_nice_yaml(indent=2) }}"
 
 - name: Store dsc to local repository
   when: post_conf_job is not defined

--- a/roles/socle-config/templates/crd-conf-dso.yaml
+++ b/roles/socle-config/templates/crd-conf-dso.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: dso-socle-configs.cloud-pi-native.fr
+  annotations:
+    socleVersion: {{socle_version}}
 spec:
   conversion:
     strategy: None


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Nos ressources crd et dsc sont bien gérées en mode GitOps mais, une fois déployées dans le cluster, nous ne pouvons pas savoir de quelle version du Socle elles sont issues.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous ajoutons aux deux ressources l'annotation `socleVersion` en nous basant sur le numéro de release, lequel figure dans le fichier `package.json` du code du Socle à partir duquel les fichiers des ressources en question ont été générés.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de test.