### PR TITLE
fix: Switch off reset_password_allowed

### DIFF
--- a/roles/gitops/post-install/keycloak/tasks/main.yml
+++ b/roles/gitops/post-install/keycloak/tasks/main.yml
@@ -236,7 +236,7 @@
       passwordHistory(2) and notUsername() and forceExpiredPasswordChange(183)
     enabled: true
     otp_policy_algorithm: "HmacSHA1"
-    reset_password_allowed: true
+    reset_password_allowed: false
     action_token_generated_by_user_lifespan: 900
     smtp_server:
       host: "{{ (dsc.global.smtp | default({})).host | default(omit) }}"


### PR DESCRIPTION
## Issues liées

Issues numéro: 

---------
## Résumé

Désactive l'option "Mot de passe oublié" (Forgot password) sur le realm `dso` de Keycloak.

## Contexte

Le lien "Forgot password" était activé par défaut sur la page de login du realm `dso`, ce qui n'est pas souhaité pour ce realm.

## Changement

- `roles/gitops/post-install/keycloak/tasks/main.yml` : passage de `reset_password_allowed` à `false` sur la tâche `keycloak_realm` (realm `dso`).

## Test sur CPIN-HP

- [x] Resync pour que le job post-install se relance
- [x] Vérifier dans Keycloak Admin Console → Realm `dso` →
- [x] Realm Settings → Login que "Forgot password" est bien désactivé.
- [x] Vérifier sur la page de login (`https://keycloak.dso..../realms/dso/...`) que le lien "Mot de passe oublié" n'apparaît plus. 
