### PR TITLE
Rendre l'URL et la révision du dépôt socle configurables via le CRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1719,13 +1719,14 @@ kubectl explain dsc.spec.global.backup.cnpg
 ## Offline / air gap
 
 En mode air gap ou déconnecté d'internet, certaines valeurs de la `dsc` devront être adaptées.
-- `dsc.sonarqube:`
+- `dsc.sonarqube` :
   - `pluginDownloadUrl` et `prometheusJavaagentVersion`
 - `dsc.gitlabCatalog.catalogRepoUrl`
 - `dsc.argocd.privateGitlabDomain`
 - `dsc.grafanaOperator.ociChartUrl`
 - `helmRepoUrl` pour chaque service à savoir :
   - `argocd`, `certmanager`, `cloudnativepg`, `console`, `glexporter`, `gitlabOperator`, `gitlabrunner`, `harbor`, `keycloak`, `kyverno`, `sonarqube` et `vault`
+- `dsc.awx.repoSocle.url` (et optionnellement : `dsc.awx.repoSocle.revision`)
 
 ## Platform
 

--- a/roles/gitops/rendering-apps-files/templates/awx/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/awx/values/200-ansible-job.j2
@@ -7,7 +7,7 @@ cpn-ansible-job:
     - /bin/sh
     - -c
     - |
-      git clone https://github.com/cloud-pi-native/socle.git && \
+      git clone {{ dsc.awx.repoSocle.url }} -b {{ dsc.awx.repoSocle.revision }} socle && \
       cd socle && \
       ansible-playbook post-install/awx-oidc.yaml
 {% if dsc.proxy.enabled %}

--- a/roles/gitops/rendering-apps-files/templates/gitlab/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlab/values/200-ansible-job.j2
@@ -7,7 +7,7 @@ cpn-ansible-job:
     - /bin/sh
     - -c
     - |
-      git clone https://github.com/cloud-pi-native/socle.git && \
+      git clone {{ dsc.awx.repoSocle.url }} -b {{ dsc.awx.repoSocle.revision }} socle && \
       cd socle && \
       ansible-playbook post-install/gitlab.yaml
     extraEnvFrom:
@@ -22,6 +22,6 @@ cpn-ansible-job:
     - /bin/sh
     - -c
     - |
-      git clone https://github.com/cloud-pi-native/socle.git && \
+      git clone {{ dsc.awx.repoSocle.url }} -b {{ dsc.awx.repoSocle.revision }} socle && \
       cd socle && \
       ansible-playbook post-install/gitlab-ci-catalog.yaml

--- a/roles/gitops/rendering-apps-files/templates/global/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/global/values/200-ansible-job.j2
@@ -8,7 +8,7 @@ cpn-ansible-job:
     - /bin/sh
     - -c
     - |
-      git clone https://github.com/cloud-pi-native/socle.git && \
+      git clone {{ dsc.awx.repoSocle.url }} -b {{ dsc.awx.repoSocle.revision }} socle && \
       cd socle && \
       ansible-playbook post-install/pgdump.yaml
 {% if dsc.global.backup.s3.endpointCA is defined %}

--- a/roles/gitops/rendering-apps-files/templates/harbor/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/harbor/values/200-ansible-job.j2
@@ -7,7 +7,7 @@ cpn-ansible-job:
     - /bin/sh
     - -c
     - |
-      git clone https://github.com/cloud-pi-native/socle.git && \
+      git clone {{ dsc.awx.repoSocle.url }} -b {{ dsc.awx.repoSocle.revision }} socle && \
       cd socle && \
       ansible-playbook post-install/harbor.yaml
     extraEnvFrom:

--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/200-ansible-job.j2
@@ -7,7 +7,7 @@ cpn-ansible-job:
     - /bin/sh
     - -c
     - |
-      git clone https://github.com/cloud-pi-native/socle.git && \
+      git clone {{ dsc.awx.repoSocle.url }} -b {{ dsc.awx.repoSocle.revision }} socle && \
       cd socle && \
       ansible-playbook post-install/keycloak.yaml
     extraEnvFrom:

