### PR TITLE
Ajout du support des dépôts Helm OCI pour les apps d'infra, cert-manager et Kyverno

### DIFF
--- a/roles/cert-manager/tasks/main.yaml
+++ b/roles/cert-manager/tasks/main.yaml
@@ -19,11 +19,6 @@
     cm_mwhc.resources | length == 0 or
     dsc.certmanager.forcedInstall
   block:
-    - name: Add cert-manager helm repo
-      kubernetes.core.helm_repository:
-        name: jetstack
-        repo_url: "{{ dsc.certmanager.helmRepoUrl }}"
-        force_update: true
 
     # Installation des CRDs indépendamment du chart helm.
     # Recommandé en production.
@@ -42,8 +37,17 @@
     - name: Set path fact
       ansible.builtin.set_fact:
         path: "{{ role_path + '/templates/values' }}"
+        is_oci_repo: "{{ dsc.certmanager.helmRepoUrl.startswith('oci://') }}"
+        repo_name: "jetstack" # for HTTP repositories
 
-    - name: Compute Cert-manager Helm values
+    - name: Add cert-manager Helm repo (HTTP repo only)
+      when: not is_oci_repo
+      kubernetes.core.helm_repository:
+        name: "{{ repo_name }}"
+        repo_url: "{{ dsc.certmanager.helmRepoUrl }}"
+        force_update: true
+
+    - name: Compute cert-manager Helm values
       ansible.builtin.include_role:
         name: combine
       vars:
@@ -51,11 +55,11 @@
         combine_user_values: "{{ dsc.certmanager['values'] }}"
         combine_dest_var: "cm_values"
 
-    - name: Deploy helm
+    - name: Deploy cert-manager Helm chart
       kubernetes.core.helm:
         #    force: true
         name: cert-manager
-        chart_ref: jetstack/cert-manager
+        chart_ref: "{{ is_oci_repo | ternary(dsc.certmanager.helmRepoUrl, repo_name) }}/cert-manager"
         chart_version: "{{ dsc.certmanager.chartVersion }}"
         release_namespace: cert-manager
         create_namespace: true

--- a/roles/cloudnativepg/tasks/main.yml
+++ b/roles/cloudnativepg/tasks/main.yml
@@ -26,17 +26,20 @@
         kind: Namespace
         state: present
 
-    - name: Add CloudNativePG helm repo
+    - name: Set path and repo type facts
+      ansible.builtin.set_fact:
+        path: "{{ role_path + '/templates/values' }}"
+        is_oci_repo: "{{ dsc.cloudnativepg.operator.helmRepoUrl.startswith('oci://') }}"
+        repo_name: "cnpg" # for HTTP repositories
+
+    - name: Add CloudNativePG operator Helm repo (HTTP repo only)
+      when: not is_oci_repo
       kubernetes.core.helm_repository:
-        name: cnpg
+        name: "{{ repo_name }}"
         repo_url: "{{ dsc.cloudnativepg.operator.helmRepoUrl }}"
         force_update: true
 
-    - name: Set path fact
-      ansible.builtin.set_fact:
-        path: "{{ role_path + '/templates/values' }}"
-
-    - name: Compute Gitlab Helm values
+    - name: Compute GitLab Helm values
       ansible.builtin.include_role:
         name: combine
       vars:
@@ -44,10 +47,10 @@
         combine_user_values: "{{ dsc.cloudnativepg.operator['values'] }}"
         combine_dest_var: "cnpg_values"
 
-    - name: Deploy CloudNativePG helm
+    - name: Deploy CloudNativePG operator Helm chart
       kubernetes.core.helm:
         name: cloudnative-pg
-        chart_ref: cnpg/cloudnative-pg
+        chart_ref: "{{ is_oci_repo | ternary(dsc.cloudnativepg.operator.helmRepoUrl, repo_name) }}/cloudnative-pg"
         chart_version: "{{ dsc.cloudnativepg.operator.chartVersion }}"
         release_namespace: "{{ dsc.cloudnativepg.namespace }}"
         values: "{{ cnpg_values }}"

--- a/roles/gitops/rendering-apps-files/tasks/preliminary.yml
+++ b/roles/gitops/rendering-apps-files/tasks/preliminary.yml
@@ -1,25 +1,58 @@
 ---
