### PR TITLE
chore(upgrade-argocd): bump ArgoCD chart to 10.7.2 / ArgoCD v3.5.2

### DIFF
--- a/roles/socle-config/files/releases.yaml
+++ b/roles/socle-config/files/releases.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   argocd:
     # https://artifacthub.io/packages/helm/argo/argo-cd
-    chartVersion: 8.5.6
+    chartVersion: 10.7.2
     # https://github.com/cloud-pi-native/helm-charts/tree/main/charts/dso-argocd-zone
     zoneChartVersion: "1.0.6"
   argocdInfra:


### PR DESCRIPTION
## Issues liées

Issues numéro : https://github.com/cloud-pi-native/socle/issues/1098

## Quel est le comportement actuel ?

Le release ArgoCD du cluster workload est sur le chart 8.5.6 (ArgoCD v3.1.7).

## Quel est le nouveau comportement ?

Bump du chart ArgoCD du cluster workload de 8.5.6 (ArgoCD v3.1.7) à 10.7.2 (v3.5.2), soit une chaîne de releases mineures au sein de la même ligne majeure (3.x). `argocdInfra` est hors périmètre (non géré ici).

Revue effectuée par rapport aux guides d'upgrade officiels (3.1→3.2, 3.2→3.3, 3.3→3.4, 3.4→3.5) : aucun des breaking changes ne touche notre configuration (RBAC `policy.csv`, `oidc.config`, `resource.exclusions`, auth OCI/Harbor). Le défaut `timeout.reconciliation` passe de 180s à 120s (non surchargé chez nous, reconciliation plus fréquente, non cassant).

## Cette PR introduit-elle un breaking change ?

Non, pour le code de ce repo. Point opérationnel à surveiller au rollout (pas un breaking change de config) : la CRD `ApplicationSet` dépasse désormais la limite de taille pour un apply client-side (breaking change introduit en 3.3). Le release `argocd` gère ses propres CRDs sur ce cluster (`crds.install: true`, `argo_infra_ownership` est `false` ici), mais le sync qui le déploie utilise déjà `ServerSideApply=true` par défaut (`dso-appset.yaml.j2`), ce qui couvre normalement ce cas. À surveiller au premier sync post-upgrade : en cas d'échec par conflit de propriété de champ (409), ajouter ponctuellement `Force=true` en plus de `ServerSideApply=true`.

## Autres informations

