### PR TITLE
fix(vault-infra): use vaultInfra.helmRepoUrl instead of vault.helmRep…

### DIFF
--- a/roles/infra/vault-infra/tasks/main.yml
+++ b/roles/infra/vault-infra/tasks/main.yml
@@ -61,7 +61,7 @@
     - name: Add Helm repo
       kubernetes.core.helm_repository:
         name: dso
-        repo_url: "{{ dsc.global.backup.vault.helmRepoUrl }}"
+        repo_url: "{{ dsc.global.backup.vaultInfra.helmRepoUrl }}"
         force_update: true
 
     - name: Get s3 backup secret from Keycloak infra namespace


### PR DESCRIPTION
Issues numéro: 1080

## Quel est le comportement actuel ?

Dans `roles/infra/vault-infra/tasks/main.yml`, la tâche "Add Helm repo" (backup de Vault infra)
lit `dsc.global.backup.vault.helmRepoUrl` au lieu de `dsc.global.backup.vaultInfra.helmRepoUrl`.
Tous les autres champs du même bloc (`chartVersion`, `pathPrefix`, `retentionPolicy`,
`mcExtraArgs`, `cron`, `enabled`) lisent correctement `vaultInfra`.

Sur un setup où le backup Vault applicatif est désactivé (`vault.enabled: false`, pas de
`helmRepoUrl` défini) pendant que le backup Vault infra est activé
(`vaultInfra.enabled: true`), le playbook plante :

Error while resolving value for 'repo_url': object of type 'dict' has no attribute 'helmRepoUrl'



## Quel est le nouveau comportement ?

`repo_url` lit maintenant `dsc.global.backup.vaultInfra.helmRepoUrl`, cohérent avec le reste du
bloc. Changement d'une ligne, aucun autre comportement modifié.

## Cette PR introduit-elle un breaking change ?

Non. Sur les setups où `vault.helmRepoUrl` et `vaultInfra.helmRepoUrl` ont la même valeur le comportement observé est identique. Sur les setups où elles diffèrent,
le comportement devient correct (utilise la bonne URL pour le bon backup).

## Autres informations

Testé et la modification à résolue l'issue, je ne sais juste pas si c'est juste une erreur de ma part ou une erreur/ 
