### PR TITLE
fix(argocd): prefix harbor repo-creds url with oci://

### DIFF
--- a/roles/gitops/rendering-apps-files/templates/argocd/templates/repo-creds.yml.j2
+++ b/roles/gitops/rendering-apps-files/templates/argocd/templates/repo-creds.yml.j2
@@ -35,7 +35,7 @@ metadata:
     argocd.argoproj.io/secret-type: repo-creds
   name: oci-harbor-creds
 stringData:
-  url: <path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.harbor}>
+  url: "oci://<path:{{ vaultinfra_kv_name }}/data/env/{{ dsc_name }}/apps/global/values#domain | jsonPath {.harbor}>"
   name: harbor
   type: helm
   enableOCI: "true"


### PR DESCRIPTION
## Issues liées

_(aucune)_

## Quel est le comportement actuel ?

Dans `repo-creds.yml.j2`, le secret `oci-harbor-creds` expose une `url` sans schéma
(`harbor.<domain>`). ArgoCD ne rattache alors pas ces credentials aux Applications
qui référencent le registre en `oci://harbor.<domain>`, d'où des échecs
d'authentification au pull des charts Helm.

## Quel est le nouveau comportement ?

L'`url` est préfixée par `oci://` et mise entre quotes.

## Cette PR introduit-elle un breaking change ?

Non.
