### PR TITLE
fix: use gitlab internal url for runner adn glexporter

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/gitlabrunner/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlabrunner/values/00-main.j2
@@ -5,7 +5,7 @@ gitlabrunner:
 ## How many old ReplicaSets for this Deployment you want to retain
   revisionHistoryLimit: 2
   
-  gitlabUrl: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.gitlab}>/
+  gitlabUrl: http://gitlab-webservice-default.{{ dsc.gitlab.namespace }}.svc.cluster.local:8080/
   
   runnerToken: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/gitlab/values#runnerToken>
   

--- a/roles/gitops/rendering-apps-files/templates/glexporter/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/templates/glexporter/values/00-main.j2
@@ -2,7 +2,7 @@ glexporter:
   fullnameOverride: "glexporter"
   config:
     gitlab:
-      url: https://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.gitlab}>/
+      url: http://gitlab-webservice-default.{{ dsc.gitlab.namespace }}.svc.cluster.local:8080/
       token: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/gitlab/values#gitlabToken>
     redis:
       url: "redis://glexporter-redis-master.{{ dsc.gitlab.namespace }}.svc:6379"


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Gitlab runner et glexporter utilisent l'url public de gitlab

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Gitlab runner et glexporter utilisent l'url interne de gitlab

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
