### PR TITLE
fix: bump console chart version to 2.4.36

### DIFF
--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -28,7 +28,7 @@ spec:
       chartVersion: "0.27.0"
   console:
     # https://github.com/cloud-pi-native/console/releases
-    chartVersion: 2.4.30
+    chartVersion: 2.4.36
   cpnAnsibleJob:
     # https://github.com/cloud-pi-native/helm-charts/releases
     chartVersion: "1.1.0"


### PR DESCRIPTION
## Issues liées

Issues numéro:

---------

## Quel est le comportement actuel ?

Le socle déploie la console en chart `2.4.30`.

## Quel est le nouveau comportement ?

`roles/socle-config/files/releases.yaml` passe le `chartVersion` de la console à
`2.4.36`. Aucun autre fichier ne change.

Détail des versions : https://github.com/cloud-pi-native/console/releases

## Cette PR introduit-elle un breaking change ?

Non.

## Autres informations

Une seule ligne modifiée, pas de changement de valeurs ni de configuration.
