### PR TITLE
fix(maven): internal url should no go through proxy

### DIFF
--- a/roles/gitops/post-install/gitlab/templates/mvn_conf_file.j2
+++ b/roles/gitops/post-install/gitlab/templates/mvn_conf_file.j2
@@ -55,7 +55,7 @@
       <active>true</active>
       <host>{{ dsc.proxy.host }}</host>
       <port>{{ dsc.proxy.port }}</port>
-      <nonProxyHosts>nexus.{{ dsc.nexus.namespace }}.svc.cluster.local|localhost|127.0.0.1</nonProxyHosts>
+      <nonProxyHosts>*.svc.cluster.local|localhost|127.0.0.1</nonProxyHosts>
     </proxy>
   </proxies>
 {% endif %}


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->
## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Le job de test sonar sur l'environnement MI pointe sur une URL interne avec un proxy configuré. Ce job utilise une commande Maven et n'arrive pas à contacter le sonarqube interne car il passe automatiquement par le proxy alors qu'il ne devrait pas.
cf [PR nº1 Socle Projet Test](https://github.com/cloud-pi-native/socle-project-test/pull/1/changes#diff-7fc67bf85e0fe7b25bd60855724bffe994b282b599a068c4bce2490b2e950699R35)

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
La configuration Maven ne fait plus passer les connexions interne par le proxy.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