-- name: Get Argo CD app version
+- name: Set repo type fact
+  ansible.builtin.set_fact:
+    is_oci_repo: "{{ dsc.argocdInfra.helmRepoUrl.startswith('oci://') }}"
+    repo_name: "argo" # for HTTP repositories
+
+- name: Get Argo CD infra app version (HTTP)
+  when: not is_oci_repo
   block:
-    - name: Add Argo CD helm repo
+    - name: Add Argo CD Helm repo (HTTP repo only)
       changed_when: false
       kubernetes.core.helm_repository:
-        name: argo
-        repo_url: "{{ dsc.argocd.helmRepoUrl }}"
+        name: "{{ repo_name }}"
+        repo_url: "{{ dsc.argocdInfra.helmRepoUrl }}"
         force_update: true
 
-    - name: Retrieve Argo CD Helm infos
+    - name: Retrieve Argo CD Helm chart info (HTTP)
       changed_when: false
-      ansible.builtin.shell:
-        cmd: |
-          set -o pipefail
-          helm search repo -l argo --version "{{ dsc.argocd.chartVersion }}" | tail -n 1
-        executable: /bin/bash
+      ansible.builtin.command: >-
+        helm search repo {{ repo_name }}/argo-cd --version "{{ dsc.argocdInfra.chartVersion }}"
       register: argo_infos
+      ignore_errors: true
 
-    - name: Set argo_app_version fact
+    - name: Fail if chart version retrieval failed (HTTP)
+      when: argo_infos.rc != 0 or argo_infos.stdout == ""
+      ansible.builtin.fail:
+        msg: >-
+          Failed to retrieve Argo CD Helm chart version.
+          Check the repository URL ({{ dsc.argocdInfra.helmRepoUrl }}) and chart version ({{ dsc.argocdInfra.chartVersion }}).
+
+    - name: Set argo_app_version fact (HTTP)
       ansible.builtin.set_fact:
-        argo_app_version: "{{ argo_infos.stdout | regex_search('v([0-9]*\\.)+([0-9]+)') }}"
+        argo_app_version: >-
+          {{ argo_infos.stdout | regex_search('v([0-9]+\\.[0-9]+\\.[0-9]+)') }}
+
+- name: Get Argo CD infra app version (OCI)
+  when: is_oci_repo
+  block:
+    - name: Retrieve Argo CD Helm chart info (OCI)
+      changed_when: false
+      ansible.builtin.command: >-
+        helm show chart {{ dsc.argocdInfra.helmRepoUrl }}/argo-cd --version "{{ dsc.argocdInfra.chartVersion }}"
+      register: argo_infos
+      ignore_errors: true
+
+    - name: Fail if chart version retrieval failed (OCI)
+      when: argo_infos.rc != 0 or argo_infos.stdout == ""
+      ansible.builtin.fail:
+        msg: >-
+          Failed to retrieve Argo CD Helm chart version.
+          Check the repository URL ({{ dsc.argocdInfra.helmRepoUrl }}) and chart version ({{ dsc.argocdInfra.chartVersion }}).
+
+    - name: Set argo_app_version fact (OCI)
+      ansible.builtin.set_fact:
+        argo_app_version: "{{ argo_infos.stdout | regex_search('(?<=appVersion: )v([0-9]+\\.[0-9]+\\.[0-9]+)') }}"
 
 - name: Find argo crd existence
   kubernetes.core.k8s_info:
@@ -41,7 +74,7 @@
   ansible.builtin.set_fact:
     path: "{{ role_path + '/gitlab/values' }}"
 
-- name: Compute Gitlab Helm values
+- name: Compute GitLab Helm values
   ansible.builtin.include_role:
     name: combine
   vars:

--- a/roles/gitops/rendering-apps-files/tasks/template.yml
+++ b/roles/gitops/rendering-apps-files/tasks/template.yml
@@ -98,6 +98,11 @@
 - name: Values rendering
   when: install_enabled
   block:
+    - name: Check for cpin-ansible-job template file existence
+      ansible.builtin.stat:
+        path: "{{ source_path }}/values/200-ansible-job.j2"
+      register: ansible_job_template
+
     - name: Compute "{{ item.1.argocd_app }}" Helm values
       ansible.builtin.include_role:
         name: combine
