### PR TITLE
fix(vault-secrets): vault_infra_token modifiable par le role

### DIFF
--- a/roles/gitops/vault-secrets/tasks/write.yml
+++ b/roles/gitops/vault-secrets/tasks/write.yml
@@ -40,7 +40,7 @@
           echo '{
             "old": {{ current_vault_values.secret | default({}) | to_json }},
             "new": {{ item.1.vault_values | default({}) | to_json }}
-          }' | yq -p=json -o=json -I=0 '.old *n .new'
+          }' | yq -p=json -o=json -I=0 '(.old | del(.vault_infra_token)) as $old | $old *n .new'
       register: current_vault_values_combined_pre
       changed_when: false
 


### PR DESCRIPTION
## Issues liées

Issues numéro: 1076

---------

## Quel est le comportement actuel ?

Si vault_infra_token est écrit vide dans Vault une fois (par exemple à cause d'un problème de timing au premier run), plus aucun re-run du playbook ne peut le corriger, même quand la vraie valeur est correctement calculée sur les runs suivants.

Cause : le merge yq '.old *n .new' dans roles/gitops/vault-secrets/tasks/write.yml ne remplace jamais une clé déjà présente côté old, même si sa valeur est une chaîne vide "".

## Quel est le nouveau comportement ?

vault_infra_token est supprimé du côté old avant le merge (del(.vault_infra_token)), donc traité comme une clé absente et toujours remplie avec la valeur fraîchement calculée côté new. Les autres clés/secrets gardent leur comportement de protection habituel, inchangé.


## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

RAS.
