### PR TITLE
fix: combine with user supplied values task fixes

### DIFF
--- a/roles/gitops/rendering-apps-files/tasks/template.yml
+++ b/roles/gitops/rendering-apps-files/tasks/template.yml
@@ -107,10 +107,14 @@
         combine_user_values: >-
           {%- set app_name = item.1.argocd_app -%}
           {%- if app_name == 'gitlab' -%}
+            {%- if 'cnpg' in dsc.gitlab and 'values' in dsc.gitlab['cnpg'] -%}
           {{ {} | combine({app_name: dsc.gitlabOperator['values'], 'cluster': dsc[app_name]['cnpg']['values']}) }}
+            {%- else -%}
+          {{ {} | combine({app_name: dsc.gitlabOperator['values']}) }}
+            {%- endif -%}
           {%- elif app_name == 'cloudnativepg' -%}
           {{ {} | combine({app_name: dsc[app_name]['operator']['values']}) }}
-          {%- elif dsc[app_name]['cnpg'] is defined and dsc[app_name]['cnpg']['values'] is defined -%}
+          {%- elif 'cnpg' in dsc[app_name] and 'values' in dsc[app_name]['cnpg'] -%}
           {{ {} | combine({app_name: dsc[app_name]['values'], 'cluster': dsc[app_name]['cnpg']['values']}) }}
           {%- else -%}
           {{ {} | combine({app_name: dsc[app_name]['values']}) }}


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Actuellement sur la branche `main`, le playbook install-gitops ne fonctionne plus côté environnement MI.
Un bug sur un template Jinja provoque une erreur sur la tâche des combinaisons des values.yml renseigner dans la `dsc` `conf-dso` avec les templates charts helm pour les outils utilisant CNPg.
Les configuration `dsc` dans l'environnement MI ne contient pas de surcharge de `values` pour CNPg

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Le playbook est de nouveau fonctionnel.
Il a été testé sur les environnements PAX et MI.
## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->

L'explication du bug c'est que en python un dictionnaire aura toujours un attribut `values` même si le dictionnaire n'a pas de `key`.
Donc le `dict.value is defined` retournera toujours `true` dans un template Jinja....
Pour tester l'existence d'une `key` dans un dictionnaire python ou Jinja il faut utiliser l'opérateur `in`