@@ -105,19 +110,27 @@
         combine_path: "{{ source_path }}/values"
         combine_user_values: >-
           {%- set app_name = item.1.argocd_app -%}
+          {%- set app_values = dsc[app_name].get('values', {}) -%}
+          {%- set cnpg_values = dsc[app_name].get('cnpg', {}).get('values', {}) -%}
+          {%- set cluster_values = {} -%}
           {%- if app_name == 'gitlab' -%}
-            {%- if 'cnpg' in dsc.gitlab and 'values' in dsc.gitlab['cnpg'] -%}
-          {{ {} | combine({app_name: dsc.gitlabOperator['values'], 'cluster': dsc[app_name]['cnpg']['values']}) }}
-            {%- else -%}
-          {{ {} | combine({app_name: dsc.gitlabOperator['values']}) }}
-            {%- endif -%}
+            {%- set app_values = dsc.gitlabOperator.get('values', {}) -%}
+            {%- set cluster_values = dsc.gitlab.get('cnpg', {}).get('values', {}) -%}
           {%- elif app_name == 'cloudnativepg' -%}
-          {{ {} | combine({app_name: dsc[app_name]['operator']['values']}) }}
-          {%- elif 'cnpg' in dsc[app_name] and 'values' in dsc[app_name]['cnpg'] -%}
-          {{ {} | combine({app_name: dsc[app_name]['values'], 'cluster': dsc[app_name]['cnpg']['values']}) }}
-          {%- else -%}
-          {{ {} | combine({app_name: dsc[app_name]['values']}) }}
+            {%- set app_values = dsc[app_name].get('operator', {}).get('values', {}) -%}
           {%- endif -%}
+
+          {%- set result = {} -%}
+          {%- if app_values -%}
+            {%- set _ = result.update({app_name: app_values}) -%}
+          {%- endif -%}
+          {%- if cnpg_values or cluster_values -%}
+            {%- set _ = result.update({'cluster': cnpg_values | combine(cluster_values)}) -%}
+          {%- endif -%}
+          {%- if dsc.get('cpnAnsibleJob', {}).get('values') is defined and ansible_job_template.stat.exists -%}
+            {%- set _ = result.update({'cpn-ansible-job': dsc.cpnAnsibleJob['values']}) -%}
+          {%- endif -%}
+          {{ result }}
         combine_dest_var: "{{ item.1.argocd_app }}_values"
 
     - name: Render "{{ item.1.argocd_app }}" values and write values.yaml to destination

--- a/roles/infra/argocd-infra/tasks/main.yaml
+++ b/roles/infra/argocd-infra/tasks/main.yaml
@@ -68,6 +68,7 @@
 # OpenShift CRB
 
 - name: Argo CD OpenShift scc crb
+  when: dsc.global.platform == "openshift"
   kubernetes.core.k8s:
     definition:
       apiVersion: rbac.authorization.k8s.io/v1
@@ -96,29 +97,63 @@
           namespace: "{{ dsc.argocdInfra.namespace }}"
           name: "{{ dsc_name }}-argo-infra-redis-ha-haproxy"
 
