### PR TITLE
Fix/dsc ingress annotation

### DIFF
--- a/roles/socle-config/tasks/main.yaml
+++ b/roles/socle-config/tasks/main.yaml
@@ -117,21 +117,28 @@
 - name: Set dsc_yaml fact
   ansible.builtin.set_fact:
     dsc_yaml: "{{ dsc
-      | ansible.utils.remove_keys(target=['annotations', 'creationTimestamp', 'generation', 'managedFields', 'resourceVersion', 'uid'])
+      | ansible.utils.remove_keys(target=['metadata', 'creationTimestamp', 'generation', 'managedFields', 'resourceVersion', 'uid'])
       | to_nice_yaml(indent=2) }}"
 
-- name: Annotate dsc_yaml with socle_version
+- name: Add socle_version annotation and dsc_name to dsc_yaml
   block:
     - name: Parsing YAML to dict
       ansible.builtin.set_fact:
         dsc_yaml_dict: "{{ dsc_yaml | from_yaml }}"
 
-    - name: Adding annotation
+    - name: Adding annotation and dsc name
       ansible.builtin.set_fact:
         dsc_yaml_dict: >-
           {{ dsc_yaml_dict
             | combine(
-                {'metadata': {'annotations': {'socleVersion': socle_version}}},
+                {
+                  'metadata': {
+                    'annotations': {
+                      'socleVersion': socle_version
+                      },
+                    'name': dsc_name
+                    }
+                },
                 recursive=True
               )
           }}
@@ -265,3 +272,5 @@
   when: post_conf_job is not defined
   ansible.builtin.include_tasks:
     file: envs.yaml
+
+- meta: end_play


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->

Le role socle-config, lorsqu'il effectue le rendu du template dsc.yaml,  supprime toutes les annotations de la dsc, au lieu de supprimer uniquement les annotations qui se trouvent sous metadata.

Il en résulte qu'il supprime aussi dans ce fichier les annotations éventuelles de la partie ingress, ce que nous souhaitons éviter.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->

Nous corrigeons le point en effectuant une supression préalable de la partie metadata de la représentation YAML qui sera écrite dans le fichier dsc.yaml, avant de la reconstruire avec les metadatas souhaitées (annotation "socleVersion" et nom de la dsc), de sorte que le reste des éventuelles annotations du fichier ne soit pas impacté.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

Non.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

Comportement testé et validé dans un cluster de test.
