### PR TITLE
fix: keycloak user as gitops - dont update the password of inactivate…

### DIFF
--- a/roles/gitops/post-install/keycloak/tasks/sync_users.yml
+++ b/roles/gitops/post-install/keycloak/tasks/sync_users.yml
@@ -38,7 +38,7 @@
     credentials: >-
       {{
         omit
-        if item.value.email in (kc_dso_users_list | map(attribute='email') | list)
+        if item.value.email in (kc_dso_users_list | map(attribute='email') | list) or item.value.status != 'active'
         else [
           {
             'type': 'password',


### PR DESCRIPTION
…d user

## Issues liées

Issues numéro: #968
---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Le job post-install keycloak essaie de remettre le mot de passe temporaries pour les utilisateurs désactivés  

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
si l'user n'est pas a activer, le job post-install ne fournie pas un mot de passe 

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