-- name: Add Argo CD helm repo
-  changed_when: false
-  kubernetes.core.helm_repository:
-    name: argo
-    repo_url: "{{ dsc.argocdInfra.helmRepoUrl }}"
-    force_update: true
+- name: Set repo type facts
+  ansible.builtin.set_fact:
+    is_oci_repo: "{{ dsc.argocdInfra.helmRepoUrl.startswith('oci://') }}"
+    repo_name: argo
+
+# Retreive Argo CD app version
+
+- name: Get Argo CD infra app version (HTTP)
+  when: not is_oci_repo
+  block:
+    - name: Add Argo CD Helm repo (HTTP repo only)
+      changed_when: false
+      kubernetes.core.helm_repository:
+        name: "{{ repo_name }}"
+        repo_url: "{{ dsc.argocdInfra.helmRepoUrl }}"
+        force_update: true
+    - name: Retrieve Argo CD Helm chart info (HTTP)
+      changed_when: false
+      ansible.builtin.command: >-
+        helm search repo {{ repo_name }}/argo-cd --version "{{ dsc.argocdInfra.chartVersion }}"
+      register: argo_infos
+      ignore_errors: true
+
+    - name: Fail if chart version retrieval failed (HTTP)
+      when: argo_infos.rc != 0 or argo_infos.stdout == ""
+      ansible.builtin.fail:
+        msg: >-
+          Failed to retrieve Argo CD Helm chart version.
+          Check the repository URL ({{ dsc.argocdInfra.helmRepoUrl }}) and chart version ({{ dsc.argocdInfra.chartVersion }}).
+
+    - name: Set argo_app_version fact (HTTP)
+      ansible.builtin.set_fact:
+        argo_app_version: >-
+          {{ argo_infos.stdout | regex_search('v([0-9]+\\.[0-9]+\\.[0-9]+)') }}
+
+- name: Get Argo CD infra app version (OCI)
+  when: is_oci_repo
+  block:
+    - name: Retrieve Argo CD Helm chart info (OCI)
+      changed_when: false
+      ansible.builtin.command: >-
+        helm show chart {{ dsc.argocdInfra.helmRepoUrl }}/argo-cd --version "{{ dsc.argocdInfra.chartVersion }}"
+      register: argo_infos
+      ignore_errors: true
+
+    - name: Fail if chart version retrieval failed (OCI)
+      when: argo_infos.rc != 0 or argo_infos.stdout == ""
+      ansible.builtin.fail:
+        msg: >-
+          Failed to retrieve Argo CD Helm chart version.
+          Check the repository URL ({{ dsc.argocdInfra.helmRepoUrl }}) and chart version ({{ dsc.argocdInfra.chartVersion }}).
+
+    - name: Set argo_app_version fact (OCI)
+      ansible.builtin.set_fact:
+        argo_app_version: "{{ argo_infos.stdout | regex_search('(?<=appVersion: )v([0-9]+\\.[0-9]+\\.[0-9]+)') }}"
 
 # Vault plugin setup
-
-- name: Get Argo CD infra app version
-  block:
-    - name: Retrieve Argo CD Helm infos
-      changed_when: false
-      ansible.builtin.shell:
-        cmd: |
-          set -o pipefail
-          helm search repo -l argo --version "{{ dsc.argocdInfra.chartVersion }}" | tail -n 1
-        executable: /bin/bash
-      register: argo_infos
-
-    - name: Set argo_app_version fact
-      ansible.builtin.set_fact:
-        argo_app_version: "{{ argo_infos.stdout | regex_search('v([0-9]*\\.)+([0-9]+)') }}"
 
 - name: Deploy Argo CD infra Vault plugin config
   kubernetes.core.k8s:
@@ -152,8 +187,7 @@
         missing_secret: false
 
     - name: Update missing_secret fact
-      when:
-        (helm_docker_registry_secret.resources | length == 0) or
+      when: (helm_docker_registry_secret.resources | length == 0) or
         (oci_dockerhub_creds.resources | length == 0)
       ansible.builtin.set_fact:
         missing_secret: true
@@ -217,10 +251,10 @@
     combine_user_values: "{{ dsc.argocdInfra['values'] }}"
     combine_dest_var: "argo_values"
 
-- name: Deploy helm
+- name: Deploy Argo CD Helm chart
   kubernetes.core.helm:
     name: "{{ dsc_name }}-argo-infra"
-    chart_ref: argo/argo-cd
+    chart_ref: "{{ is_oci_repo | ternary(dsc.argocdInfra.helmRepoUrl, repo_name) }}/argo-cd"
     chart_version: "{{ dsc.argocdInfra.chartVersion }}"
     release_namespace: "{{ dsc.argocdInfra.namespace }}"
     create_namespace: true

--- a/roles/infra/keycloak-infra/tasks/main.yml
+++ b/roles/infra/keycloak-infra/tasks/main.yml
@@ -148,9 +148,19 @@
 
 # Deploy Keycloak
 
-- name: Set path fact
+- name: Set path and repo type facts
   ansible.builtin.set_fact:
     path: "{{ role_path + '/templates/values' }}"
+    is_oci_repo: "{{ dsc.keycloakInfra.helmRepoUrl.startswith('oci://') }}"
+    repo_name: "hashicorp" # for HTTP repositories
+
+- name: Add Keycloak Helm repo (HTTP repo only)
+  when: not is_oci_repo
+  changed_when: false
+  kubernetes.core.helm_repository:
+    name: "{{ repo_name }}"
+    repo_url: "{{ dsc.keycloakInfra.helmRepoUrl }}"
+    force_update: true
 
 - name: Compute Keycloak Helm values
   ansible.builtin.include_role:
