### PR TITLE
fix: rendering argocd ingress values indentations

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/argocd/values/10-ingress.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/values/10-ingress.j2
@@ -20,7 +20,7 @@ argocd:
 {% endif %}
 
 {% if not dsc.ingress.tls.type == 'none' %}
-  {% if dsc.ingress.tls.type == 'tlsSecret' %}
+  {% if dsc.ingress.tls.type == 'tlsSecret' +%}
       extraTls:
         - hosts:
           - <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.argocd}>
@@ -51,7 +51,7 @@ argocd:
 {% endif %}
 
 {% if not dsc.ingress.tls.type == 'none' %}
-  {% if dsc.ingress.tls.type == 'tlsSecret' %}
+  {% if dsc.ingress.tls.type == 'tlsSecret' +%}
       extraTls:
         - hosts:
           - appset.<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.argocd}>


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Ansible n'arrive pas à terminer la génération des templates suites à un problème d'indentation sur les values pour le composant ArgoCD.
Ce comportement a uniquement été observé sur l'environnement MI. (lors de la préparation de DSO Integ)

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Ansible génère correctement les templates attendus

Ce correctif a été testé sur tous les environnement MI et PAX.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->
N/A
## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
N/A