### PR TITLE
changement du registry haproxy de redis‑ha d'Argo CD

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/argocd/values/10-registry.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/values/10-registry.j2
@@ -1,16 +1,16 @@
 argocd:
   image:
     repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.quay}>
-  
   redis:
     image:
       repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>
-
   redis-ha:
     image:
       repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/library/redis
       tag: 7.4.1-alpine
-
+    haproxy:
+      image:
+        repository: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#image | jsonPath {.repository.docker}>/haproxy
 {% if dsc.global.imagePullSecrets is defined %}
 argocd:
   global:

--- a/roles/infra/argocd-infra/templates/values/00-main.j2
+++ b/roles/infra/argocd-infra/templates/values/00-main.j2
@@ -136,12 +136,10 @@ global:
 {% endif %}
 redis-ha:
   enabled: true
-{% if use_private_registry %}
   image:
-    repository: "{{ dsc.global.registry }}/library/redis"
     tag: 7.4.1-alpine
-{% endif %}
 {% if use_private_registry %}
+    repository: "{{ dsc.global.registry }}/library/redis"
   haproxy:
     image:
       repository: "{{ dsc.global.registry }}/haproxy"


### PR DESCRIPTION
## Quel est le comportement actuel ?
Quand `public.ecr.aws` n’est pas disponible, l’instance haproxy du `redis-ha` d’Argo CD ne peut pas être installée, car le chart `redis-ha` pointe par défaut sur `public.ecr.aws/docker/library/haproxy`. Or, cette même image est disponible sur `docker.io/library/haproxy` (sachant que `/xxx`, `/library/xxx` et `/_/xxx` sont synonymes sur docker hub).

## Quel est le nouveau comportement ?
L'image haproxy de `redis-ha` est explicitement redirigé vers `docker.io/library/haproxy` (via le registre Docker configuré), ce qui permet l’installation même lorsque `public.ecr.aws` est inaccessible (offline ou filtrage réseau).

Concernant l'Argo CD d'infra, la condition redondante est simplifiée et le tag pour l'image redis-ha devient indépendant du registre. Pour rappel, redis 7.4 est la dernière version sous license BSD.

## Cette PR introduit-elle un breaking change ?
Non

## Autres informations
Valkey pourrait être utilisé à la place de Redis !