@@ -160,9 +170,9 @@
     combine_user_values: "{{ dsc.keycloakInfra['values'] }}"
     combine_dest_var: "kc_values"
 
-- name: Deploy helm
+- name: Deploy Keycloak Helm chart
   kubernetes.core.helm:
-    chart_ref: "{{ dsc.keycloakInfra.helmRepoUrl }}/keycloak"
+    chart_ref: "{{ is_oci_repo | ternary(dsc.keycloakInfra.helmRepoUrl, repo_name) }}/keycloak"
     chart_version: "{{ dsc.keycloakInfra.chartVersion }}"
     release_namespace: "{{ dsc.keycloakInfra.namespace }}"
     release_name: keycloak

--- a/roles/infra/vault-infra/tasks/main.yml
+++ b/roles/infra/vault-infra/tasks/main.yml
@@ -1,23 +1,26 @@
 ---
 - name: Create Vault namespace
   kubernetes.core.k8s:
-    state: present
-    kind: Namespace
     name: "{{ dsc.vaultInfra.namespace }}"
     api_version: v1
+    kind: Namespace
+    state: present
 
-- name: Add helm repo
+- name: Set path and repo type facts
+  ansible.builtin.set_fact:
+    path: "{{ role_path + '/templates/values' }}"
+    is_oci_repo: "{{ dsc.vaultInfra.helmRepoUrl.startswith('oci://') }}"
+    repo_name: "hashicorp" # for HTTP repositories
+
+- name: Add Vault Helm repo (HTTP repo only)
+  when: not is_oci_repo
   changed_when: false
   kubernetes.core.helm_repository:
-    name: hashicorp
+    name: "{{ repo_name }}"
     repo_url: "{{ dsc.vaultInfra.helmRepoUrl }}"
     force_update: true
 
-- name: Set path fact
-  ansible.builtin.set_fact:
-    path: "{{ role_path + '/templates/values' }}"
-
-- name: Compute Vault Helm values
+- name: Compute Vault infra Helm values
   ansible.builtin.include_role:
     name: combine
   vars:
@@ -35,10 +38,10 @@
         tls.crt: "{{ exposed_ca_pem | b64encode }}"
   when: dsc.exposedCA.type == "configmap" or dsc.exposedCA.type == "secret"
 
-- name: Deploy helm
+- name: Deploy Helm chart
   kubernetes.core.helm:
     name: "{{ dsc_name }}-vault-infra"
-    chart_ref: hashicorp/vault
+    chart_ref: "{{ is_oci_repo | ternary(dsc.vaultInfra.helmRepoUrl, repo_name) }}/vault"
     chart_version: "{{ dsc.vaultInfra.chartVersion }}"
     release_namespace: "{{ dsc.vaultInfra.namespace }}"
     create_namespace: true
@@ -58,9 +61,15 @@
 - name: Add backup utils Helm repo and deploy
   when: dsc.global.backup.vaultInfra.enabled
   block:
-    - name: Add Helm repo
+    - name: Set backup utils repo type facts
+      ansible.builtin.set_fact:
+        is_oci_repo: "{{ dsc.global.backup.vault.helmRepoUrl.startswith('oci://') }}"
+        repo_name: "dso" # for HTTP repositories
+
+    - name: Add backup utils Helm repo (HTTP repo only)
+      when: not is_oci_repo
       kubernetes.core.helm_repository:
-        name: dso
+        name: "{{ repo_name }}"
         repo_url: "{{ dsc.global.backup.vault.helmRepoUrl }}"
         force_update: true
 
@@ -76,10 +85,10 @@
         s3_access_key: "{{ s3_backup_secret.resources[0].data.accessKeyId | b64decode }}"
         s3_secret_key: "{{ s3_backup_secret.resources[0].data.secretAccessKey | b64decode }}"
 
-    - name: Deploy Helm chart
+    - name: Deploy backup utils Helm chart
       kubernetes.core.helm:
         name: "{{ dsc_name }}-vault-backup"
