### PR TITLE
feat: :sparkles: add cloudProvider for specificity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,11 @@ description = "Outillage d'installation de la plateforme Cloud Pi Native"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "ansible>=13.2.0",
-    "hvac>=2.4.0",
-    "jmespath>=1.0.1",
-    "kubernetes>=35.0.0",
-    "python-gitlab>=7.1.0",
-    "pyyaml>=6.0.3",
-    "urllib3<2.6.0", # https://github.com/kubernetes-client/python/issues/2477
+  "ansible>=13.2.0",
+  "hvac>=2.4.0",
+  "jmespath>=1.0.1",
+  "kubernetes>=35.0.0",
+  "python-gitlab>=7.1.0",
+  "pyyaml>=6.0.3",
+  "urllib3<2.6.0", # https://github.com/kubernetes-client/python/issues/2477
 ]

--- a/roles/gitops/rendering-apps-files/templates/console/values/100-cnpg.j2
+++ b/roles/gitops/rendering-apps-files/templates/console/values/100-cnpg.j2
@@ -57,6 +57,12 @@ cluster:
       schedule: 0 0 */6 * * *                                                              
       backupOwnerReference: self
       method: barmanObjectStore
+{% if dsc.global.cloudProvider is defined and dsc.global.cloudProvider == 'Scaleway' %}
+    wal:
+      encryption: ''
+    data:
+      encryption: ''
+{% endif %}
 {% if dsc.global.backup.s3.endpointCA is defined %}
     endpointCA:
       create: true

--- a/roles/gitops/rendering-apps-files/templates/gitlab/values/100-cnpg.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlab/values/100-cnpg.j2
@@ -57,6 +57,12 @@ cluster:
       schedule: 0 0 */6 * * *                                                              
       backupOwnerReference: self
       method: barmanObjectStore
+{% if dsc.global.cloudProvider is defined and dsc.global.cloudProvider == 'Scaleway' %}
+    wal:
+      encryption: ''
+    data:
+      encryption: ''
+{% endif %}
 {% if dsc.global.backup.s3.endpointCA is defined %}
     endpointCA:
       create: true

--- a/roles/gitops/rendering-apps-files/templates/harbor/values/100-cnpg.j2
+++ b/roles/gitops/rendering-apps-files/templates/harbor/values/100-cnpg.j2
@@ -57,6 +57,12 @@ cluster:
       schedule: 0 0 */6 * * *                                                              
       backupOwnerReference: self
       method: barmanObjectStore
+{% if dsc.global.cloudProvider is defined and dsc.global.cloudProvider == 'Scaleway' %}
+    wal:
+      encryption: ''
+    data:
+      encryption: ''
+{% endif %}
 {% if dsc.global.backup.s3.endpointCA is defined %}
     endpointCA:
       create: true

--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/100-cnpg.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/100-cnpg.j2
@@ -57,6 +57,12 @@ cluster:
       schedule: 0 0 */6 * * *                                                              
       backupOwnerReference: self
       method: barmanObjectStore
+{% if dsc.global.cloudProvider is defined and dsc.global.cloudProvider == 'Scaleway' %}
+    wal:
+      encryption: ''
+    data:
+      encryption: ''
+{% endif %}
 {% if dsc.global.backup.s3.endpointCA is defined %}
     endpointCA:
       create: true

--- a/roles/gitops/rendering-apps-files/templates/sonarqube/values/100-cnpg.j2
+++ b/roles/gitops/rendering-apps-files/templates/sonarqube/values/100-cnpg.j2
@@ -57,6 +57,12 @@ cluster:
       schedule: 0 0 */6 * * *                                                              
       backupOwnerReference: self
       method: barmanObjectStore
+{% if dsc.global.cloudProvider is defined and dsc.global.cloudProvider == 'Scaleway' %}
+    wal:
+      encryption: ''
+    data:
+      encryption: ''
+{% endif %}
 {% if dsc.global.backup.s3.endpointCA is defined %}
     endpointCA:
       create: true

--- a/roles/socle-config/templates/crd-conf-dso.yaml
+++ b/roles/socle-config/templates/crd-conf-dso.yaml
@@ -983,6 +983,10 @@ spec:
                               type: string
                           type: object
                       type: object
+                    cloudProvider:
+                      description: |
+                        Cloud provider (AWS, GCP, Azure, Scaleway...).
+                      type: string
                     platform:
                       default: openshift
                       description: |


### PR DESCRIPTION
## Issues liées

Issues numéro: #975 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Related to https://github.com/cloud-pi-native/socle/pull/911, some cloud providers suddenly stop supporting AES encryption which made CNPG backup fail.
We were adding manually in our values repositories.
```yaml
    wal:
      encryption: ''
    data:
      encryption: ''
```

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Time to automate this.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
No.

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
We could have use `dsc` values but need this to be fixed first: https://github.com/cloud-pi-native/socle/issues/788

