### PR TITLE
feat: :sparkles: use internal Nexus url in Maven config file

### DIFF
--- a/roles/gitops/post-install/gitlab/templates/mvn_conf_file.j2
+++ b/roles/gitops/post-install/gitlab/templates/mvn_conf_file.j2
@@ -15,19 +15,19 @@
     <mirror>
       <id>mirror-dso</id>
       <name>mirror-dso</name>
-      <url>https://{{ nexus_domain }}/repository/$${env.PROJECT_PATH}-repository-group/</url>
+      <url>http://nexus.{{ dsc.nexus.namespace }}.svc.cluster.local:8081/repository/$${env.PROJECT_PATH}-repository-group/</url>
       <mirrorOf>*</mirrorOf>
     </mirror>
     <mirror>
       <id>nexus</id>
       <name>nexus</name>
-      <url>https://{{ nexus_domain }}/repository/maven-public/</url>
+      <url>http://nexus.{{ dsc.nexus.namespace }}.svc.cluster.local:8081/repository/maven-public/</url>
       <mirrorOf>*</mirrorOf>
     </mirror>
     <mirror>
       <id>mirror-dso</id>
       <name>mirror-dso</name>
-      <url>https://{{ nexus_domain }}/repository/public/</url>
+      <url>http://nexus.{{ dsc.nexus.namespace }}.svc.cluster.local:8081/repository/public/</url>
       <mirrorOf>*</mirrorOf>
     </mirror>
   </mirrors>
@@ -37,7 +37,7 @@
       <repositories>
         <repository>
           <id>nexus</id>
-          <url>https://{{ nexus_domain }}/repository/$${env.PROJECT_PATH}-repository-group/</url>
+          <url>http://nexus.{{ dsc.nexus.namespace }}.svc.cluster.local:8081/repository/$${env.PROJECT_PATH}-repository-group/</url>
           <releases>
             <enabled>true</enabled>
           </releases>


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Maven config for pipeline is using nexus public url.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Maven config for pipeline will use nexus internal url.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
No.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
IMPORTANT: this need careful consideration before merging to main. Because Gitlab post-install will synchronize if `dsc.gitlab.repoSocle.revision` is set to `main`.