### PR TITLE
fix: bump version to non destructive values on error

### DIFF
--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -79,7 +79,7 @@ spec:
     # https://github.com/cloud-pi-native/helm-charts/tags
     observabilityChartVersion: ">=0.0.0 <1.0.0"
     # https://github.com/cloud-pi-native/helm-charts/tags
-    observabilityPluginVersion: "v1.1.6"
+    observabilityPluginVersion: "v1.1.7"
   sonarqube:
     # https://artifacthub.io/packages/helm/sonarqube/sonarqube
     chartVersion: 10.8.1


### PR DESCRIPTION

Le plugin d'observabilite detruisait toute les values en cas d'erreur sur la requete
vers l'instance GitLab.

Note: https://github.com/cloud-pi-native/console-plugin-observability/issues/18

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>
