### PR TITLE
Documentation : alignement README/INSTALL avec la CRD

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -235,6 +235,8 @@ Pour configurer la ressource `dsc` nommée `conf-dso`, vous pouvez soit la modif
 kubectl edit dsc conf-dso
 ```
 
+La ressource correspond au type `DsoSocleConfig` (apiVersion `cloud-pi-native.fr/v1alpha`).
+
 Ou vous pouvez déclarer la ressource `dsc` nommée `conf-dso` dans un fichier YAML, par exemple « ma-conf-dso.yaml », puis la créer via la commande suivante :
 
 ```bash
@@ -244,8 +246,11 @@ kubectl apply -f ma-conf-dso.yaml
 Pour vous aider à démarrer, le fichier [cr-conf-dso-default.yaml](roles/socle-config/files/cr-conf-dso-default.yaml) est un **exemple** de configuration également utilisé lors de la première installation. Il surcharge les valeurs par défaut des fichiers [config.yaml](roles/socle-config/files/config.yaml) et [releases.yaml](roles/socle-config/files/releases.yaml). Ce fichier doit être adapté à partir de la section **spec**, en particulier pour les éléments suivants :
 
 - du paramètre `global.rootDomain` (votre domaine principal précédé d'un point),
+- du paramètre `global.infraRootDomain` si vous utilisez un domaine distinct pour l'infrastructure,
 - des mots de passe de certains outils,
 - du paramètre `global.platform` (définir à `kubernetes` si vous n'utilisez pas OpenShift),
+- des paramètres `global.gitOps` (`repo.url`, `repo.path`, `envName`, `namespacePrefix`),
+- du paramètre `global.offline` en mode air gap,
 - de la taille de certains PVCs,
 - de l'activation ou non des métriques,
 - du proxy si besoin ainsi que des sections CA et ingress.
@@ -294,7 +299,9 @@ Aucune configuration supplémentaire n’est nécessaire, l’Ingress est direct
 ##### Cas 2 : certificat auto-signé
 
 Si vous utilisez un certificat auto-signé, vous devez exposer la **CA racine** pour que les autres composants puissent valider ce certificat.
-Pour cela, ajoutez la CA racine dans un `Secret` ou un `ConfigMap`, puis référencez-le dans le champ `exposedCA` de la ressource `DSC`.
+Pour cela, ajoutez la CA racine dans un `Secret` ou un `ConfigMap`, puis référencez-le dans le champ `exposedCA` de la ressource `dsc`.
+
+La configuration TLS des ingress se fait via `spec.ingress.tls` (type `tlsSecret`, `acme` ou `ca`).
 
 Exemple avec un Secret :
 
@@ -315,8 +322,8 @@ stringData:
 Et puis dans la configuration `dsc`:
 
 ```yaml
-apiVersion: dso.cloud-pi-native.io/v1alpha1
-kind: DSC
+apiVersion: cloud-pi-native.fr/v1alpha
+kind: DsoSocleConfig
 metadata:
   name: conf-dso
 spec:
@@ -326,6 +333,12 @@ spec:
       namespace: ingress-nginx
       name: root-ca
       key: ca
+  ingress:
+    tls:
+      type: tlsSecret
+      tlsSecret:
+        method: in-namespace
+        name: wildcard-tls
 ```
 
 ## Désinstallation

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,7 +57,7 @@ Nous appellerons ce cluster **cluster socle**.
 
 ## Installation
 
-L'installation de la plateforme Cloud Pi Native se fait de manière automatisée via Ansible.  
+L'installation de la plateforme Cloud Pi Native se fait de manière automatisée via Ansible.
 Veuillez suivre les étapes suivantes dans l'ordre pour installer la plateforme.
 
 ### 1. Création du dépôt GitOps
@@ -119,7 +119,7 @@ export VAULT_INFRA_DOMAIN=infra-vault.example.com
 export VAULT_INFRA_TOKEN=vault-infra-token
 ```
 
-Si vous utilisez un proxy pour accéder à votre cluster d'administration, vous devez également définir la variable d'environnement `KUBECONFIG_PROXY_INFRA` avec le chemin absolu vers votre configuration proxy.  
+Si vous utilisez un proxy pour accéder à votre cluster d'administration, vous devez également définir la variable d'environnement `KUBECONFIG_PROXY_INFRA` avec le chemin absolu vers votre configuration proxy.
 Exemple :
 
 ```bash
@@ -155,9 +155,15 @@ La commande créera pour vous le fichier `/tmp/my-credentials.yaml` qu'il vous i
 
 ### 8. Configuration première installation de Nexus
 
-En cas de premiere installation de l'outil Nexus, il faudra mettre le champs `nexus.chownDataDir` à `true` dans le fichier `values.yaml` du chart Helm générés par le playbook `rendering-apps-files.yaml` situé dans le répertoire `gitops/envs/conf-dso/apps/nexus`.
+En cas de première installation de l'outil Nexus, il faudra définir le champ `nexus.values.chownDataDir` à `true` dans la ressource `dsc`, par exemple :
 
-**NB**: Une fois Nexus installé et configuré, il est recommandé de mettre à jour le champs `nexus3.chownDataDir` à `false` pour éviter de modifier les permissions des fichiers de Nexus.
+```yaml
+nexus:
+  values:
+    chownDataDir: true
+```
+
+**NB** : Une fois Nexus installé et configuré, il est recommandé de remettre ce champ à `false` pour éviter de modifier les permissions des fichiers de Nexus.
 
 ### 9. Pousser les fichiers IaC générés dans le dépôt GitOps
 

--- a/README.md
+++ b/README.md
@@ -300,11 +300,9 @@ harbor:
     persistence:
       imageChartStorage:
         s3:
-          accesskey: <accesskey>
           bucket: <bucket>
           region: <region>
           regionendpoint: <regionendpoint>
-          secretkey: <secretkey>
         type: s3
 ```
 Il faut supprimer et remplacer par ce qui suit.
@@ -312,11 +310,9 @@ Il faut supprimer et remplacer par ce qui suit.
 harbor:
   s3ImageChartStorage:
     enabled: true
-    accesskey: <accesskey>
     bucket: <bucket>
     region: <region>
     regionendpoint: <regionendpoint>
-    secretkey: <secretkey>
 ```
 Puis lancer le playbook d'insertion des secrets dans le Vault d'infrastructure.
 ```shell
@@ -886,7 +882,8 @@ kubectl explain dsc.spec.global.backup.cnpg
 
 ## Offline / air gap
 
-En mode air gap ou déconnecté d'internet, certaines valeurs de la `dsc` devront être adaptées.
+En mode air gap ou déconnecté d'internet, positionnez `global.offline` à `true` dans la `dsc`.
+Certaines valeurs devront également être adaptées.
 - `dsc.sonarqube.pluginDownloadUrl` et `dsc.sonarqube.prometheusJavaagentVersion`
 - `dsc.keycloak.pluginDownloadUrl` et `dsc.keycloak.providerDownloadUrl`
 - `dsc.gitlabCatalog.catalogRepoUrl`
@@ -898,14 +895,16 @@ En mode air gap ou déconnecté d'internet, certaines valeurs de la `dsc` devron
 
 Par défaut, le déploiement du socle DSO se fait sur un cluster de la famille Openshift, mais il est possible de déployer sur les autres types de distribution Kubernetes (Vanilla, K3s, RKE2, EKS, GKE...) en spécifiant comme suit dans la dsc.
 ```
-platform: kubernetes
+global:
+  platform: kubernetes
 ```
 
 ## Profile CIS
 
 Pour un déploiement sur un cluster qui n'est pas de la famille d'Openshift, par exemple sur un Kubernetes Vanilla, il est possible d'activer le profil de sécurité CIS pour enforcer la partie securityContext, en spécifiant comme suit dans la dsc.
 ```
-profile: cis
+global:
+  profile: cis
 ```
 
 ## Utilisation de credentials pour le pull des images de registres privés

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@
 - [Offline / air gap](#offline--air-gap)
 - [Platform](#platform)
 - [Profile CIS](#profile-cis)
-- [Utilisation de credentials Docker Hub pour le pull des images](#utilisation-de-credentials-docker-hub-pour-le-pull-des-images)
+- [Utilisation de credentials pour le pull des images de registres privés](#utilisation-de-credentials-pour-le-pull-des-images-de-registres-privés)
+  - [Gestion des secrets de type docker-registry](#gestion-des-secrets-de-type-docker-registry)
+  - [Configuration `dsc`](#configuration-dsc)
 - [Gestion des users Keycloak](#gestion-des-users-keycloak)
 - [MFA pour les utilisateurs Keycloak](#mfa-pour-les-utilisateurs-keycloak)
 - [Tests d'intégration](#tests-dintégration)
@@ -885,14 +887,12 @@ kubectl explain dsc.spec.global.backup.cnpg
 ## Offline / air gap
 
 En mode air gap ou déconnecté d'internet, certaines valeurs de la `dsc` devront être adaptées.
-- `dsc.sonarqube` :
-  - `pluginDownloadUrl` et `prometheusJavaagentVersion`
+- `dsc.sonarqube.pluginDownloadUrl` et `dsc.sonarqube.prometheusJavaagentVersion`
+- `dsc.keycloak.pluginDownloadUrl` et `dsc.keycloak.providerDownloadUrl`
 - `dsc.gitlabCatalog.catalogRepoUrl`
 - `dsc.argocd.privateGitlabDomain`
-- `dsc.grafanaOperator.ociChartUrl`
-- `helmRepoUrl` pour chaque service à savoir :
-  - `argocd`, `certmanager`, `cloudnativepg`, `console`, `glexporter`, `gitlabOperator`, `gitlabrunner`, `harbor`, `keycloak`, `kyverno`, `sonarqube` et `vault`
-- `dsc.awx.repoSocle.url` (et optionnellement : `dsc.awx.repoSocle.revision`)
+- `helmRepoUrl` pour chaque service concerné
+- `repoSocle.url` (et optionnellement : `repoSocle.revision`) pour les applications ayant un job ansible de post-installation
 
 ## Platform
 
@@ -914,7 +914,7 @@ Il est possible d'utiliser des secrets de type docker-registry pour le pull des 
 
 ### Gestion des secrets de type docker-registry
 
-L'**équipe Infrastructure** est chargée de créer les secrets de type docker-registry lors de la phase de provisionnement initial du cluster.  
+L'**équipe Infrastructure** est chargée de créer les secrets de type docker-registry lors de la phase de provisionnement initial du cluster.
 Si ces secrets ne sont pas présents ou ne peuvent pas être automatisés à la source, l'équipe Ops est responsable de leur **création manuelle** dans le cluster
 
 ### Configuration `dsc`
@@ -951,10 +951,10 @@ Il sera nécessaire pour activer le MFA sur les utilisateurs existants, de lance
 ansible-playbook admin-tools/keycloak-enforce-mfa.yml
 ```
 
-## Tests d'intégration 
+## Tests d'intégration
 
-Il est possible d'activer les tests d'intégration sur un environnement en spécifiant le paramètre `dsc.tests.installEnabled` à `true`.  
-Les notifications étant pour l'instant uniquement supporté sur Mattermost dans le code, il faudra alors récupérer l'id du channel et le token du bot pour les insérer dans le Vault d'infrastructure.  
+Il est possible d'activer les tests d'intégration sur un environnement en spécifiant le paramètre `dsc.tests.installEnabled` à `true`.
+Les notifications étant pour l'instant uniquement supporté sur Mattermost dans le code, il faudra alors récupérer l'id du channel et le token du bot pour les insérer dans le Vault d'infrastructure.
 Pour ce qui concerne les comptes de tests `testuser@example.com` et `secondtestuser@example.com`, il faudra s'assurer que :
 - leurs mots de passe correspondent à ceux qui sont insérés dans le Vault d'infrastructure.
 - le MFA n'est pas appliqué.


### PR DESCRIPTION
Plusieurs sections de documentation étaient désynchronisées par rapport à la CRD (roles/socle-config/templates/crd-conf-dso.yaml) : références obsolètes, entrées de sommaire manquantes et consignes inexactes pour la première installation de Nexus. Les espaces superflus ont été supprimés.

README.md

- Sommaire : correction des entrées et ajout des sous-sections manquantes.
- Offline / air gap : alignement avec les chemins DSC complets et retrait des champs obsolètes.
- Harbor GitOps : mise à jour de l’exemple S3 vers `s3ImageChartStorage`.
- Platform / Profile CIS : exemples basculés sous `global.*`.

INSTALL.md

- Installation Nexus : consigne simplifiée via `nexus.values.chownDataDir` dans la dsc.
- DSC : correction du type/`apiVersion` et des exemples.
- TLS / CA : clarification via `spec.ingress.tls`.
- Configuration : ajout des points clés (`global.infraRootDomain`, `global.gitOps`, `global.offline`).