### PR TITLE
fix: skip cert-manager checks when install disabled

### DIFF
--- a/roles/check-prerequisite/tasks/main.yml
+++ b/roles/check-prerequisite/tasks/main.yml
@@ -9,6 +9,7 @@
   ignore_errors: true
 
 - name: Validate cert-manager is first install
+  when: dsc.certmanager.installEnabled
   block:
     - name: Get cluster infos
       kubernetes.core.k8s_cluster_info:


### PR DESCRIPTION
## Quel est le comportement actuel ?
Le role check-requirements, qui tourne à chaque execution (always) du playbook `install-gitops.yaml` effectue plusieurs vérifications sur l'état d'installation de cert-manager. Cependant ces vérifications prennent un certain temps et ne sont pas nécessaires quand celui-ci n'est pas installé (ou en tous cas pas avec l'ensemble de la forge).

## Quel est le nouveau comportement ?
Une simple condition pour éviter de perdre du temps sur des vérifications inutiles lorsque cert-manager n'as pas lieu d'être installé.

## Cette PR introduit-elle un breaking change ?
Non

## Autres informations

