### PR TITLE
fix(kyverno): enforce  runAsUser across containers/initContainers in …

### DIFF
--- a/roles/kyverno/templates/cis.yml.j2
+++ b/roles/kyverno/templates/cis.yml.j2
@@ -303,6 +303,7 @@ spec:
             spec:
               securityContext:
                 +(runAsNonRoot): true
+                runAsUser: 1000
               containers:
               - name: '*'
                 securityContext:
@@ -313,6 +314,7 @@ spec:
                   +(runAsNonRoot): true
                   +(seccompProfile):
                     type: RuntimeDefault
+                  runAsUser: 1000
               initContainers:
               - name: '*'
                 securityContext:
@@ -323,6 +325,7 @@ spec:
                   +(runAsNonRoot): true
                   +(seccompProfile):
                     type: RuntimeDefault
+                  runAsUser: 1000
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy


### PR DESCRIPTION
## Issues liées : 1082


## Quel est le comportement actuel ?

La `ClusterPolicy` `security-context-dso-gitlab` (`roles/kyverno/templates/cis.yml.j2`) impose
`runAsNonRoot: true` sur containers et initContainers, mais ne fixe jamais `runAsUser`. Résultat :
chaque conteneur garde l'UID par défaut de son image — 65534 pour les init containers de
`gitlab-shell`/`minio` (chart GitLab), 1000 pour leurs conteneurs principaux. Sous profil CIS,
ce mismatch bloque `gitlab-shell` et `minio` en `CrashLoopBackOff` (le conteneur d'init écrit des
fichiers qu'un autre utilisateur non-root ne peut ensuite pas lire/remplacer).

D'autres policies du même fichier (`security-context-dso`, `-awx`, `-keycloak`, `-vault`, etc.)
fixent déjà un `runAsUser` cohérent sur containers et initContainers — `security-context-dso-gitlab`
est la seule à ne pas suivre cette .

## Quel est le nouveau comportement ?

Ajout de `runAsUser: 1000` sur les trois niveaux de `securityContext` de la policy (pod, containers, et initContainers) — cette fois en écrasant toujours la valeur, pas seulement en la complétant si absente (contrairement à `+()` utilisé ailleurs dans le fichier). 

Résultat : tous les conteneurs d'un même pod GitLab, y compris ceux d'initialisation, tournent désormais
sous le même utilisateur (1000) — celui déjà utilisé par le conteneur principal du chart.

## Cette PR introduit-elle un breaking change ?

Non a priori (d'après mes tests). Mais je doute qu'il puisse y avoir des problèmes liés à ce changement par le futur.