--- a/roles/gitops/rendering-apps-files/templates/sonarqube/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/sonarqube/values/200-ansible-job.j2
@@ -7,7 +7,7 @@ cpn-ansible-job:
     - /bin/sh
     - -c
     - |
-      git clone https://github.com/cloud-pi-native/socle.git && \
+      git clone {{ dsc.awx.repoSocle.url }} -b {{ dsc.awx.repoSocle.revision }} socle && \
       cd socle && \
       ansible-playbook post-install/sonarqube.yaml
     extraEnvFrom:

--- a/roles/gitops/rendering-apps-files/templates/vault/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/vault/values/200-ansible-job.j2
@@ -7,7 +7,7 @@ cpn-ansible-job:
     - /bin/sh
     - -c
     - |
-      git clone https://github.com/cloud-pi-native/socle.git && \
+      git clone {{ dsc.awx.repoSocle.url }} -b {{ dsc.awx.repoSocle.revision }} socle && \
       cd socle && \
       ansible-playbook post-install/vault.yaml
     extraEnvFrom:

--- a/roles/socle-config/templates/crd-conf-dso.yaml
+++ b/roles/socle-config/templates/crd-conf-dso.yaml
@@ -183,6 +183,16 @@ spec:
                     chartVersion:
                       description: AWX Operator helm chart version (e.g., "2.19.1").
                       type: string
+                    repoSocle:
+                      type: object
+                      description: Configuration for the socle Git repository used by Ansible jobs for post-installation tasks.
+                      properties:
+                        url:
+                          type: string
+                          description: URL of the socle Git repository containing the post-installation Ansible playbooks.
+                        revision:
+                          type: string
+                          description: Branch, tag, or commit hash of the Git repository to clone for Ansible jobs.
                     defaultAwxVersion:
                       description: |
                         AWX default version related to chartVersion is required only
@@ -200,7 +210,7 @@ spec:
                       type: string
                       default: 10Gi
                     helmRepoUrl:
-                      description: AWX repository url.
+                      description: AWX helm repository url.
                       type: string
                     cnpg:
                       description: Configuration for cnpg clusters.
@@ -215,7 +225,7 @@ spec:
                             - replica
                             - restore
                         exposed:
-                          description: Whether or not the cnpg cluster shoul be exposed via NodePort.
+                          description: Whether or not the cnpg cluster should be exposed via NodePort.
                           type: boolean
                           default: false
                         nodePort:


### PR DESCRIPTION
## Quel est le comportement actuel ?
Actuellement, l’URL et la révision du dépôt Git "socle" utilisé par les jobs Ansible pour les tâches de post-installation sont **codées en dur**. Le dépôt est cloné avec une URL fixe (`https://github.com/cloud-pi-native/socle.git`) sans possibilité de spécifier une révision (branche, tag ou commit) autre que la branche par défaut.

## Quel est le nouveau comportement ?
Avec ce changement, l’URL et la révision du dépôt "socle" deviennent **configurables** via le CRD. Deux nouveaux champs ont été ajoutés :
- `repoSocle.url` : Permet de spécifier une URL personnalisée pour le dépôt Git contenant les playbooks Ansible.
- `repoSocle.revision` : Permet de spécifier une branche, un tag ou un commit spécifique à cloner.

Exemple d’utilisation dans le CRD :
```yaml
repoSocle:
  url: "https://mon-depot.fr/mon-socle.git"
  revision: "branche-tag-ou-commit-id"
```

## Cette PR introduit-elle un breaking change ?
Non, pas de modification du comportement par défaut.

## Autres informations
Ce changement est particulièrement utile pour :
- Les environnements **air-gapped** où l’URL du dépôt peut être différente.
- Les phases de **développement** ou de test, où il est nécessaire de pointer vers une branche ou un commit spécifique.

Je l'ai testé et, même si le `\` se met sur la ligne suivante, cela ne pose pas de problème lors de execution du job :
```
    - 'git clone https://github.com/benji78/pi-native-socle.git -b develop socle &&
      \
```