### PR TITLE
Correction de la paramétrisation des chemins Vault dans les templates Argo CD Vault plugin

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/argocd/values/10-exposed-ca.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/values/10-exposed-ca.j2
@@ -3,5 +3,5 @@ argocd:
   configs:
     tls:
       certificates:
-        {{ gitlab_domain }}: <path:{{ vaultinfra_kv_name }}/data/env/conf-dso/apps/global/values#exposedCa>
+        {{ gitlab_domain }}: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#exposedCa>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/templates/argocd/values/10-offline.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/values/10-offline.j2
@@ -3,5 +3,5 @@ argocd:
   configs:
     tls:
       certificates:
-        {{ dsc.argocd.privateGitlabDomain }}: <path:{{ vaultinfra_kv_name }}/data/env/conf-dso/apps/global/values#exposedCa>
+        {{ dsc.argocd.privateGitlabDomain }}: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#exposedCa>
 {% endif %}

--- a/roles/gitops/rendering-apps-files/vars/main.yaml
+++ b/roles/gitops/rendering-apps-files/vars/main.yaml
@@ -75,7 +75,7 @@ values:
 
     rootCA_block: |
       rootCA: |
-        <path:{{ vaultinfra_kv_name }}/data/env/conf-dso/apps/global/values#exposedCa | indent 2>
+        <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#exposedCa | indent 2>
 
     controller_metrics: |
       metrics:


### PR DESCRIPTION
## Quel est le comportement actuel ?
Les templates Jinja2 utilisaient un chemin **statique** (`conf-dso`) pour accéder aux certificats dans Vault, au lieu de la variable dynamique `{{ dsc_name }}`. Cela créait une incohérence avec les 360 autres occurrences du projet, où le chemin est correctement paramétré.

## Quel est le nouveau comportement ?
Les chemins Vault sont désormais **dynamiques** et utilisent la variable `{{ dsc_name }}` pour s’aligner sur le reste du code. Cela garantit que les certificats sont lus depuis le bon environnement (ex: `dev`, `prod`, etc.), évitant ainsi des erreurs de configuration.

## Cette PR introduit-elle un breaking change ?
Non

## Autres informations
### Proposition d’amélioration future
Avec **363 occurrences** du pattern suivant dans le code :
```jinja
<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/
```
Il serait judicieux de **factoriser ce chemin** dans une variable dédiée (ex: `{{ vaultinfra_dsc_path }}`) pour réduire la verbosité des templates et améliorer la lisibilité des fichiers de configuration

Exemple :
```jinja
# Avant
<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#exposedCa | indent 2>

# Après (si la variable est définie)
<path:{{ vaultinfra_apps_path }}/global/values#exposedCa | indent 2>
```

Cependant cela nécessite la modification de 87 fichiers.