### PR TITLE
fix: duplication of custom CAs for gitlab fix

### DIFF
--- a/roles/gitops/rendering-apps-files/gitlab/values/00-main.j2
+++ b/roles/gitops/rendering-apps-files/gitlab/values/00-main.j2
@@ -111,19 +111,6 @@ global:
       key: password
   registry:
     enabled: false
-  certificates:
-    customCAs:
-{% for item in dsc.additionalsCA %}
-{% if item.kind == 'ConfigMap' %}
-      - configMap: {{ item.name }}
-{% endif %}
-{% if item.kind == 'Secret' %}
-      - secret: {{ item.name }}
-{% endif %}
-{% endfor %}
-{% if dsc.exposedCA.type != 'none' %}
-      - secret: exposed-ca
-{% endif %}
   hosts:
     domain: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#rootDomain>
     registry:


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
Les certificats sont définie en double dans les customCAs des values de la ressource GitLab
Car ils sont définie à deux endroits dans le `00-main.j2` et dans les fichiers `10-additionnals-ca.j2` et `10-exposed-ca.j2`

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Les certificats sont définie sans duplication dans les customCAs des values de la ressource GitLab

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
