### PR TITLE
fix(gitlab): pass dsc_cr to cpn-ansible-job post-install playbooks

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/awx/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/awx/values/200-ansible-job.j2
@@ -9,7 +9,7 @@ cpn-ansible-job:
     - |
       git clone {{ dsc.awx.repoSocle.url }} -b {{ dsc.awx.repoSocle.revision }} socle && \
       cd socle && \
-      ansible-playbook post-install/awx-oidc.yaml
+      ansible-playbook post-install/awx-oidc.yaml -e dsc_cr={{ dsc_name }}
 {% if dsc.proxy.enabled %}
     extraEnvFrom:
     - secretRef: 

--- a/roles/gitops/rendering-apps-files/templates/gitlab/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/gitlab/values/200-ansible-job.j2
@@ -9,7 +9,7 @@ cpn-ansible-job:
     - |
       git clone {{ dsc.gitlab.repoSocle.url }} -b {{ dsc.gitlab.repoSocle.revision }} socle && \
       cd socle && \
-      ansible-playbook post-install/gitlab.yaml
+      ansible-playbook post-install/gitlab.yaml -e dsc_cr={{ dsc_name }}
     extraEnvFrom:
     - secretRef: 
         name: ansible-secret
@@ -24,4 +24,4 @@ cpn-ansible-job:
     - |
       git clone {{ dsc.gitlab.repoSocle.url }} -b {{ dsc.gitlab.repoSocle.revision }} socle && \
       cd socle && \
-      ansible-playbook post-install/gitlab-ci-catalog.yaml
+      ansible-playbook post-install/gitlab-ci-catalog.yaml -e dsc_cr={{ dsc_name }}

--- a/roles/gitops/rendering-apps-files/templates/global/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/global/values/200-ansible-job.j2
@@ -10,7 +10,7 @@ cpn-ansible-job:
     - |
       git clone {{ dsc.global.repoSocle.url }} -b {{ dsc.global.repoSocle.revision }} socle && \
       cd socle && \
-      ansible-playbook post-install/pgdump.yaml
+      ansible-playbook post-install/pgdump.yaml -e dsc_cr={{ dsc_name }}
 {% if dsc.global.backup.s3.endpointCA is defined %}
     extraEnv:
       - name: AWS_CA_BUNDLE

--- a/roles/gitops/rendering-apps-files/templates/harbor/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/harbor/values/200-ansible-job.j2
@@ -9,7 +9,7 @@ cpn-ansible-job:
     - |
       git clone {{ dsc.harbor.repoSocle.url }} -b {{ dsc.harbor.repoSocle.revision }} socle && \
       cd socle && \
-      ansible-playbook post-install/harbor.yaml
+      ansible-playbook post-install/harbor.yaml -e dsc_cr={{ dsc_name }}
     extraEnvFrom:
     - secretRef: 
         name: ansible-secret

--- a/roles/gitops/rendering-apps-files/templates/keycloak/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/keycloak/values/200-ansible-job.j2
@@ -9,7 +9,7 @@ cpn-ansible-job:
     - |
       git clone {{ dsc.keycloak.repoSocle.url }} -b {{ dsc.keycloak.repoSocle.revision }} socle && \
       cd socle && \
-      ansible-playbook post-install/keycloak.yaml
+      ansible-playbook post-install/keycloak.yaml -e dsc_cr={{ dsc_name }}
     extraEnvFrom:
     - secretRef: 
         name: ansible-secret

--- a/roles/gitops/rendering-apps-files/templates/sonarqube/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/sonarqube/values/200-ansible-job.j2
@@ -9,7 +9,7 @@ cpn-ansible-job:
     - |
       git clone {{ dsc.sonarqube.repoSocle.url }} -b {{ dsc.sonarqube.repoSocle.revision }} socle && \
       cd socle && \
-      ansible-playbook post-install/sonarqube.yaml
+      ansible-playbook post-install/sonarqube.yaml -e dsc_cr={{ dsc_name }}
     extraEnvFrom:
     - secretRef: 
         name: ansible-secret

--- a/roles/gitops/rendering-apps-files/templates/vault/values/200-ansible-job.j2
+++ b/roles/gitops/rendering-apps-files/templates/vault/values/200-ansible-job.j2
@@ -9,7 +9,7 @@ cpn-ansible-job:
     - |
       git clone {{ dsc.vault.repoSocle.url }} -b {{ dsc.vault.repoSocle.revision }} socle && \
       cd socle && \
-      ansible-playbook post-install/vault.yaml
+      ansible-playbook post-install/vault.yaml -e dsc_cr={{ dsc_name }}
     extraEnvFrom:
     - secretRef: 
         name: ansible-secret


### PR DESCRIPTION
## Issues liées

Issues numéro: #1084

## Quel est le comportement actuel ?

`cpn-ansible-job` (Job + CronJob) lance `ansible-playbook post-install/gitlab.yaml` et
`post-install/gitlab-ci-catalog.yaml` sans `-e dsc_cr=...`. Sur une dsc renommée (différente de
`conf-dso`), le playbook ne la trouve pas, tente de créer une dsc exemple à l'échelle du cluster,
échoue en `403 Forbidden` (RBAC namespace-scoped), retente en boucle jusqu'à `DeadlineExceeded`.

## Quel est le nouveau comportement ?

Ajout de `-e dsc_cr={{ dsc_name }}` aux deux commandes — `dsc_name` déjà calculé dans ce même
template.

## Cette PR introduit-elle un breaking change ?

Non — sur la dsc par défaut `conf-dso`, `dsc_name` résout à la même valeur, comportement
identique.

## Autres informations

Testé sur un déploiement réel le Job échouait systématiquement avant, tourne
correctement depuis le fix.