-        chart_ref: dso/cpn-backup-utils
+        chart_ref: "{{ is_oci_repo | ternary(dsc.global.backup.vault.helmRepoUrl, repo_name) }}/cpn-backup-utils"
         chart_version: "{{ dsc.global.backup.vaultInfra.chartVersion }}"
         release_namespace: "{{ dsc.vaultInfra.namespace }}"
         values:
@@ -124,6 +133,5 @@
         name: "{{ item }}"
         definition:
           metadata:
-            labels:
-              "{{ dsc.global.metrics.additionalLabels }}"
+            labels: "{{ dsc.global.metrics.additionalLabels }}"
       loop: "{{ service_monitors_names }}"

--- a/roles/kyverno/tasks/main.yaml
+++ b/roles/kyverno/tasks/main.yaml
@@ -6,9 +6,11 @@
       - "app.kubernetes.io/part-of=kyverno"
   register: kyverno_pods
 
-- name: Set path fact
+- name: Set path and repo type facts
   ansible.builtin.set_fact:
     path: "{{ role_path + '/templates/values' }}"
+    is_oci_repo: "{{ dsc.kyverno.helmRepoUrl.startswith('oci://') }}"
+    repo_name: kyverno # for HTTP repositories
 
 - name: Compute Kyverno Helm values
   ansible.builtin.include_role:
@@ -23,16 +25,17 @@
     kyverno_pods.resources | length == 0 or
     dsc.kyverno.forcedInstall
   block:
-    - name: Add helm repo
+    - name: Add Kyverno Helm repo (HTTP repo only)
+      when: not is_oci_repo
       kubernetes.core.helm_repository:
-        name: kyverno
+        name: "{{ repo_name }}"
         repo_url: "{{ dsc.kyverno.helmRepoUrl }}"
         force_update: true
 
-    - name: Deploy helm
+    - name: Deploy Kyverno Helm chart
       kubernetes.core.helm:
         name: kyverno
-        chart_ref: kyverno/kyverno
+        chart_ref: "{{ is_oci_repo | ternary(dsc.kyverno.helmRepoUrl, repo_name) }}/kyverno"
         chart_version: "{{ dsc.kyverno.chartVersion }}"
         release_namespace: "{{ dsc.kyverno.namespace }}"
         create_namespace: true


### PR DESCRIPTION
## Quel est le comportement actuel ?
Les rôles utilisent uniquement des dépôts Helm HTTP via `helm_repository`. Les `chart_ref` sont fixés sur des alias HTTP (ex: `argo/argo-cd`, `hashicorp/vault`), ce qui empêche l’utilisation de dépôts OCI. La récupération de la version Argo CD infra repose sur `helm search repo` uniquement.
Depuis l'utilisation de Helm chart wrappers, les applications de la forge le supporte nativement, mais peu-être pas (à vérifier) pour Nexus (que je n'installe pas) et Keycloak (en HTTP) qui ont des conditions différentes. c.f. :
https://github.com/cloud-pi-native/socle/blob/6982842b32f92dec0328e20a85f93efa20e8b1ce/roles/gitops/rendering-apps-files/templates/keycloak/Chart.yaml.j2#L14
https://github.com/cloud-pi-native/socle/blob/6982842b32f92dec0328e20a85f93efa20e8b1ce/roles/gitops/rendering-apps-files/templates/nexus/Chart.yaml.j2#L10

## Quel est le nouveau comportement ?
- Les rôles infra (Argo CD, Keycloak, Vault), cert-manager, CloudNativePG et Kyverno détectent `oci://` et adaptent l’ajout de repo ainsi que `chart_ref`.
- La récupération de version Argo CD infra est gérée pour HTTP et OCI (avec `helm show chart` pour OCI).
- L’installation conserve le même rendu de values, mais change la source Helm en fonction du type de dépôt.

J'ai également ajouté un `when` conditionnel sur OpenShift pour le CRB Argo CD infra, sans impact sur les plateformes non‑OpenShift (à ma connaissance).

## Cette PR introduit-elle un breaking change ?
Non. Les dépôts HTTP continuent de fonctionner comme avant.

## Autres informations
J'ai ainsi déployé Argo CD (d'infra et de la forge) avec un dépot OCI sans problème.
Pour information, j'avais fait ce changement juste avant le passage au déploiement de la forge par Argo CD (gitops) mais avec toutes les modifications et corrections apportés à ce moment là, j'ai retardé cette contribution.