### PR TITLE
fix: disable gitlab public search

### DIFF
--- a/roles/gitops/post-install/gitlab/tasks/main.yaml
+++ b/roles/gitops/post-install/gitlab/tasks/main.yaml
@@ -67,6 +67,8 @@
       default_branch_protection: 0
       import_sources:
         - git
+      restricted_visibility_levels:
+        - public
     body_format: form-urlencoded
   changed_when: true
 


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
l'url /search de gitlab est public

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
/search redirige vers le keycloak

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
