### PR TITLE
feat(gitlab-postinstall): disable gitlab prometheus metrics

### DIFF
--- a/roles/gitops/post-install/gitlab/tasks/main.yaml
+++ b/roles/gitops/post-install/gitlab/tasks/main.yaml
@@ -65,6 +65,7 @@
       signup_enabled: false
       outbound_local_requests_allowlist_raw: "0.0.0.0/0"
       default_branch_protection: 0
+      prometheus_metrics_enabled: false
       import_sources:
         - git
       restricted_visibility_levels:


### PR DESCRIPTION
## Issues liées

Issues numéro: 
#1024 
---------

<!-- Ne soumettez pas de mises à jour des dépendances à moins qu'elles ne corrigent un problème. -->

<!-- Veuillez essayer de limiter votre Pull Request à un seul type (correction de bogue, fonctionnalité, etc.). Soumettez plusieurs PRs si nécessaire. -->

## Quel est le comportement actuel ?
<!-- Veuillez décrire le comportement actuel que vous modifiez. -->
L'option GitLab Prometheus Metrics dans l'Admin Area active un exportateur interne à l'application Ruby. Dans un environnement Kubernetes géré par Helm, cette option est redondante car nous utilisons déjà des Exporters dédiés (Sidecars) et des ServiceMonitors.

Activer les métriques GitLab en interne crée un double emploi :
- Cela surcharge inutilement la mémoire des pods webservice et sidekiq.
- Cela génère des données souvent identiques à celles déjà collectées par notre stack de monitoring externe.

En désactivant cette option, nous réduisons l'empreinte mémoire de GitLab tout en conservant une visibilité totale via le monitoring natif du Chart Helm.

## Quel est le nouveau comportement ?
<!-- Veuillez décrire le comportement ou les changements apportés par cette PR. -->
Une fois désactivé, nos dashboards Grafana continuent de recevoir des données en utilisant le ServiceMonitor du Chart GitLab, ils récupèrent les données via les ports 8082, 9101, etc., et non via l'interface web de GitLab.

## Cette PR introduit-elle un breaking change ?
<!-- Si un breaking change est introduit, veuillez décrire ci-dessous l'impact et la procédure de migration pour les applications existantes. -->

## Autres informations
<!-- Toute autre information importante pour la PR, telle que des captures d'écran montrant l'aspect du composant avant et après la modification. -->
